### PR TITLE
Fix dark mode theming in bottom sheet components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "patch-package",
     "android": "react-native run-android",
     "build:android": "cd android && ./gradlew assembleDebug && cd ..",
-    "build:android:release": "cd android && ./gradlew assembleRelease && cd ..",
+    "build:android:release": "cd android && ./gradlew bundleRelease && cd ..",
     "ios": "react-native run-ios --simulator=\"iPhone 15 Pro\"",
     "ios:build": "cd ios && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace PocketPal.xcworkspace -scheme PocketPal -configuration Debug -sdk iphonesimulator -arch $(uname -m) ONLY_ACTIVE_ARCH=YES GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO | xcpretty",
     "ios:build:release": "cd ios && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace PocketPal.xcworkspace -scheme PocketPal -configuration Release -sdk iphoneos -arch arm64 -arch x86_64 GCC_OPTIMIZATION_LEVEL=s GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=space DEBUG_INFORMATION_FORMAT=dwarf-with-dsym COMPILER_INDEX_STORE_ENABLE=YES | xcpretty",

--- a/src/screens/ModelsScreen/HFModelSearch/styles.tsx
+++ b/src/screens/ModelsScreen/HFModelSearch/styles.tsx
@@ -1,0 +1,14 @@
+import {StyleSheet} from 'react-native';
+import {Theme} from '../../../utils/types';
+
+export const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    // ... existing styles ...
+    bottomSheetHandle: {
+      backgroundColor: theme.colors.onSurface,
+      opacity: 0.5,
+    },
+    bottomSheetBackground: {
+      backgroundColor: theme.colors.background,
+    },
+  });


### PR DESCRIPTION
## Description

Bottom sheet content is rendered in a portal, outside the main component tree, which breaks the theme context chain. 
By adding PaperProvider within the bottom sheets, we restore proper theming for all Paper components rendered inside them.

Fixes #96 

- Added PaperProvider within bottom sheet components to restore theme context
- Fixed background colors for bottom sheet and handle indicator

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
