### PR TITLE
fix(ci): add env var for gradle in step 10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,11 @@ jobs:
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
-          ./gradlew assembleRelease
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file=./app/pocketpal-release-key.keystore \
+            -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
+            -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
+            -Pandroid.injected.signing.key.password=$KEY_PASSWORD
 
       # Step 11: Create GitHub Release with APK
       - name: Create GitHub Release


### PR DESCRIPTION
## Description

Seemingly the signing config isn't being properly passed to Gradle. 
This modifies the Android build step to ensure the signing configuration is properly set using gradle params.