### PR TITLE
[Feat] Expose attn, batch, ubatch, cach_type_kv settings to the UI and bench results

### DIFF
--- a/src/screens/BenchmarkScreen/BenchResultCard/BenchResultCard.tsx
+++ b/src/screens/BenchmarkScreen/BenchResultCard/BenchResultCard.tsx
@@ -79,26 +79,43 @@ export const BenchResultCard = ({result, onDelete, onShare}: Props) => {
           </Button>
         </View>
 
-        <View style={styles.configBar}>
-          <Text variant="labelSmall">Config</Text>
-          <Text style={styles.configText}>
-            PP: {result.config.pp} • TG: {result.config.tg} • PL:{' '}
-            {result.config.pl} • Rep: {result.config.nr}
-          </Text>
-        </View>
-
-        {result.initSettings && (
+        <View style={styles.configContainer}>
           <View style={styles.configBar}>
-            <Text variant="labelSmall">Model Settings</Text>
+            <Text variant="labelSmall">Benchmark Config</Text>
             <Text style={styles.configText}>
-              Context: {result.initSettings.n_context} • Batch:{' '}
-              {result.initSettings.n_batch} • Threads:{' '}
-              {result.initSettings.n_threads} • GPU Layers:{' '}
-              {result.initSettings.n_gpu_layers}
-              {result.initSettings.flash_attn && ' • Flash Attn'}
+              PP: {result.config.pp} • TG: {result.config.tg} • PL:{' '}
+              {result.config.pl} • Rep: {result.config.nr}
             </Text>
           </View>
-        )}
+
+          {result.initSettings && (
+            <View style={styles.configBar}>
+              <Text variant="labelSmall">Model Settings</Text>
+              <View style={styles.configTextContainer}>
+                <Text style={styles.configText}>
+                  Context: {result.initSettings.n_context} • Batch:{' '}
+                  {result.initSettings.n_batch} • UBatch:{' '}
+                  {result.initSettings.n_ubatch}
+                </Text>
+                <Text style={styles.configText}>
+                  CPU Threads: {result.initSettings.n_threads} • GPU Layers:{' '}
+                  {result.initSettings.n_gpu_layers}
+                </Text>
+                {result.initSettings.flash_attn ? (
+                  <Text style={styles.configText}>
+                    Flash Attention Enabled • Cache Types:{' '}
+                    {result.initSettings.cache_type_k}/
+                    {result.initSettings.cache_type_v}
+                  </Text>
+                ) : (
+                  <Text style={styles.configText}>
+                    Flash Attention Disabled
+                  </Text>
+                )}
+              </View>
+            </View>
+          )}
+        </View>
 
         <View style={styles.resultsContainer}>
           <View style={styles.resultRow}>

--- a/src/screens/BenchmarkScreen/BenchResultCard/BenchResultCard.tsx
+++ b/src/screens/BenchmarkScreen/BenchResultCard/BenchResultCard.tsx
@@ -87,6 +87,19 @@ export const BenchResultCard = ({result, onDelete, onShare}: Props) => {
           </Text>
         </View>
 
+        {result.initSettings && (
+          <View style={styles.configBar}>
+            <Text variant="labelSmall">Model Settings</Text>
+            <Text style={styles.configText}>
+              Context: {result.initSettings.n_context} • Batch:{' '}
+              {result.initSettings.n_batch} • Threads:{' '}
+              {result.initSettings.n_threads} • GPU Layers:{' '}
+              {result.initSettings.n_gpu_layers}
+              {result.initSettings.flash_attn && ' • Flash Attn'}
+            </Text>
+          </View>
+        )}
+
         <View style={styles.resultsContainer}>
           <View style={styles.resultRow}>
             <View style={styles.resultItem}>

--- a/src/screens/BenchmarkScreen/BenchResultCard/styles.ts
+++ b/src/screens/BenchmarkScreen/BenchResultCard/styles.ts
@@ -29,20 +29,27 @@ export const createStyles = (theme: Theme) =>
       fontSize: 12,
       color: theme.colors.onSurfaceVariant,
     },
-    configBar: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      paddingVertical: 8,
-      marginBottom: 16,
+    configContainer: {
       borderTopWidth: 1,
       borderBottomWidth: 1,
       borderColor: theme.colors.surfaceVariant,
+      marginVertical: 8,
+      paddingHorizontal: 12,
+    },
+    configBar: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      paddingVertical: 8,
+      gap: 4,
     },
     configText: {
       fontSize: 12,
       color: theme.colors.onSurfaceVariant,
-      textAlign: 'center',
+      flex: 1,
+    },
+    configTextContainer: {
+      gap: 4,
+      width: '100%',
     },
     resultsContainer: {
       marginBottom: 16,

--- a/src/screens/BenchmarkScreen/BenchmarkScreen.tsx
+++ b/src/screens/BenchmarkScreen/BenchmarkScreen.tsx
@@ -30,11 +30,11 @@ const DEFAULT_CONFIGS: BenchmarkConfig[] = [
 
 const BENCHMARK_PARAMS_METADATA = {
   pp: {
-    validation: {min: 64, max: 512},
+    validation: {min: 64, max: 2048},
     descriptionKey: 'Number of prompt processing tokens',
   },
   tg: {
-    validation: {min: 32, max: 512},
+    validation: {min: 32, max: 2048},
     descriptionKey: 'Number of text generation tokens',
   },
   pl: {
@@ -176,6 +176,7 @@ export const BenchmarkScreen: React.FC = observer(() => {
         peakMemoryUsage: peakMemoryUsage || undefined,
         wallTimeMs,
         uuid: uuidv4(),
+        initSettings: modelStore.activeContextSettings,
       };
 
       benchmarkStore.addResult(result);

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -169,6 +169,85 @@ export const SettingsScreen: React.FC = observer(() => {
               </View>
               <Divider />
 
+              <View style={styles.settingItemContainer}>
+                <Text variant="titleMedium" style={styles.textLabel}>
+                  {l10n.contextSize}
+                </Text>
+                <TextInput
+                  ref={inputRef}
+                  style={[
+                    styles.textInput,
+                    !isValidInput && styles.invalidInput,
+                  ]}
+                  keyboardType="numeric"
+                  value={contextSize}
+                  onChangeText={handleContextSizeChange}
+                  placeholder={l10n.contextSizePlaceholder.replace(
+                    '{{minContextSize}}',
+                    modelStore.MIN_CONTEXT_SIZE.toString(),
+                  )}
+                />
+                {!isValidInput && (
+                  <Text style={styles.errorText}>
+                    {l10n.invalidContextSizeError.replace(
+                      '{{minContextSize}}',
+                      modelStore.MIN_CONTEXT_SIZE.toString(),
+                    )}
+                  </Text>
+                )}
+                <Text variant="labelSmall" style={styles.textDescription}>
+                  {l10n.modelReloadNotice}
+                </Text>
+              </View>
+
+              {/* Batch Size Slider */}
+              <View style={styles.settingItemContainer}>
+                <Text variant="titleMedium" style={styles.textLabel}>
+                  Batch Size
+                </Text>
+                <Slider
+                  testID="batch-size-slider"
+                  value={modelStore.n_batch}
+                  onValueChange={value =>
+                    modelStore.setNBatch(Math.round(value))
+                  }
+                  minimumValue={1}
+                  maximumValue={modelStore.n_context}
+                  step={1}
+                  style={styles.nGPUSlider}
+                  thumbTintColor={theme.colors.primary}
+                  minimumTrackTintColor={theme.colors.primary}
+                />
+                <Text variant="labelSmall" style={styles.textDescription}>
+                  {`Batch size: ${modelStore.n_batch} (max: ${modelStore.n_context})`}
+                </Text>
+              </View>
+              <Divider />
+
+              {/* Physical Batch Size Slider */}
+              <View style={styles.settingItemContainer}>
+                <Text variant="titleMedium" style={styles.textLabel}>
+                  Physical Batch Size
+                </Text>
+                <Slider
+                  testID="ubatch-size-slider"
+                  value={modelStore.n_ubatch}
+                  onValueChange={value =>
+                    modelStore.setNUBatch(Math.round(value))
+                  }
+                  minimumValue={1}
+                  maximumValue={modelStore.n_batch}
+                  step={1}
+                  style={styles.nGPUSlider}
+                  thumbTintColor={theme.colors.primary}
+                  minimumTrackTintColor={theme.colors.primary}
+                />
+                <Text variant="labelSmall" style={styles.textDescription}>
+                  {`Physical batch size: ${modelStore.n_ubatch} (max: ${modelStore.n_batch})`}
+                </Text>
+              </View>
+              <Divider />
+
               {/* Flash Attention Switch */}
               <View style={styles.settingItemContainer}>
                 <View style={styles.switchContainer}>
@@ -197,7 +276,9 @@ export const SettingsScreen: React.FC = observer(() => {
                       Key Cache Type
                     </Text>
                     <Text variant="labelSmall" style={styles.textDescription}>
-                      Select the cache type for key computation
+                      {modelStore.flash_attn
+                        ? 'Select the cache type for key computation'
+                        : 'Enable Flash Attention to change cache type'}
                     </Text>
                   </View>
                   <View style={styles.menuContainer} ref={keyCacheButtonRef}>
@@ -206,6 +287,7 @@ export const SettingsScreen: React.FC = observer(() => {
                       onPress={handleKeyCachePress}
                       style={styles.menuButton}
                       contentStyle={styles.buttonContent}
+                      disabled={!modelStore.flash_attn}
                       icon={({size, color}) => (
                         <Icon source="chevron-down" size={size} color={color} />
                       )}>
@@ -241,7 +323,9 @@ export const SettingsScreen: React.FC = observer(() => {
                       Value Cache Type
                     </Text>
                     <Text variant="labelSmall" style={styles.textDescription}>
-                      Select the cache type for value computation
+                      {modelStore.flash_attn
+                        ? 'Select the cache type for value computation'
+                        : 'Enable Flash Attention to change cache type'}
                     </Text>
                   </View>
                   <View style={styles.menuContainer} ref={valueCacheButtonRef}>
@@ -250,6 +334,7 @@ export const SettingsScreen: React.FC = observer(() => {
                       onPress={handleValueCachePress}
                       style={styles.menuButton}
                       contentStyle={styles.buttonContent}
+                      disabled={!modelStore.flash_attn}
                       icon={({size, color}) => (
                         <Icon source="chevron-down" size={size} color={color} />
                       )}>
@@ -319,36 +404,6 @@ export const SettingsScreen: React.FC = observer(() => {
                 </View>
               )}
               <Divider />
-              <View style={styles.settingItemContainer}>
-                <Text variant="titleMedium" style={styles.textLabel}>
-                  {l10n.contextSize}
-                </Text>
-                <TextInput
-                  ref={inputRef}
-                  style={[
-                    styles.textInput,
-                    !isValidInput && styles.invalidInput,
-                  ]}
-                  keyboardType="numeric"
-                  value={contextSize}
-                  onChangeText={handleContextSizeChange}
-                  placeholder={l10n.contextSizePlaceholder.replace(
-                    '{{minContextSize}}',
-                    modelStore.MIN_CONTEXT_SIZE.toString(),
-                  )}
-                />
-                {!isValidInput && (
-                  <Text style={styles.errorText}>
-                    {l10n.invalidContextSizeError.replace(
-                      '{{minContextSize}}',
-                      modelStore.MIN_CONTEXT_SIZE.toString(),
-                    )}
-                  </Text>
-                )}
-                <Text variant="labelSmall" style={styles.textDescription}>
-                  {l10n.modelReloadNotice}
-                </Text>
-              </View>
 
               <View style={styles.switchContainer}>
                 <View style={styles.textContainer}>

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -145,30 +145,7 @@ export const SettingsScreen: React.FC = observer(() => {
               </View>
               <Divider />
 
-              {/* Thread Count Slider */}
-              <View style={styles.settingItemContainer}>
-                <Text variant="titleMedium" style={styles.textLabel}>
-                  Thread Count
-                </Text>
-                <Slider
-                  testID="thread-count-slider"
-                  value={modelStore.n_threads}
-                  onValueChange={value =>
-                    modelStore.setNThreads(Math.round(value))
-                  }
-                  minimumValue={1}
-                  maximumValue={modelStore.max_threads}
-                  step={1}
-                  style={styles.nGPUSlider}
-                  thumbTintColor={theme.colors.primary}
-                  minimumTrackTintColor={theme.colors.primary}
-                />
-                <Text variant="labelSmall" style={styles.textDescription}>
-                  {`Using ${modelStore.n_threads} of ${modelStore.max_threads} available threads`}
-                </Text>
-              </View>
-              <Divider />
-
+              {/* Context Size */}
               <View style={styles.settingItemContainer}>
                 <Text variant="titleMedium" style={styles.textLabel}>
                   {l10n.contextSize}
@@ -199,6 +176,7 @@ export const SettingsScreen: React.FC = observer(() => {
                   {l10n.modelReloadNotice}
                 </Text>
               </View>
+              <Divider />
 
               {/* Batch Size Slider */}
               <View style={styles.settingItemContainer}>
@@ -212,14 +190,18 @@ export const SettingsScreen: React.FC = observer(() => {
                     modelStore.setNBatch(Math.round(value))
                   }
                   minimumValue={1}
-                  maximumValue={modelStore.n_context}
+                  maximumValue={4096}
                   step={1}
                   style={styles.nGPUSlider}
                   thumbTintColor={theme.colors.primary}
                   minimumTrackTintColor={theme.colors.primary}
                 />
                 <Text variant="labelSmall" style={styles.textDescription}>
-                  {`Batch size: ${modelStore.n_batch} (max: ${modelStore.n_context})`}
+                  {`Batch size: ${modelStore.n_batch}${
+                    modelStore.n_batch > modelStore.n_context
+                      ? ` (effective: ${modelStore.n_context})`
+                      : ''
+                  }`}
                 </Text>
               </View>
               <Divider />
@@ -236,14 +218,46 @@ export const SettingsScreen: React.FC = observer(() => {
                     modelStore.setNUBatch(Math.round(value))
                   }
                   minimumValue={1}
-                  maximumValue={modelStore.n_batch}
+                  maximumValue={4096}
                   step={1}
                   style={styles.nGPUSlider}
                   thumbTintColor={theme.colors.primary}
                   minimumTrackTintColor={theme.colors.primary}
                 />
                 <Text variant="labelSmall" style={styles.textDescription}>
-                  {`Physical batch size: ${modelStore.n_ubatch} (max: ${modelStore.n_batch})`}
+                  {`Physical batch size: ${modelStore.n_ubatch}${
+                    modelStore.n_ubatch >
+                    Math.min(modelStore.n_batch, modelStore.n_context)
+                      ? ` (effective: ${Math.min(
+                          modelStore.n_batch,
+                          modelStore.n_context,
+                        )})`
+                      : ''
+                  }`}
+                </Text>
+              </View>
+              <Divider />
+
+              {/* Thread Count Slider */}
+              <View style={styles.settingItemContainer}>
+                <Text variant="titleMedium" style={styles.textLabel}>
+                  Thread Count
+                </Text>
+                <Slider
+                  testID="thread-count-slider"
+                  value={modelStore.n_threads}
+                  onValueChange={value =>
+                    modelStore.setNThreads(Math.round(value))
+                  }
+                  minimumValue={1}
+                  maximumValue={modelStore.max_threads}
+                  step={1}
+                  style={styles.nGPUSlider}
+                  thumbTintColor={theme.colors.primary}
+                  minimumTrackTintColor={theme.colors.primary}
+                />
+                <Text variant="labelSmall" style={styles.textDescription}>
+                  {`Using ${modelStore.n_threads} of ${modelStore.max_threads} available threads`}
                 </Text>
               </View>
               <Divider />

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -180,6 +180,7 @@ export const SettingsScreen: React.FC = observer(() => {
                 </Text>
                 <TextInput
                   ref={inputRef}
+                  testID="context-size-input"
                   style={[
                     styles.textInput,
                     !isValidInput && styles.invalidInput,

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -276,7 +276,7 @@ export const SettingsScreen: React.FC = observer(() => {
                   {/* Thread Count Slider */}
                   <View style={styles.settingItemContainer}>
                     <Text variant="titleMedium" style={styles.textLabel}>
-                      Thread Count
+                      CPU Threads
                     </Text>
                     <Slider
                       testID="thread-count-slider"

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -33,6 +33,7 @@ export const SettingsScreen: React.FC = observer(() => {
     modelStore.n_context.toString(),
   );
   const [isValidInput, setIsValidInput] = useState(true);
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
   const inputRef = useRef<RNTextInput>(null);
   const [showKeyCacheMenu, setShowKeyCacheMenu] = useState(false);
   const [showValueCacheMenu, setShowValueCacheMenu] = useState(false);
@@ -70,6 +71,7 @@ export const SettingsScreen: React.FC = observer(() => {
     setIsValidInput(true);
     setShowKeyCacheMenu(false);
     setShowValueCacheMenu(false);
+    setShowAdvancedSettings(false);
   };
 
   const handleContextSizeChange = (text: string) => {
@@ -120,31 +122,10 @@ export const SettingsScreen: React.FC = observer(() => {
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <TouchableWithoutFeedback onPress={handleOutsidePress}>
         <ScrollView contentContainerStyle={styles.container}>
-          {/* Model Settings Section */}
+          {/* Model Initialization Settings */}
           <Card elevation={0} style={styles.card}>
-            <Card.Title title={l10n.modelSettingsTitle} />
+            <Card.Title title="Model Initialization Settings" />
             <Card.Content>
-              <View style={styles.settingItemContainer}>
-                <View style={styles.switchContainer}>
-                  <View style={styles.textContainer}>
-                    <Text variant="titleMedium" style={styles.textLabel}>
-                      {l10n.autoOffloadLoad}
-                    </Text>
-                    <Text variant="labelSmall" style={styles.textDescription}>
-                      {l10n.autoOffloadLoadDescription}
-                    </Text>
-                  </View>
-                  <Switch
-                    testID="auto-offload-load-switch"
-                    value={modelStore.useAutoRelease}
-                    onValueChange={value =>
-                      modelStore.updateUseAutoRelease(value)
-                    }
-                  />
-                </View>
-              </View>
-              <Divider />
-
               {/* Context Size */}
               <View style={styles.settingItemContainer}>
                 <Text variant="titleMedium" style={styles.textLabel}>
@@ -176,294 +157,352 @@ export const SettingsScreen: React.FC = observer(() => {
                   {l10n.modelReloadNotice}
                 </Text>
               </View>
-              <Divider />
 
-              {/* Batch Size Slider */}
-              <View style={styles.settingItemContainer}>
-                <Text variant="titleMedium" style={styles.textLabel}>
-                  Batch Size
-                </Text>
-                <Slider
-                  testID="batch-size-slider"
-                  value={modelStore.n_batch}
-                  onValueChange={value =>
-                    modelStore.setNBatch(Math.round(value))
-                  }
-                  minimumValue={1}
-                  maximumValue={4096}
-                  step={1}
-                  style={styles.nGPUSlider}
-                  thumbTintColor={theme.colors.primary}
-                  minimumTrackTintColor={theme.colors.primary}
-                />
-                <Text variant="labelSmall" style={styles.textDescription}>
-                  {`Batch size: ${modelStore.n_batch}${
-                    modelStore.n_batch > modelStore.n_context
-                      ? ` (effective: ${modelStore.n_context})`
-                      : ''
-                  }`}
-                </Text>
-              </View>
-              <Divider />
-
-              {/* Physical Batch Size Slider */}
-              <View style={styles.settingItemContainer}>
-                <Text variant="titleMedium" style={styles.textLabel}>
-                  Physical Batch Size
-                </Text>
-                <Slider
-                  testID="ubatch-size-slider"
-                  value={modelStore.n_ubatch}
-                  onValueChange={value =>
-                    modelStore.setNUBatch(Math.round(value))
-                  }
-                  minimumValue={1}
-                  maximumValue={4096}
-                  step={1}
-                  style={styles.nGPUSlider}
-                  thumbTintColor={theme.colors.primary}
-                  minimumTrackTintColor={theme.colors.primary}
-                />
-                <Text variant="labelSmall" style={styles.textDescription}>
-                  {`Physical batch size: ${modelStore.n_ubatch}${
-                    modelStore.n_ubatch >
-                    Math.min(modelStore.n_batch, modelStore.n_context)
-                      ? ` (effective: ${Math.min(
-                          modelStore.n_batch,
-                          modelStore.n_context,
-                        )})`
-                      : ''
-                  }`}
-                </Text>
-              </View>
-              <Divider />
-
-              {/* Thread Count Slider */}
-              <View style={styles.settingItemContainer}>
-                <Text variant="titleMedium" style={styles.textLabel}>
-                  Thread Count
-                </Text>
-                <Slider
-                  testID="thread-count-slider"
-                  value={modelStore.n_threads}
-                  onValueChange={value =>
-                    modelStore.setNThreads(Math.round(value))
-                  }
-                  minimumValue={1}
-                  maximumValue={modelStore.max_threads}
-                  step={1}
-                  style={styles.nGPUSlider}
-                  thumbTintColor={theme.colors.primary}
-                  minimumTrackTintColor={theme.colors.primary}
-                />
-                <Text variant="labelSmall" style={styles.textDescription}>
-                  {`Using ${modelStore.n_threads} of ${modelStore.max_threads} available threads`}
-                </Text>
-              </View>
-              <Divider />
-
-              {/* Flash Attention Switch */}
-              <View style={styles.settingItemContainer}>
-                <View style={styles.switchContainer}>
-                  <View style={styles.textContainer}>
-                    <Text variant="titleMedium" style={styles.textLabel}>
-                      Flash Attention
-                    </Text>
-                    <Text variant="labelSmall" style={styles.textDescription}>
-                      Enable Flash Attention for faster processing
-                    </Text>
-                  </View>
-                  <Switch
-                    testID="flash-attention-switch"
-                    value={modelStore.flash_attn}
-                    onValueChange={value => modelStore.setFlashAttn(value)}
-                  />
-                </View>
-              </View>
-              <Divider />
-
-              {/* Cache Type K Selection */}
-              <View style={styles.settingItemContainer}>
-                <View style={styles.switchContainer}>
-                  <View style={styles.textContainer}>
-                    <Text variant="titleMedium" style={styles.textLabel}>
-                      Key Cache Type
-                    </Text>
-                    <Text variant="labelSmall" style={styles.textDescription}>
-                      {modelStore.flash_attn
-                        ? 'Select the cache type for key computation'
-                        : 'Enable Flash Attention to change cache type'}
-                    </Text>
-                  </View>
-                  <View style={styles.menuContainer} ref={keyCacheButtonRef}>
-                    <Button
-                      mode="outlined"
-                      onPress={handleKeyCachePress}
-                      style={styles.menuButton}
-                      contentStyle={styles.buttonContent}
-                      disabled={!modelStore.flash_attn}
-                      icon={({size, color}) => (
-                        <Icon source="chevron-down" size={size} color={color} />
-                      )}>
-                      {getCacheTypeLabel(modelStore.cache_type_k)}
-                    </Button>
-                    <Menu
-                      visible={showKeyCacheMenu}
-                      onDismiss={() => setShowKeyCacheMenu(false)}
-                      anchor={keyCacheAnchor}
-                      selectable>
-                      {cacheTypeOptions.map(option => (
-                        <Menu.Item
-                          key={option.value}
-                          label={option.label}
-                          selected={option.value === modelStore.cache_type_k}
-                          onPress={() => {
-                            modelStore.setCacheTypeK(option.value);
-                            setShowKeyCacheMenu(false);
-                          }}
-                        />
-                      ))}
-                    </Menu>
-                  </View>
-                </View>
-              </View>
-              <Divider />
-
-              {/* Cache Type V Selection */}
-              <View style={styles.settingItemContainer}>
-                <View style={styles.switchContainer}>
-                  <View style={styles.textContainer}>
-                    <Text variant="titleMedium" style={styles.textLabel}>
-                      Value Cache Type
-                    </Text>
-                    <Text variant="labelSmall" style={styles.textDescription}>
-                      {modelStore.flash_attn
-                        ? 'Select the cache type for value computation'
-                        : 'Enable Flash Attention to change cache type'}
-                    </Text>
-                  </View>
-                  <View style={styles.menuContainer} ref={valueCacheButtonRef}>
-                    <Button
-                      mode="outlined"
-                      onPress={handleValueCachePress}
-                      style={styles.menuButton}
-                      contentStyle={styles.buttonContent}
-                      disabled={!modelStore.flash_attn}
-                      icon={({size, color}) => (
-                        <Icon source="chevron-down" size={size} color={color} />
-                      )}>
-                      {getCacheTypeLabel(modelStore.cache_type_v)}
-                    </Button>
-                    <Menu
-                      visible={showValueCacheMenu}
-                      onDismiss={() => setShowValueCacheMenu(false)}
-                      anchor={valueCacheAnchor}
-                      selectable>
-                      {cacheTypeOptions.map(option => (
-                        <Menu.Item
-                          key={option.value}
-                          label={option.label}
-                          selected={option.value === modelStore.cache_type_v}
-                          onPress={() => {
-                            modelStore.setCacheTypeV(option.value);
-                            setShowValueCacheMenu(false);
-                          }}
-                        />
-                      ))}
-                    </Menu>
-                  </View>
-                </View>
-              </View>
-              <Divider />
-
+              {/* Metal Settings (iOS only) */}
               {Platform.OS === 'ios' && (
-                <View style={styles.settingItemContainer}>
-                  <View style={styles.switchContainer}>
-                    <View style={styles.textContainer}>
-                      <Text variant="titleMedium" style={styles.textLabel}>
-                        {l10n.metal}
-                      </Text>
-                      <Text variant="labelSmall" style={styles.textDescription}>
-                        {l10n.metalDescription}
-                      </Text>
+                <>
+                  <Divider />
+                  <View style={styles.settingItemContainer}>
+                    <View style={styles.switchContainer}>
+                      <View style={styles.textContainer}>
+                        <Text variant="titleMedium" style={styles.textLabel}>
+                          {l10n.metal}
+                        </Text>
+                        <Text
+                          variant="labelSmall"
+                          style={styles.textDescription}>
+                          {l10n.metalDescription}
+                        </Text>
+                      </View>
+                      <Switch
+                        testID="metal-switch"
+                        value={modelStore.useMetal}
+                        onValueChange={value =>
+                          modelStore.updateUseMetal(value)
+                        }
+                      />
                     </View>
-                    <Switch
-                      testID="metal-switch"
-                      value={modelStore.useMetal}
-                      onValueChange={value => modelStore.updateUseMetal(value)}
-                    />
-                  </View>
-                  <Slider
-                    testID="gpu-layers-slider"
-                    disabled={!modelStore.useMetal}
-                    value={modelStore.n_gpu_layers}
-                    onValueChange={value =>
-                      modelStore.setNGPULayers(Math.round(value))
-                    }
-                    minimumValue={1}
-                    maximumValue={100}
-                    step={1}
-                    style={styles.nGPUSlider}
-                    thumbTintColor={theme.colors.primary}
-                    minimumTrackTintColor={theme.colors.primary}
-                  />
-                  <Text
-                    variant="labelSmall"
-                    style={[styles.textDescription, {}]}>
-                    {l10n.layersOnGPU.replace(
-                      '{{gpuLayers}}',
-                      modelStore.n_gpu_layers.toString(),
-                    )}
-                  </Text>
-                </View>
-              )}
-              <Divider />
-
-              <View style={styles.switchContainer}>
-                <View style={styles.textContainer}>
-                  <Text variant="titleMedium" style={styles.textLabel}>
-                    {l10n.autoNavigateToChat}
-                  </Text>
-                  <Text variant="labelSmall" style={styles.textDescription}>
-                    {l10n.autoNavigateToChatDescription}
-                  </Text>
-                </View>
-                <Switch
-                  testID="auto-navigate-to-chat-switch"
-                  value={uiStore.autoNavigatetoChat}
-                  onValueChange={value => uiStore.setAutoNavigateToChat(value)}
-                />
-              </View>
-
-              {Platform.OS === 'ios' && (
-                <View style={styles.settingItemContainer}>
-                  <View style={styles.switchContainer}>
-                    <View style={styles.textContainer}>
-                      <Text variant="titleMedium" style={styles.textLabel}>
-                        {l10n.iOSBackgroundDownload}
-                      </Text>
-                      <Text variant="labelSmall" style={styles.textDescription}>
-                        {l10n.iOSBackgroundDownloadDescription}
-                      </Text>
-                    </View>
-                    <Switch
-                      testID="ios-background-download-switch"
-                      value={uiStore.iOSBackgroundDownloading}
+                    <Slider
+                      testID="gpu-layers-slider"
+                      disabled={!modelStore.useMetal}
+                      value={modelStore.n_gpu_layers}
                       onValueChange={value =>
-                        uiStore.setiOSBackgroundDownloading(value)
+                        modelStore.setNGPULayers(Math.round(value))
                       }
+                      minimumValue={1}
+                      maximumValue={100}
+                      step={1}
+                      style={styles.nGPUSlider}
+                      thumbTintColor={theme.colors.primary}
+                      minimumTrackTintColor={theme.colors.primary}
                     />
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {l10n.layersOnGPU.replace(
+                        '{{gpuLayers}}',
+                        modelStore.n_gpu_layers.toString(),
+                      )}
+                    </Text>
+                  </View>
+                </>
+              )}
+
+              {/* Advanced Settings Button */}
+              <Button
+                mode="outlined"
+                onPress={() => setShowAdvancedSettings(!showAdvancedSettings)}
+                style={styles.advancedSettingsButton}
+                contentStyle={styles.buttonContent}
+                icon={({size, color}) => (
+                  <Icon
+                    source={
+                      showAdvancedSettings ? 'chevron-up' : 'chevron-down'
+                    }
+                    size={size}
+                    color={color}
+                  />
+                )}>
+                Advanced Settings
+              </Button>
+
+              {/* Advanced Settings Content */}
+              {showAdvancedSettings && (
+                <View style={styles.advancedSettingsContent}>
+                  <Divider />
+                  {/* Batch Size Slider */}
+                  <View style={styles.settingItemContainer}>
+                    <Text variant="titleMedium" style={styles.textLabel}>
+                      Batch Size
+                    </Text>
+                    <Slider
+                      testID="batch-size-slider"
+                      value={modelStore.n_batch}
+                      onValueChange={value =>
+                        modelStore.setNBatch(Math.round(value))
+                      }
+                      minimumValue={1}
+                      maximumValue={4096}
+                      step={1}
+                      style={styles.nGPUSlider}
+                      thumbTintColor={theme.colors.primary}
+                      minimumTrackTintColor={theme.colors.primary}
+                    />
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {`Batch size: ${modelStore.n_batch}${
+                        modelStore.n_batch > modelStore.n_context
+                          ? ` (effective: ${modelStore.n_context})`
+                          : ''
+                      }`}
+                    </Text>
+                  </View>
+                  <Divider />
+
+                  {/* Physical Batch Size Slider */}
+                  <View style={styles.settingItemContainer}>
+                    <Text variant="titleMedium" style={styles.textLabel}>
+                      Physical Batch Size
+                    </Text>
+                    <Slider
+                      testID="ubatch-size-slider"
+                      value={modelStore.n_ubatch}
+                      onValueChange={value =>
+                        modelStore.setNUBatch(Math.round(value))
+                      }
+                      minimumValue={1}
+                      maximumValue={4096}
+                      step={1}
+                      style={styles.nGPUSlider}
+                      thumbTintColor={theme.colors.primary}
+                      minimumTrackTintColor={theme.colors.primary}
+                    />
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {`Physical batch size: ${modelStore.n_ubatch}${
+                        modelStore.n_ubatch >
+                        Math.min(modelStore.n_batch, modelStore.n_context)
+                          ? ` (effective: ${Math.min(
+                              modelStore.n_batch,
+                              modelStore.n_context,
+                            )})`
+                          : ''
+                      }`}
+                    </Text>
+                  </View>
+                  <Divider />
+
+                  {/* Thread Count Slider */}
+                  <View style={styles.settingItemContainer}>
+                    <Text variant="titleMedium" style={styles.textLabel}>
+                      Thread Count
+                    </Text>
+                    <Slider
+                      testID="thread-count-slider"
+                      value={modelStore.n_threads}
+                      onValueChange={value =>
+                        modelStore.setNThreads(Math.round(value))
+                      }
+                      minimumValue={1}
+                      maximumValue={modelStore.max_threads}
+                      step={1}
+                      style={styles.nGPUSlider}
+                      thumbTintColor={theme.colors.primary}
+                      minimumTrackTintColor={theme.colors.primary}
+                    />
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {`Using ${modelStore.n_threads} of ${modelStore.max_threads} available threads`}
+                    </Text>
+                  </View>
+                  <Divider />
+
+                  {/* Flash Attention and Cache Types */}
+                  <View style={styles.settingItemContainer}>
+                    <View style={styles.switchContainer}>
+                      <View style={styles.textContainer}>
+                        <Text variant="titleMedium" style={styles.textLabel}>
+                          Flash Attention
+                        </Text>
+                        <Text
+                          variant="labelSmall"
+                          style={styles.textDescription}>
+                          Enable Flash Attention for faster processing
+                        </Text>
+                      </View>
+                      <Switch
+                        testID="flash-attention-switch"
+                        value={modelStore.flash_attn}
+                        onValueChange={value => modelStore.setFlashAttn(value)}
+                      />
+                    </View>
+                  </View>
+                  <Divider />
+
+                  {/* Cache Type K Selection */}
+                  <View style={styles.settingItemContainer}>
+                    <View style={styles.switchContainer}>
+                      <View style={styles.textContainer}>
+                        <Text variant="titleMedium" style={styles.textLabel}>
+                          Key Cache Type
+                        </Text>
+                        <Text
+                          variant="labelSmall"
+                          style={styles.textDescription}>
+                          {modelStore.flash_attn
+                            ? 'Select the cache type for key computation'
+                            : 'Enable Flash Attention to change cache type'}
+                        </Text>
+                      </View>
+                      <View
+                        style={styles.menuContainer}
+                        ref={keyCacheButtonRef}>
+                        <Button
+                          mode="outlined"
+                          onPress={handleKeyCachePress}
+                          style={styles.menuButton}
+                          contentStyle={styles.buttonContent}
+                          disabled={!modelStore.flash_attn}
+                          icon={({size, color}) => (
+                            <Icon
+                              source="chevron-down"
+                              size={size}
+                              color={color}
+                            />
+                          )}>
+                          {getCacheTypeLabel(modelStore.cache_type_k)}
+                        </Button>
+                        <Menu
+                          visible={showKeyCacheMenu}
+                          onDismiss={() => setShowKeyCacheMenu(false)}
+                          anchor={keyCacheAnchor}
+                          selectable>
+                          {cacheTypeOptions.map(option => (
+                            <Menu.Item
+                              key={option.value}
+                              label={option.label}
+                              selected={
+                                option.value === modelStore.cache_type_k
+                              }
+                              onPress={() => {
+                                modelStore.setCacheTypeK(option.value);
+                                setShowKeyCacheMenu(false);
+                              }}
+                            />
+                          ))}
+                        </Menu>
+                      </View>
+                    </View>
+                  </View>
+                  <Divider />
+
+                  {/* Cache Type V Selection */}
+                  <View style={styles.settingItemContainer}>
+                    <View style={styles.switchContainer}>
+                      <View style={styles.textContainer}>
+                        <Text variant="titleMedium" style={styles.textLabel}>
+                          Value Cache Type
+                        </Text>
+                        <Text
+                          variant="labelSmall"
+                          style={styles.textDescription}>
+                          {modelStore.flash_attn
+                            ? 'Select the cache type for value computation'
+                            : 'Enable Flash Attention to change cache type'}
+                        </Text>
+                      </View>
+                      <View
+                        style={styles.menuContainer}
+                        ref={valueCacheButtonRef}>
+                        <Button
+                          mode="outlined"
+                          onPress={handleValueCachePress}
+                          style={styles.menuButton}
+                          contentStyle={styles.buttonContent}
+                          disabled={!modelStore.flash_attn}
+                          icon={({size, color}) => (
+                            <Icon
+                              source="chevron-down"
+                              size={size}
+                              color={color}
+                            />
+                          )}>
+                          {getCacheTypeLabel(modelStore.cache_type_v)}
+                        </Button>
+                        <Menu
+                          visible={showValueCacheMenu}
+                          onDismiss={() => setShowValueCacheMenu(false)}
+                          anchor={valueCacheAnchor}
+                          selectable>
+                          {cacheTypeOptions.map(option => (
+                            <Menu.Item
+                              key={option.value}
+                              label={option.label}
+                              selected={
+                                option.value === modelStore.cache_type_v
+                              }
+                              onPress={() => {
+                                modelStore.setCacheTypeV(option.value);
+                                setShowValueCacheMenu(false);
+                              }}
+                            />
+                          ))}
+                        </Menu>
+                      </View>
+                    </View>
                   </View>
                 </View>
               )}
             </Card.Content>
           </Card>
 
-          {/* UI Settings Section */}
+          {/* Model Loading Settings */}
           <Card elevation={0} style={styles.card}>
-            <Card.Title title={l10n.uiSettingsTitle} />
+            <Card.Title title="Model Loading Settings" />
             <Card.Content>
               <View style={styles.settingItemContainer}>
+                {/* Auto Offload/Load */}
+                <View style={styles.switchContainer}>
+                  <View style={styles.textContainer}>
+                    <Text variant="titleMedium" style={styles.textLabel}>
+                      {l10n.autoOffloadLoad}
+                    </Text>
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {l10n.autoOffloadLoadDescription}
+                    </Text>
+                  </View>
+                  <Switch
+                    testID="auto-offload-load-switch"
+                    value={modelStore.useAutoRelease}
+                    onValueChange={value =>
+                      modelStore.updateUseAutoRelease(value)
+                    }
+                  />
+                </View>
+
+                {/* Auto Navigate to Chat */}
+                <View style={styles.switchContainer}>
+                  <View style={styles.textContainer}>
+                    <Text variant="titleMedium" style={styles.textLabel}>
+                      {l10n.autoNavigateToChat}
+                    </Text>
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {l10n.autoNavigateToChatDescription}
+                    </Text>
+                  </View>
+                  <Switch
+                    testID="auto-navigate-to-chat-switch"
+                    value={uiStore.autoNavigatetoChat}
+                    onValueChange={value =>
+                      uiStore.setAutoNavigateToChat(value)
+                    }
+                  />
+                </View>
+              </View>
+            </Card.Content>
+          </Card>
+
+          {/* UI Settings */}
+          <Card elevation={0} style={styles.card}>
+            <Card.Title title="UI Settings" />
+            <Card.Content>
+              <View style={styles.settingItemContainer}>
+                {/* Dark Mode */}
                 <View style={styles.switchContainer}>
                   <View style={styles.textContainer}>
                     <Text variant="titleMedium" style={styles.textLabel}>
@@ -482,6 +521,28 @@ export const SettingsScreen: React.FC = observer(() => {
                   />
                 </View>
 
+                {/* iOS Background Download */}
+                {Platform.OS === 'ios' && (
+                  <View style={styles.switchContainer}>
+                    <View style={styles.textContainer}>
+                      <Text variant="titleMedium" style={styles.textLabel}>
+                        {l10n.iOSBackgroundDownload}
+                      </Text>
+                      <Text variant="labelSmall" style={styles.textDescription}>
+                        {l10n.iOSBackgroundDownloadDescription}
+                      </Text>
+                    </View>
+                    <Switch
+                      testID="ios-background-download-switch"
+                      value={uiStore.iOSBackgroundDownloading}
+                      onValueChange={value =>
+                        uiStore.setiOSBackgroundDownloading(value)
+                      }
+                    />
+                  </View>
+                )}
+
+                {/* Display Memory Usage (iOS only) */}
                 {Platform.OS === 'ios' && (
                   <View style={styles.switchContainer}>
                     <View style={styles.textContainer}>

--- a/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
+++ b/src/screens/SettingsScreen/__tests__/SettingsScreen.test.tsx
@@ -7,8 +7,6 @@ import {SettingsScreen} from '../SettingsScreen';
 
 import {modelStore, uiStore} from '../../../store';
 
-import {l10n} from '../../../utils/l10n';
-
 jest.useFakeTimers();
 
 describe('SettingsScreen', () => {
@@ -22,8 +20,9 @@ describe('SettingsScreen', () => {
       withSafeArea: true,
     });
 
-    expect(getByText(l10n.en.modelSettingsTitle)).toBeTruthy();
-    expect(getByText(l10n.en.autoOffloadLoad)).toBeTruthy();
+    expect(getByText('Model Initialization Settings')).toBeTruthy();
+    expect(getByText('Model Loading Settings')).toBeTruthy();
+    expect(getByText('App Settings')).toBeTruthy();
     expect(getByDisplayValue('1024')).toBeTruthy(); // Context size
   });
 
@@ -69,7 +68,7 @@ describe('SettingsScreen', () => {
     const contextSizeInput = getByDisplayValue('1024');
 
     fireEvent.changeText(contextSizeInput, '512');
-    fireEvent.press(getByText(l10n.en.modelSettingsTitle));
+    fireEvent.press(getByText('Model Initialization Settings'));
 
     await waitFor(() => {
       expect(Keyboard.dismiss).toHaveBeenCalled();

--- a/src/screens/SettingsScreen/styles.ts
+++ b/src/screens/SettingsScreen/styles.ts
@@ -9,51 +9,60 @@ export const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.background,
     },
     container: {
-      padding: 10,
+      padding: 16,
     },
     scrollViewContent: {
-      paddingVertical: 10,
-      paddingHorizontal: 15,
+      paddingVertical: 16,
+      paddingHorizontal: 16,
     },
     card: {
-      marginVertical: 10,
-      borderRadius: 15,
+      marginVertical: 8,
+      borderRadius: 12,
       backgroundColor: theme.colors.surface,
     },
     settingItemContainer: {
-      marginVertical: 15,
+      marginVertical: 8,
     },
     switchContainer: {
       flexDirection: 'row',
-      alignItems: 'center',
       justifyContent: 'space-between',
-      marginBottom: 5,
+      alignItems: 'center',
+      marginVertical: 8,
     },
     textContainer: {
       flex: 1,
+      marginRight: 16,
     },
     textLabel: {
-      fontSize: 16,
-      fontWeight: '600',
+      color: theme.colors.onSurface,
     },
     textDescription: {
-      fontSize: 14,
-      marginRight: 2,
-      color: theme.colors.textSecondary,
-    },
-    textInput: {
-      marginVertical: 5,
+      color: theme.colors.onSurfaceVariant,
+      marginTop: 4,
     },
     nGPUSlider: {
       marginTop: 1,
     },
+    textInput: {
+      marginVertical: 8,
+      //backgroundColor: theme.colors.surface,
+    },
     invalidInput: {
-      borderColor: 'red',
+      borderColor: theme.colors.error,
       borderWidth: 1,
     },
     errorText: {
-      color: 'red',
-      fontSize: 12,
-      marginTop: 5,
+      color: theme.colors.error,
+      marginTop: 4,
+    },
+    menuContainer: {
+      position: 'relative',
+    },
+    menuButton: {
+      //backgroundColor: theme.colors.surface,
+      minWidth: 100,
+    },
+    buttonContent: {
+      flexDirection: 'row-reverse',
     },
   });

--- a/src/screens/SettingsScreen/styles.ts
+++ b/src/screens/SettingsScreen/styles.ts
@@ -21,7 +21,7 @@ export const createStyles = (theme: Theme) =>
       backgroundColor: theme.colors.surface,
     },
     settingItemContainer: {
-      marginVertical: 8,
+      marginVertical: 16,
     },
     switchContainer: {
       flexDirection: 'row',
@@ -38,11 +38,11 @@ export const createStyles = (theme: Theme) =>
     },
     textDescription: {
       color: theme.colors.onSurfaceVariant,
-      marginTop: 4,
+      //marginTop: 4,
     },
-    nGPUSlider: {
-      marginVertical: 8,
-      height: 40,
+    slider: {
+      //marginVertical: 8,
+      //height: 40,
     },
     textInput: {
       marginVertical: 8,
@@ -70,5 +70,17 @@ export const createStyles = (theme: Theme) =>
     },
     advancedSettingsContent: {
       marginTop: 8,
+    },
+    advancedAccordion: {
+      borderRadius: 8,
+      height: 55,
+      backgroundColor: theme.colors.surface,
+    },
+    accordionTitle: {
+      fontSize: 14,
+      color: theme.colors.secondary,
+    },
+    menu: {
+      width: 170,
     },
   });

--- a/src/screens/SettingsScreen/styles.ts
+++ b/src/screens/SettingsScreen/styles.ts
@@ -63,5 +63,12 @@ export const createStyles = (theme: Theme) =>
     },
     buttonContent: {
       flexDirection: 'row-reverse',
+      justifyContent: 'space-between',
+    },
+    advancedSettingsButton: {
+      marginVertical: 8,
+    },
+    advancedSettingsContent: {
+      marginTop: 8,
     },
   });

--- a/src/screens/SettingsScreen/styles.ts
+++ b/src/screens/SettingsScreen/styles.ts
@@ -41,11 +41,11 @@ export const createStyles = (theme: Theme) =>
       marginTop: 4,
     },
     nGPUSlider: {
-      marginTop: 1,
+      marginVertical: 8,
+      height: 40,
     },
     textInput: {
       marginVertical: 8,
-      //backgroundColor: theme.colors.surface,
     },
     invalidInput: {
       borderColor: theme.colors.error,
@@ -59,7 +59,6 @@ export const createStyles = (theme: Theme) =>
       position: 'relative',
     },
     menuButton: {
-      //backgroundColor: theme.colors.surface,
       minWidth: 100,
     },
     buttonContent: {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -443,3 +443,14 @@ export type DeviceInfo = {
     hasI8mm: boolean;
   };
 };
+
+export enum CacheType {
+  F16 = 'f16',
+  F32 = 'f32',
+  Q8_0 = 'q8_0',
+  Q4_0 = 'q4_0',
+  Q4_1 = 'q4_1',
+  IQ4_NL = 'iq4_nl',
+  Q5_0 = 'q5_0',
+  Q5_1 = 'q5_1',
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -388,7 +388,7 @@ export type BenchmarkConfig = {
   label: string;
 };
 
-export type BenchmarkResult = {
+export interface BenchmarkResult {
   config: BenchmarkConfig;
   modelDesc: string;
   modelSize: number;
@@ -402,7 +402,7 @@ export type BenchmarkResult = {
   modelName: string;
   oid?: string;
   rfilename?: string;
-  filename: string;
+  filename?: string;
   peakMemoryUsage?: {
     total: number;
     used: number;
@@ -411,7 +411,17 @@ export type BenchmarkResult = {
   wallTimeMs?: number;
   uuid: string;
   submitted?: boolean;
-};
+  initSettings?: {
+    n_context: number;
+    n_batch: number;
+    n_ubatch: number;
+    n_threads: number;
+    flash_attn: boolean;
+    cache_type_k: CacheType;
+    cache_type_v: CacheType;
+    n_gpu_layers: number;
+  };
+}
 
 export type DeviceInfo = {
   model: string;


### PR DESCRIPTION
## Description

This PR adds the following model initialization parameters to the settings page UI:
-   n_batch
-   n_ubatch
-   n_threads
-   flash_attn
-   cache_type_k
-   cache_type_v

Additionally, the benchmark results now include these metrics:
-   n_context
-   n_batch
-   n_ubatch
-   n_threads
-   flash_attn
-   cache_type_k
-   cache_type_v
-   n_gpu_layers

Fixes #79 

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
