### PR TITLE
fix: correctly populate chat input text when editing the first message

### DIFF
--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -35,7 +35,9 @@ class ChatSessionStore {
   get shouldShowHeaderDivider(): boolean {
     return (
       !this.activeSessionId ||
-      (this.currentSessionMessages.length === 0 && !this.isGenerating)
+      (this.currentSessionMessages.length === 0 &&
+        !this.isGenerating &&
+        !this.isEditMode)
     );
   }
 


### PR DESCRIPTION
## Description

When entering edit mode for a message, the entire chat screen would remount, causing the input state to reset. This was happening because `shouldShowHeaderDivider` computed property would change when messages were filtered in edit mode, triggering a screen options update.

## Solution
Added `!isEditMode` condition to `shouldShowHeaderDivider` getter to prevent header style changes during edit mode. This ensures screen options remain stable when editing messages.

Fixes #169 

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [ ] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
