### PR TITLE
fix: resolve model list merge issue during app update

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,8 +81,8 @@ android {
         applicationId "com.pocketpalai"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11 
-        versionName "1.4.4"
+        versionCode 12 
+        versionName "1.4.5"
         ndk {
             abiFilters "arm64-v8a", "x86_64"
         }

--- a/ios/PocketPal.xcodeproj/project.pbxproj
+++ b/ios/PocketPal.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = MYXGXY23Y6;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = PocketPal/Info.plist;
@@ -488,7 +488,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -521,7 +521,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = MYXGXY23Y6;
 				INFOPLIST_FILE = PocketPal/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -529,7 +529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.4;
+				MARKETING_VERSION = 1.4.5;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "PocketPal",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "scripts": {
     "prepare": "husky",

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -1,0 +1,80 @@
+jest.unmock('../ModelStore'); // This is not really needed, as only importing from store is mocked.
+import {modelStore} from '../ModelStore';
+import {runInAction} from 'mobx';
+import {defaultModels} from '../defaultModels';
+
+describe('ModelStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    modelStore.models = []; // Clear models before each test
+  });
+
+  describe('mergeModelLists', () => {
+    it('should add missing default models to the existing model list', () => {
+      modelStore.models = []; // Start with no existing models
+
+      runInAction(() => {
+        modelStore.mergeModelLists();
+      });
+
+      expect(modelStore.models.length).toBeGreaterThan(0);
+      expect(modelStore.models).toEqual(expect.arrayContaining(defaultModels));
+    });
+
+    it('should merge existing models with default models, adding any that are missing', () => {
+      const notExistedModel = defaultModels[0];
+      modelStore.models = defaultModels.slice(1); // Start with all but the first model, so we can test if it's added back
+      expect(modelStore.models.length).toBe(defaultModels.length - 1);
+      expect(modelStore.models).not.toContainEqual(notExistedModel);
+
+      runInAction(() => {
+        modelStore.mergeModelLists();
+      });
+
+      expect(modelStore.models.length).toBeGreaterThan(0);
+      expect(modelStore.models).toContainEqual(notExistedModel);
+    });
+
+    it('should retain value of existing variables while merging new variables', () => {
+      const newDefaultModel = defaultModels[0];
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const {temperature, ...completionSettingsWithoutTemperature} =
+        newDefaultModel.completionSettings; // Exclude temperature
+
+      // Apply changes to the existing model:
+      //  - chatTemplate.template: existing variable with a value different from the default
+      //  - completionSettings.n_predict: existing variable with a value different from the default
+      //  - temperature: new variable in the default model - not present in the existing model
+      const existingModel = {
+        ...newDefaultModel,
+        chatTemplate: {
+          ...newDefaultModel.chatTemplate,
+          template: 'existing',
+        },
+        completionSettings: {
+          ...completionSettingsWithoutTemperature, // Use the completionSettings without temperature - simulates new parameters
+          n_predict: 101010,
+        },
+      };
+
+      modelStore.models[0] = existingModel;
+
+      runInAction(() => {
+        modelStore.mergeModelLists();
+      });
+
+      expect(modelStore.models[0].chatTemplate).toEqual(
+        expect.objectContaining({
+          template: 'existing', // Existing value should remain
+        }),
+      );
+
+      expect(modelStore.models[0].completionSettings).toEqual(
+        expect.objectContaining({
+          n_predict: 101010, // Existing value should remain
+          temperature: newDefaultModel.completionSettings.temperature, // Non-existing value should be merged
+        }),
+      );
+    });
+  });
+});

--- a/src/store/defaultModels.ts
+++ b/src/store/defaultModels.ts
@@ -2,7 +2,7 @@ import {Model} from '../utils/types';
 import {chatTemplates, defaultCompletionParams} from '../utils/chat';
 import {Platform} from 'react-native';
 
-export const MODEL_LIST_VERSION = 5;
+export const MODEL_LIST_VERSION = 6;
 
 export const defaultModels: Model[] = [
   {

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import {formatBytes, getTextSizeInBytes, unwrap} from '..';
+import {deepMerge, formatBytes, getTextSizeInBytes, unwrap} from '..';
 
 describe('formatBytes', () => {
   it('formats bytes correctly when the size is 0', () => {
@@ -36,5 +36,78 @@ describe('unwrap', () => {
     expect.assertions(1);
     const prop = 'prop';
     expect(unwrap(prop)).toStrictEqual(prop);
+  });
+});
+
+describe('deepMerge', () => {
+  it('should merge two flat objects', () => {
+    const target = {a: 1, b: 2};
+    const source = {b: 3, c: 4};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: 1, b: 2, c: 4}); // b should remain 2
+  });
+
+  it('should merge nested objects', () => {
+    const target = {a: {b: 1}};
+    const source = {a: {c: 2}};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: {b: 1, c: 2}}); // c should be added
+  });
+
+  it('should overwrite nested properties', () => {
+    const target = {a: {b: 1, c: 2}};
+    const source = {a: {b: 3}};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: {b: 1, c: 2}}); // b should remain 1
+  });
+
+  it('should handle arrays correctly', () => {
+    const target = {a: [1, 2]};
+    const source = {a: [3, 4]};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: [1, 2]});
+  });
+
+  it('should handle null values', () => {
+    const target = {a: null};
+    const source = {a: {b: 1}};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: {b: 1}}); // Replaces null with the object
+  });
+
+  it('should handle flat to nested', () => {
+    const target = {a: 1, c: {d: 2, e: 3}};
+    const source = {a: {b: 1}, c: 4};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: {b: 1}, c: 4});
+  });
+
+  it('should not modify the original objects', () => {
+    const target = {a: 1};
+    const source = {b: 2};
+    deepMerge(target, source);
+    expect(target).toEqual({a: 1, b: 2});
+    expect(source).toEqual({b: 2}); // Source should remain unchanged
+  });
+
+  it('should handle empty objects', () => {
+    const target = {};
+    const source = {a: 1};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: 1}); // Merges from source
+  });
+
+  it('should handle deeply nested objects', () => {
+    const target = {a: {b: {c: 1}}};
+    const source = {a: {b: {d: 2}}};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: {b: {c: 1, d: 2}}});
+  });
+
+  it('should merge multiple levels of nesting', () => {
+    const target = {a: {b: {c: {d: 1, e: 3}}}};
+    const source = {a: {b: {c: {e: 2, f: 4}}}};
+    const result = deepMerge(target, source);
+    expect(result).toEqual({a: {b: {c: {d: 1, e: 3, f: 4}}}});
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -313,4 +313,32 @@ export async function hasEnoughSpace(model: Model): Promise<boolean> {
   }
 }
 
+/**
+ * Merges properties from the source object into the target object deeply.
+ * Only sets properties that do not already exist in the target or if the types differ.
+ *
+ * @param target - The target object to merge properties into.
+ * @param source - The source object from which properties are taken.
+ * @returns The updated target object after merging.
+ */
+export const deepMerge = (target: any, source: any): any => {
+  for (const key in source) {
+    if (source.hasOwnProperty(key)) {
+      if (typeof source[key] === 'object' && source[key] !== null) {
+        // If the property is an object, recursively merge.
+        // If target[key] is not an object, it means the property type is different so we will replace it.
+        target[key] =
+          target[key] && typeof target[key] === 'object' ? target[key] : {};
+        deepMerge(target[key], source[key]);
+      } else {
+        // Set the property in the target only if it doesn't exist or if the types differ
+        if (!(key in target) || typeof target[key] !== typeof source[key]) {
+          target[key] = source[key];
+        }
+      }
+    }
+  }
+  return target;
+};
+
 export const randId = () => Math.random().toString(36).substring(2, 11);


### PR DESCRIPTION
## Description

If a new parameter is introduced to the model completion settings, the parameter is not applied to the existing model unless the model list is reset. This causes an app crash when the UI tries to display the updated settings in the model card.

Fixes #75

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
