### PR TITLE
Fix: Improve edge-to-edge display implementation across Android versions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,6 +137,9 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:32.7.0')
     implementation 'com.google.firebase:firebase-appcheck-playintegrity'
     implementation 'com.google.firebase:firebase-appcheck-debug'
+
+    // for edge-to-edge display
+    implementation "androidx.activity:activity-ktx:1.9.3" 
 }
 
 // apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,10 +26,7 @@
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize"
-        android:exported="true"
-        android:screenOrientation="portrait"
-        android:fitsSystemWindows="false"
-        android:theme="@style/AppTheme">
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/java/com/pocketpalai/MainActivity.kt
+++ b/android/app/src/main/java/com/pocketpalai/MainActivity.kt
@@ -4,7 +4,9 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
-import android.os.Bundle
+import androidx.activity.enableEdgeToEdge 
+import android.os.Bundle  // Required for onCreate parameter
+
 
 class MainActivity : ReactActivity() {
 
@@ -22,11 +24,7 @@ class MainActivity : ReactActivity() {
       DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    
-    // Enable edge-to-edge display
-    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-        window.setDecorFitsSystemWindows(false)
-    }
+      enableEdgeToEdge()
+      super.onCreate(savedInstanceState)
   }
 }

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,9 +4,6 @@
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Description

Previous implementation of edge-to-edge display had compatibility issues with older Android versions (<=14) and required manual configuration of system bars, fails on even older ones (<=10).

This PR replaces manual configuration with official AndroidX Activity library's `enableEdgeToEdge()` function.

Fixes #219
Fixes #222 

## Platform Affected

- [ ] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [x] Android Emulator/Device
    - [x] Verified working on:
                - Android 15 (API 35)
                - Android 14 (API 34)
                - Android 10 (API 29)
                - Android 9 (API 28)
- [x] Unit tests and integration tests pass locally.
