### PR TITLE
fix(android): remove fp16 compiler flag for llama.rn to resolve deeps…

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -140,7 +140,7 @@ PODS:
   - hermes-engine (0.76.3):
     - hermes-engine/Pre-built (= 0.76.3)
   - hermes-engine/Pre-built (0.76.3)
-  - llama-rn (0.4.8-1):
+  - llama-rn (0.4.8-2):
     - React-Core
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
@@ -2264,7 +2264,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: ee5c2d2242816773fbf79e5b0563f5355ef1c315
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   hermes-engine: 0555a84ea495e8e3b4bde71b597cd87fbb382888
-  llama-rn: 687ae7370110322ebb06830527f77f4c70bee7cf
+  llama-rn: eb844b9cc4b240409b0411f16836416e567374f8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 84578c8756030547307e4572ab1947de1685c599

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@dr.pogodin/react-native-fs": "^2.30.3",
     "@flyerhq/react-native-link-preview": "^1.6.0",
     "@gorhom/bottom-sheet": "^5.0.6",
-    "@pocketpalai/llama.rn": "^0.4.8-1",
+    "@pocketpalai/llama.rn": "^0.4.8-2",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",
     "@react-native-community/blur": "^4.4.1",

--- a/src/components/MarkdownView/styles.ts
+++ b/src/components/MarkdownView/styles.ts
@@ -39,7 +39,7 @@ export const createStyles = (theme: Theme) =>
       flex: 1,
     },
     thinkContainer: {
-      backgroundColor: theme.colors.surface,
+      backgroundColor: theme.colors.surfaceContainerHigh,
       borderRadius: 8,
       padding: 12,
       marginVertical: 8,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,10 +2099,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pocketpalai/llama.rn@^0.4.8-1":
-  version "0.4.8-1"
-  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.4.8-1.tgz#731e02e3da6c31898cbee7b075e32ee955ec8dee"
-  integrity sha512-oNGQJzH5RDQifMWID6rEW5YEAlJgeuZzYIS0EluQBD903S+ICbqmXPGQk79BAzTsw2W6RAHDPGxDmM4utGNE4Q==
+"@pocketpalai/llama.rn@^0.4.8-2":
+  version "0.4.8-2"
+  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.4.8-2.tgz#69b24e0c7480b4037c619834c519d7c7dbe7170d"
+  integrity sha512-FsPnChABdeJ95Fxh6GxpSp7pDkVWTnVgp7oYtdS9Oq7F3jZnABuX8Xy8jNE6lAEIdYazat2ml+fOFaPKbVgs4w==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## Description
This PR upgrades llama.rn, which in turn removes the fp16 compiler flag for Android librnllama builds, resolving an issue with Deepseek R1 Qwen family inference.

More details can be found here: https://github.com/mybigday/llama.rn/pull/110


## Platform Affected

- [ ] iOS
- [x] Android

## Checklist

- [ ] Necessary comments have been made.
- [x] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
