### PR TITLE
fix: use file size as first check for file integrity test, then hash

### DIFF
--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -423,13 +423,6 @@ class ModelStore {
 
     // Don't mark as downloaded if currently downloading
     if (exists && !this.downloadJobs.has(model.id)) {
-      // Only calculate hash if it's not already stored. Hash calculation is expensive.
-      if (!model.hash) {
-        const hash = await getSHA256Hash(filePath);
-        runInAction(() => {
-          model.hash = hash;
-        });
-      }
       runInAction(() => {
         model.isDownloaded = true;
       });
@@ -561,12 +554,14 @@ class ModelStore {
 
       const result = await ret.promise;
       if (result.statusCode === 200) {
-        // Calculate hash after successful download
-        const hash = await getSHA256Hash(downloadDest);
+        // We removed hash check for now, as it's not reliable and expensive..
+        // It is done only if file size match fails.
+        // // Calculate hash after successful download
+        // const hash = await getSHA256Hash(downloadDest);
 
         runInAction(() => {
           model.progress = 100;
-          model.hash = hash;
+          //model.hash = hash;
           model.isDownloaded = true; // Only mark as downloaded here
         });
 
@@ -1073,6 +1068,25 @@ class ModelStore {
       console.error('Failed to fetch model file details:', error);
     }
   }
+
+  // Expensive operation.
+  // It will be calculating hash if hash is not set, unless force is true.
+  updateModelHash = async (modelId: string, force: boolean = false) => {
+    const model = this.models.find(m => m.id === modelId);
+
+    // We only update hash if the model is downloaded and not currently being downloaded.
+    if (model?.isDownloaded && !this.downloadJobs.has(modelId)) {
+      // If not forced, we only update hash if it's not already set.
+      if (model.hash && !force) {
+        return;
+      }
+      const filePath = await this.getModelFullPath(model);
+      const hash = await getSHA256Hash(filePath);
+      runInAction(() => {
+        model.hash = hash;
+      });
+    }
+  };
 }
 
 export const modelStore = new ModelStore();

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -423,9 +423,15 @@ class ModelStore {
 
     // Don't mark as downloaded if currently downloading
     if (exists && !this.downloadJobs.has(model.id)) {
-      runInAction(() => {
-        model.isDownloaded = true;
-      });
+      if (!model.isDownloaded) {
+        console.log(
+          'checkFileExists: marking as downloaded - this should not happen:',
+          model.id,
+        );
+        runInAction(() => {
+          model.isDownloaded = true;
+        });
+      }
     } else {
       runInAction(() => {
         model.isDownloaded = false;


### PR DESCRIPTION
## Description

- Modified model integrity checking to prioritize file size comparison over hash verification, has for some reason `RNFS.hash` not always  return correct hash
- Added 0.1% size difference tolerance. Sufficient for detecting most corruption/incomplete download issues.
- Made hash checking a fallback option only when size comparison isn't possible

Fixes #172 

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
