### PR TITLE
feat: bump llama.rn version to enable runtime repacking for Q4_0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@dr.pogodin/react-native-fs": "^2.30.1",
     "@flyerhq/react-native-link-preview": "^1.6.0",
     "@gorhom/bottom-sheet": "^5.0.6",
-    "@pocketpalai/llama.rn": "^0.4.7-2",
+    "@pocketpalai/llama.rn": "^0.4.7-3",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",
     "@react-native-community/blur": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,10 +2099,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pocketpalai/llama.rn@^0.4.7-2":
-  version "0.4.7-2"
-  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.4.7-2.tgz#bdf112b3c41ce33d771fc58d2d8fefcf21e6f90b"
-  integrity sha512-Wo3nzqgNn9lNJKryT+vi5Lv+bjwUJb5/DI1Ll2YHQXtzOe/HdLAuhZYE1WoXK7MFYaWCclcYPbzP/cxVwTNrdA==
+"@pocketpalai/llama.rn@^0.4.7-3":
+  version "0.4.7-3"
+  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.4.7-3.tgz#7a237d7b42177dbcef4dd89693cb9a82e721dd53"
+  integrity sha512-Yt451G8JXIhhn2hfQHadUVf4KqvGQVUTU1JZ0XUFw28f0+T1N2ta/MSgoJpY4lXyh2h+0fnSc+DqS+5jgQIYmA==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## Description

This PR adds -DLM_GGML_USE_CPU_AARCH64 compile definition to Android CMake build, which in turn enables runtime tensor repacking optimization for Q4_0 quantization on ARM64.

The screenshot from PocketPal's benchmarking before/after setting -DLM_GGML_USE_CPU_AARCH64:

<img width="1290" alt="Screenshot 2025-01-06 at 10 17 57" src="https://github.com/user-attachments/assets/9d41d5e7-64f0-491a-9594-41111ed11380" />


## Platform Affected

- [ ] iOS
- [x] Android

## Checklist

- [ ] Necessary comments have been made.
- [x] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
