### PR TITLE
fix: add empty system prompt for HF and local models

### DIFF
--- a/__mocks__/stores/modelStore.ts
+++ b/__mocks__/stores/modelStore.ts
@@ -7,7 +7,7 @@ export const mockModelStore = {
   useAutoRelease: true,
   useMetal: false,
   n_gpu_layers: 50,
-  activeModel: null,
+  activeModelId: undefined as string | undefined,
   setNContext: jest.fn(),
   updateUseAutoRelease: jest.fn(),
   updateUseMetal: jest.fn(),
@@ -15,11 +15,13 @@ export const mockModelStore = {
   refreshDownloadStatuses: jest.fn(),
   addLocalModel: jest.fn(),
   resetModels: jest.fn(),
-  //initContext: jest.fn().mockResolvedValue(undefined),
   initContext: jest.fn().mockResolvedValue(Promise.resolve()),
   checkSpaceAndDownload: jest.fn(),
   getDownloadProgress: jest.fn(),
   manualReleaseContext: jest.fn(),
+  setActiveModel(modelId: string) {
+    this.activeModelId = modelId;
+  },
 };
 Object.defineProperty(mockModelStore, 'lastUsedModel', {
   get: jest.fn(() => undefined),
@@ -27,5 +29,13 @@ Object.defineProperty(mockModelStore, 'lastUsedModel', {
 });
 Object.defineProperty(mockModelStore, 'isDownloading', {
   get: jest.fn(() => () => false),
+  configurable: true,
+});
+Object.defineProperty(mockModelStore, 'activeModel', {
+  get: jest.fn(() =>
+    mockModelStore.models.find(
+      model => model.id === mockModelStore.activeModelId,
+    ),
+  ),
   configurable: true,
 });

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -97,7 +97,7 @@ export const useChatSession = (
     currentMessageInfo.current = {createdAt, id};
 
     const chatMessages = [
-      ...(modelStore.activeModel?.chatTemplate?.systemPrompt
+      ...(modelStore.activeModel?.chatTemplate?.systemPrompt?.trim()
         ? [
             {
               role: 'system' as 'system',

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -86,6 +86,7 @@ export const chatTemplates: Record<string, ChatTemplateConfig> = {
     bosToken: '',
     eosToken: '',
     chatTemplate: '',
+    systemPrompt: '',
   },
   danube3: {
     ...Templates.templates.danube2,
@@ -196,6 +197,7 @@ export function getHFDefaultSettings(hfModel: HuggingFaceModel): {
     //chatTemplate: hfModel.specs?.gguf?.chat_template ?? '',
     chatTemplate: '', // At the moment chatTemplate needs to be nunjucks, not jinja2. So by using empty string we force the use of gguf's chat template.
     addGenerationPrompt: true,
+    systemPrompt: '',
     name: 'custom',
   };
 


### PR DESCRIPTION
## Description

When the system prompt is undefined, the UI does not render the system prompt input text.
This pull request addresses the issue by setting the default value of the system prompt to an empty string.

Fixes #103 

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
