### PR TITLE
fix: add stop tokens that are in the chat template and remove tfs_z

### DIFF
--- a/jest/fixtures/models.ts
+++ b/jest/fixtures/models.ts
@@ -16,7 +16,6 @@ export const mockDefaultCompletionParams: CompletionParams = {
   temperature: 0.7,
   top_k: 40,
   top_p: 0.95,
-  tfs_z: 1.0,
   min_p: 0.05,
   xtc_threshold: 0.1,
   xtc_probability: 0.01,

--- a/src/screens/ModelsScreen/CompletionSettings/CompletionSettings.tsx
+++ b/src/screens/ModelsScreen/CompletionSettings/CompletionSettings.tsx
@@ -96,7 +96,6 @@ export const CompletionSettings: React.FC<Props> = ({settings, onChange}) => {
           {renderSlider('temperature', 0, 1)}
           {renderSlider('top_k', 1, 128, 1)}
           {renderSlider('top_p', 0, 1)}
-          {renderSlider('tfs_z', 0, 2)}
           {renderSlider('min_p', 0, 1)}
           {renderSlider('xtc_threshold', 0, 1)}
           {renderSlider('xtc_probability', 0, 1)}

--- a/src/screens/ModelsScreen/CompletionSettings/__tests__/CompletionSettings.test.tsx
+++ b/src/screens/ModelsScreen/CompletionSettings/__tests__/CompletionSettings.test.tsx
@@ -29,10 +29,6 @@ describe('CompletionSettings', () => {
     const topPSlider = getByTestId('top_p-slider');
     expect(topPSlider.props.value).toBe(0.95);
 
-    expect(getByTestId('tfs_z-slider')).toBeTruthy();
-    const tfsZSlider = getByTestId('tfs_z-slider');
-    expect(tfsZSlider.props.value).toBe(1);
-
     expect(getByTestId('min_p-slider')).toBeTruthy();
     const minPSlider = getByTestId('min_p-slider');
     expect(minPSlider.props.value).toBe(0.05);

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -218,7 +218,6 @@ export const defaultCompletionParams: CompletionParams = {
   temperature: 0.7, // The randomness of the generated text.
   top_k: 40, // Limit the next token selection to the K most probable tokens.
   top_p: 0.95, // Limit the next token selection to a subset of tokens with a cumulative probability above a threshold P.
-  tfs_z: 1.0, //Enable tail free sampling with parameter z. Default: `1.0`, which is disabled.
   min_p: 0.05, //The minimum probability for a token to be considered, relative to the probability of the most likely token.
   xtc_threshold: 0.1, // Sets a minimum probability threshold for tokens to be removed.
   xtc_probability: 0.0, // Sets the chance for token removal (checked once on sampler start)
@@ -236,3 +235,15 @@ export const defaultCompletionParams: CompletionParams = {
   stop: ['</s>'],
   // emit_partial_completion: true, // This is not used in the current version of llama.rn
 };
+
+export const stops = [
+  '</s>',
+  '<|end|>',
+  '<|eot_id|>',
+  '<|end_of_text|>',
+  '<|im_end|>',
+  '<|EOT|>',
+  '<|END_OF_TURN_TOKEN|>',
+  '<|end_of_turn|>',
+  '<|endoftext|>',
+];


### PR DESCRIPTION
## Description

When models are downloaded through Hugging Face search or loaded locally, the app currently infers stop words from the EOS token, but that’s not enough. EOT tokens also need to be included as stop words; otherwise, responses might contain those tokens.

This PR checks if any of these tokens:
```
   '</s>',
  '<|end|>',
  '<|eot_id|>',
  '<|end_of_text|>',
  '<|im_end|>',
  '<|EOT|>',
  '<|END_OF_TURN_TOKEN|>',
  '<|end_of_turn|>',
  '<|endoftext|>',
```
are in the chat template and adds them to the stops array if found.

Also we remove `tfs_z`.

Fixes #101 

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
