### PR TITLE
fix: refactor downloader

### DIFF
--- a/__mocks__/external/@kesha-antonov/react-native-background-downloader.js
+++ b/__mocks__/external/@kesha-antonov/react-native-background-downloader.js
@@ -1,0 +1,61 @@
+import {NativeModules} from 'react-native';
+
+// states:
+// 0 - Running
+// 1 - Suspended / Paused
+// 2 - Cancelled / Failed
+// 3 - Completed (not necessarily successfully)
+
+NativeModules.RNBackgroundDownloader = {
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+  download: jest.fn(),
+  pauseTask: jest.fn(),
+  resumeTask: jest.fn(),
+  stopTask: jest.fn(),
+  TaskRunning: 0,
+  TaskSuspended: 1,
+  TaskCanceling: 2,
+  TaskCompleted: 3,
+  checkForExistingDownloads: jest.fn().mockImplementation(() => {
+    const foundDownloads = [
+      {
+        id: 'taskRunning',
+        state: NativeModules.RNBackgroundDownloader.TaskRunning,
+        bytesDownloaded: 50,
+        bytesTotal: 100,
+      },
+      {
+        id: 'taskPaused',
+        state: NativeModules.RNBackgroundDownloader.TaskSuspended,
+        bytesDownloaded: 70,
+        bytesTotal: 100,
+      },
+      {
+        id: 'taskCancelled',
+        state: NativeModules.RNBackgroundDownloader.TaskCanceling,
+        bytesDownloaded: 90,
+        bytesTotal: 100,
+      },
+      {
+        id: 'taskCompletedExplicit',
+        state: NativeModules.RNBackgroundDownloader.TaskCompleted,
+        bytesDownloaded: 100,
+        bytesTotal: 100,
+      },
+      {
+        id: 'taskCompletedImplicit',
+        state: NativeModules.RNBackgroundDownloader.TaskCompleted,
+        bytesDownloaded: 100,
+        bytesTotal: 100,
+      },
+      {
+        id: 'taskFailed',
+        state: NativeModules.RNBackgroundDownloader.TaskCompleted,
+        bytesDownloaded: 90,
+        bytesTotal: 100,
+      },
+    ];
+    return Promise.resolve(foundDownloads);
+  }),
+};

--- a/__mocks__/stores/uiStore.ts
+++ b/__mocks__/stores/uiStore.ts
@@ -25,4 +25,5 @@ export const mockUiStore = {
   setColorScheme: jest.fn(),
   setDisplayMemUsage: jest.fn(),
   setBenchmarkShareDialogPreference: jest.fn(),
+  showError: jest.fn(),
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -46,5 +46,7 @@ module.exports = {
     '@react-native-firebase/app-check':
       '<rootDir>/__mocks__/external/@react-native-firebase/app-check.js',
     '\\.svg': '<rootDir>/__mocks__/external/react-native-svg.js',
+    '@kesha-antonov/react-native-background-downloader':
+      '<rootDir>/__mocks__/external/@kesha-antonov/react-native-background-downloader.js',
   },
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@dr.pogodin/react-native-fs": "^2.30.3",
     "@flyerhq/react-native-link-preview": "^1.6.0",
     "@gorhom/bottom-sheet": "^5.0.6",
+    "@kesha-antonov/react-native-background-downloader": "^3.2.6",
     "@pocketpalai/llama.rn": "^0.4.8-2",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -282,7 +282,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                 <>
                   <ProgressBar
                     testID="download-progress-bar"
-                    progress={modelStore.getDownloadProgress(model.id)}
+                    progress={model.progress / 100}
                     color={theme.colors.tertiary}
                     style={styles.progressBar}
                   />

--- a/src/services/downloads/DownloadManager.ts
+++ b/src/services/downloads/DownloadManager.ts
@@ -1,0 +1,211 @@
+import * as RNFS from '@dr.pogodin/react-native-fs';
+import {makeAutoObservable, observable} from 'mobx';
+import RNBackgroundDownloader, {
+  download,
+  completeHandler,
+} from '@kesha-antonov/react-native-background-downloader';
+
+import {
+  DownloadEventCallbacks,
+  DownloadJob,
+  DownloadMap,
+  DownloadProgress,
+} from './types';
+
+import {Model} from '../../utils/types';
+import {formatBytes, hasEnoughSpace} from '../../utils';
+
+export class DownloadManager {
+  private downloadJobs: DownloadMap;
+  private callbacks: DownloadEventCallbacks = {};
+
+  constructor() {
+    this.downloadJobs = observable.map(new Map());
+    makeAutoObservable(this);
+    this.reattachBackgroundDownloads();
+  }
+
+  setCallbacks(callbacks: DownloadEventCallbacks) {
+    this.callbacks = callbacks;
+  }
+
+  isDownloading(modelId: string): boolean {
+    return this.downloadJobs.has(modelId);
+  }
+
+  getDownloadProgress(modelId: string): number {
+    const job = this.downloadJobs.get(modelId);
+    return job?.state.progress?.progress || 0;
+  }
+
+  async startDownload(model: Model, destinationPath: string): Promise<void> {
+    const time = Date.now();
+    console.log('startDownload: ', time);
+    if (this.isDownloading(model.id)) {
+      console.log('Download already in progress for model:', model.id);
+      return;
+    }
+
+    if (!model.downloadUrl) {
+      throw new Error('Model has no download URL');
+    }
+
+    const isEnoughSpace = await hasEnoughSpace(model);
+    if (!isEnoughSpace) {
+      throw new Error('Not enough storage space to download the model');
+    }
+
+    // Ensure directory exists
+    const dirPath = destinationPath.substring(
+      0,
+      destinationPath.lastIndexOf('/'),
+    );
+    try {
+      await RNFS.mkdir(dirPath);
+    } catch (err) {
+      console.error('Failed to create directory:', err);
+      throw err;
+    }
+
+    try {
+      const task = download({
+        id: model.id,
+        url: model.downloadUrl,
+        destination: destinationPath,
+        metadata: {modelId: model.id},
+      });
+
+      const downloadJob: DownloadJob = {
+        task,
+        model,
+        state: {
+          isDownloading: true,
+          progress: null,
+          error: null,
+        },
+        lastBytesWritten: 0,
+        lastUpdateTime: Date.now(),
+      };
+
+      this.downloadJobs.set(model.id, downloadJob);
+
+      task
+        .begin(() => {
+          this.callbacks.onStart?.(model.id);
+        })
+        .progress(({bytesDownloaded, bytesTotal}) => {
+          if (!this.downloadJobs.has(model.id)) {
+            return;
+          }
+
+          const job = this.downloadJobs.get(model.id)!;
+          const currentTime = Date.now();
+          const timeDiff = (currentTime - job.lastUpdateTime) / 1000 || 1;
+          const bytesDiff = bytesDownloaded - job.lastBytesWritten;
+          const speedBps = bytesDiff / timeDiff;
+          const speedMBps = (speedBps / (1024 * 1024)).toFixed(2);
+
+          const remainingBytes = bytesTotal - bytesDownloaded;
+          const etaSeconds = speedBps > 0 ? remainingBytes / speedBps : 0;
+          const etaMinutes = Math.ceil(etaSeconds / 60);
+          const etaText =
+            etaSeconds >= 60
+              ? `${etaMinutes} min`
+              : `${Math.ceil(etaSeconds)} sec`;
+
+          const progress: DownloadProgress = {
+            bytesDownloaded,
+            bytesTotal,
+            progress: (bytesDownloaded / bytesTotal) * 100,
+            speed: `${formatBytes(bytesDownloaded, 0)} (${speedMBps} MB/s)`,
+            eta: etaText,
+          };
+          console.log('progress: ', progress.progress);
+
+          job.state.progress = progress;
+          job.lastBytesWritten = bytesDownloaded;
+          job.lastUpdateTime = currentTime;
+
+          this.callbacks.onProgress?.(model.id, progress);
+        })
+        .done(() => {
+          completeHandler(model.id);
+          this.downloadJobs.delete(model.id);
+          this.callbacks.onComplete?.(model.id);
+        })
+        .error(({error}) => {
+          console.error('Download failed:', error);
+          const job = this.downloadJobs.get(model.id);
+          if (job) {
+            job.state.error = new Error(error);
+            job.state.isDownloading = false;
+          }
+          this.downloadJobs.delete(model.id);
+          this.callbacks.onError?.(model.id, new Error(error));
+        });
+    } catch (err) {
+      console.error('Failed to start download:', err);
+      this.downloadJobs.delete(model.id);
+      throw err;
+    }
+  }
+
+  async cancelDownload(modelId: string): Promise<void> {
+    const job = this.downloadJobs.get(modelId);
+    if (job) {
+      try {
+        await job.task.stop();
+      } catch (err) {
+        console.error('Error stopping download:', err);
+      } finally {
+        this.downloadJobs.delete(modelId);
+      }
+    }
+  }
+
+  private async reattachBackgroundDownloads() {
+    try {
+      const lostTasks =
+        await RNBackgroundDownloader.checkForExistingDownloads();
+
+      for (const task of lostTasks) {
+        const downloadJob: DownloadJob = {
+          task,
+          model: task.metadata?.model,
+          state: {
+            isDownloading: true,
+            progress: null,
+            error: null,
+          },
+          lastBytesWritten: 0,
+          lastUpdateTime: Date.now(),
+        };
+
+        task
+          .progress(({bytesDownloaded, bytesTotal}) => {
+            const progress: DownloadProgress = {
+              bytesDownloaded,
+              bytesTotal,
+              progress: (bytesDownloaded / bytesTotal) * 100,
+              speed: '', // We don't have previous data for speed calculation
+              eta: '',
+            };
+            this.callbacks.onProgress?.(task.id, progress);
+          })
+          .done(() => {
+            completeHandler(task.id);
+            this.downloadJobs.delete(task.id);
+            this.callbacks.onComplete?.(task.id);
+          })
+          .error(({error}) => {
+            this.downloadJobs.delete(task.id);
+            this.callbacks.onError?.(task.id, new Error(error));
+          });
+
+        this.downloadJobs.set(task.id, downloadJob);
+      }
+    } catch (err) {
+      console.error('Error reattaching background downloads:', err);
+    }
+  }
+}

--- a/src/services/downloads/index.ts
+++ b/src/services/downloads/index.ts
@@ -1,0 +1,7 @@
+// Create a singleton instance
+import {DownloadManager} from './DownloadManager';
+
+export * from './types';
+export * from './DownloadManager';
+
+export const downloadManager = new DownloadManager();

--- a/src/services/downloads/types.ts
+++ b/src/services/downloads/types.ts
@@ -1,0 +1,33 @@
+import {DownloadTask} from '@kesha-antonov/react-native-background-downloader';
+import {Model} from '../../utils/types';
+
+export interface DownloadProgress {
+  bytesDownloaded: number;
+  bytesTotal: number;
+  progress: number;
+  speed: string;
+  eta: string;
+}
+
+export interface DownloadState {
+  isDownloading: boolean;
+  progress: DownloadProgress | null;
+  error: Error | null;
+}
+
+export interface DownloadJob {
+  task: DownloadTask;
+  model: Model;
+  state: DownloadState;
+  lastBytesWritten: number;
+  lastUpdateTime: number;
+}
+
+export type DownloadMap = Map<string, DownloadJob>;
+
+export interface DownloadEventCallbacks {
+  onProgress?: (modelId: string, progress: DownloadProgress) => void;
+  onComplete?: (modelId: string) => void;
+  onError?: (modelId: string, error: Error) => void;
+  onStart?: (modelId: string) => void;
+}

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -1,25 +1,21 @@
-import {AppState, AppStateStatus, Platform, NativeModules} from 'react-native';
+import {AppState, AppStateStatus, NativeModules} from 'react-native';
 
 import {v4 as uuidv4} from 'uuid';
 import 'react-native-get-random-values';
 import {makePersistable} from 'mobx-persist-store';
 import * as RNFS from '@dr.pogodin/react-native-fs';
+import {computed, makeAutoObservable, runInAction} from 'mobx';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {computed, makeAutoObservable, ObservableMap, runInAction} from 'mobx';
 import {CompletionParams, LlamaContext, initLlama} from '@pocketpalai/llama.rn';
 
 import {fetchModelFilesDetails} from '../api/hf';
 
 import {uiStore} from './UIStore';
 import {chatSessionStore} from './ChatSessionStore';
+import {deepMerge, getSHA256Hash, hfAsModel} from '../utils';
 import {defaultModels, MODEL_LIST_VERSION} from './defaultModels';
-import {
-  deepMerge,
-  formatBytes,
-  getSHA256Hash,
-  hasEnoughSpace,
-  hfAsModel,
-} from '../utils';
+
+import {downloadManager} from '../services/downloads';
 
 import {
   getHFDefaultSettings,
@@ -70,7 +66,6 @@ class ModelStore {
     | undefined = undefined;
 
   context: LlamaContext | undefined = undefined;
-  downloadJobs = new ObservableMap(); //new Map();
   useMetal = false; //Platform.OS === 'ios';
 
   lastUsedModelId: string | undefined = undefined;
@@ -105,6 +100,37 @@ class ModelStore {
     });
 
     this.setupAppStateListener();
+
+    // Set up download manager callbacks
+    downloadManager.setCallbacks({
+      onProgress: (modelId, progress) => {
+        const model = this.models.find(m => m.id === modelId);
+        if (model) {
+          runInAction(() => {
+            model.progress = progress.progress;
+            model.downloadSpeed = `${progress.speed} ETA: ${progress.eta}`;
+          });
+        }
+      },
+      onComplete: modelId => {
+        const model = this.models.find(m => m.id === modelId);
+        if (model) {
+          runInAction(() => {
+            model.progress = 100;
+            model.isDownloaded = true;
+          });
+        }
+      },
+      onError: modelId => {
+        const model = this.models.find(m => m.id === modelId);
+        if (model) {
+          runInAction(() => {
+            model.progress = 0;
+            model.isDownloaded = false;
+          });
+        }
+      },
+    });
   }
 
   private async initializeThreadCount() {
@@ -416,7 +442,7 @@ class ModelStore {
     const exists = await RNFS.exists(filePath);
 
     // Don't mark as downloaded if currently downloading
-    if (exists && !this.downloadJobs.has(model.id)) {
+    if (exists && !downloadManager.isDownloading(model.id)) {
       if (!model.isDownloaded) {
         console.log(
           'checkFileExists: marking as downloaded - this should not happen:',
@@ -469,146 +495,19 @@ class ModelStore {
       return;
     }
 
-    const isEnoughSpace = await hasEnoughSpace(model);
-
-    if (isEnoughSpace) {
-      this.downloadModel(model);
-    } else {
-      console.error('Not enough storage space to download the model.');
-    }
-  };
-
-  private downloadModel = async (model: Model) => {
-    if (model.isLocal || model.origin === ModelOrigin.LOCAL) {
-      return;
-    } // Skip downloading for local models
-
-    const downloadDest = await this.getModelFullPath(model);
-    console.log('downloading: downloadDest: ', downloadDest);
-
-    // Ensure directory exists
-    const dirPath = downloadDest.substring(0, downloadDest.lastIndexOf('/'));
     try {
-      await RNFS.mkdir(dirPath);
+      const destinationPath = await this.getModelFullPath(model);
+      await downloadManager.startDownload(model, destinationPath);
     } catch (err) {
-      console.error('Failed to create directory:', err);
-      return;
-    }
-
-    let lastBytesWritten = 0;
-    let lastUpdateTime = Date.now();
-
-    const progressHandler = (data: RNFS.DownloadProgressCallbackResultT) => {
-      if (!this.downloadJobs.has(model.id)) {
-        return;
-      }
-
-      const newProgress = (data.bytesWritten / data.contentLength) * 100;
-
-      // Calculate speed and ETA
-      const currentTime = Date.now();
-      const timeDiff = (currentTime - lastUpdateTime) / 1000 || 1; // '|| 1' to avoid division by zero
-      const bytesDiff = data.bytesWritten - lastBytesWritten;
-      const speedBps = bytesDiff / timeDiff;
-      const speedMBps = (speedBps / (1024 * 1024)).toFixed(2);
-
-      const remainingBytes = data.contentLength - data.bytesWritten;
-      const etaSeconds = speedBps > 0 ? remainingBytes / speedBps : 0;
-      const etaMinutes = Math.ceil(etaSeconds / 60);
-      const etaText =
-        etaSeconds >= 60 ? `${etaMinutes} min` : `${Math.ceil(etaSeconds)} sec`;
-
-      runInAction(() => {
-        model.progress = newProgress;
-        model.downloadSpeed = `${formatBytes(
-          data.bytesWritten,
-          0,
-        )}  (${speedMBps} MB/s) ETA: ${etaText}`;
-      });
-
-      lastBytesWritten = data.bytesWritten;
-      lastUpdateTime = currentTime;
-    };
-
-    const options = {
-      fromUrl: model.downloadUrl,
-      toFile: downloadDest,
-      background: uiStore.iOSBackgroundDownloading,
-      discretionary: false,
-      progressInterval: 800, // Update every 800ms
-      begin: () => {
-        runInAction(() => {
-          model.progress = 0;
-        });
-      },
-      progress: progressHandler,
-    };
-
-    try {
-      const ret = RNFS.downloadFile(options);
-      runInAction(() => {
-        model.isDownloaded = false;
-        model.hash = undefined;
-        this.downloadJobs.set(model.id, ret);
-      });
-
-      const result = await ret.promise;
-      if (result.statusCode === 200) {
-        // We removed hash check for now, as it's not reliable and expensive..
-        // It is done only if file size match fails.
-        // // Calculate hash after successful download
-        // const hash = await getSHA256Hash(downloadDest);
-
-        runInAction(() => {
-          model.progress = 100;
-          //model.hash = hash;
-          model.isDownloaded = true; // Only mark as downloaded here
-        });
-
-        if (Platform.OS === 'ios') {
-          // THIS IS REQUIRED. Without this, iOS might keep the background task running
-          // https://github.com/itinance/react-native-fs/tree/master?tab=readme-ov-file#background-downloads-tutorial-ios
-          RNFS.completeHandlerIOS(ret.jobId);
-        }
-      }
-    } catch (err: any) {
-      if (err.message !== 'Download has been aborted') {
-        console.error('Failed to download:', err);
-      } else {
-        console.log('Download aborted');
-      }
-    } finally {
-      runInAction(() => {
-        this.downloadJobs.delete(model.id);
-        this.refreshDownloadStatuses();
-      });
+      console.error('Failed to start download:', err);
+      uiStore.showError('Failed to start download: ' + (err as Error).message);
     }
   };
 
   cancelDownload = async (modelId: string) => {
-    const job = this.downloadJobs.get(modelId);
+    await downloadManager.cancelDownload(modelId);
     const model = this.models.find(m => m.id === modelId);
-    console.log('cancelling job: ', job);
-    if (job) {
-      RNFS.stopDownload(job.jobId);
-      runInAction(() => {
-        this.downloadJobs.delete(modelId);
-      });
-    }
-    console.log('cancelling model: ', model);
     if (model) {
-      const downloadDest = await this.getModelFullPath(model);
-      try {
-        // Ensure the destination file is deleted, this is specifically important for android
-        await RNFS.unlink(downloadDest);
-        console.log('Destination file deleted successfully');
-      } catch (err: any) {
-        if (err.code !== 'ENOENT') {
-          // Ignore error if file does not exist
-          console.error('Failed to delete destination file:', err);
-        }
-      }
-
       runInAction(() => {
         model.isDownloaded = false;
         model.progress = 0;
@@ -618,10 +517,12 @@ class ModelStore {
   };
 
   get isDownloading() {
-    return (modelId: string) => {
-      return this.downloadJobs.has(modelId);
-    };
+    return (modelId: string) => downloadManager.isDownloading(modelId);
   }
+
+  getDownloadProgress = (modelId: string) => {
+    return downloadManager.getDownloadProgress(modelId);
+  };
 
   /**
    * Removes a model from the models list if it is not downloaded.
@@ -692,11 +593,6 @@ class ModelStore {
         console.error('Failed to delete:', err);
       }
     }
-  };
-
-  getDownloadProgress = (modelId: string) => {
-    const model = this.models.find(m => m.id === modelId);
-    return model ? model.progress / 100 : 0; // Normalize progress to 0-1 for display
   };
 
   initContext = async (model: Model) => {
@@ -1079,7 +975,7 @@ class ModelStore {
     const model = this.models.find(m => m.id === modelId);
 
     // We only update hash if the model is downloaded and not currently being downloaded.
-    if (model?.isDownloaded && !this.downloadJobs.has(modelId)) {
+    if (model?.isDownloaded && !downloadManager.isDownloading(modelId)) {
       // If not forced, we only update hash if it's not already set.
       if (model.hash && !force) {
         return;

--- a/src/store/UIStore.ts
+++ b/src/store/UIStore.ts
@@ -33,6 +33,11 @@ export class UIStore {
     shouldShow: true,
   };
 
+  showError(message: string) {
+    // TODO: Implement error display logic (e.g., toast, alert, etc.)
+    console.error(message);
+  }
+
   constructor() {
     makeAutoObservable(this);
     makePersistable(this, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,6 +2133,11 @@
   resolved "https://registry.yarnpkg.com/@jsamr/react-native-li/-/react-native-li-2.3.1.tgz#12a5b5f6e3971cec77b96bee58104eed0ae9314a"
   integrity sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w==
 
+"@kesha-antonov/react-native-background-downloader@^3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@kesha-antonov/react-native-background-downloader/-/react-native-background-downloader-3.2.6.tgz#87656a9c6e31f9b7b915cd64b6a89e18896e79e8"
+  integrity sha512-J87PHzBh4knWTQNkCNM4LTMZ85RpMW/QSV+0LGdTxz4JmfLXoeg8R6ratbFU0DP/l8K1eL7r4S1Rc8bmqNJ3Ug==
+
 "@native-html/css-processor@1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@native-html/css-processor/-/css-processor-1.11.0.tgz#27d02e5123b0849f4986d44060ba3f235a15f552"


### PR DESCRIPTION
## Description

Switching the download method from RNFS to [react-native-background-downloader](https://github.com/kesha-antonov/react-native-background-downloader), as it appears to be more stable, particularly for Android and background downloads.

Fixes #199 and #179 

## Platform Affected

- [ ] iOS
- [ ] Android

## Checklist

- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
