### PR TITLE
refactor: improve memory requirement check with benchmark-based model

### DIFF
--- a/src/hooks/__tests__/useMemoryCheck.test.ts
+++ b/src/hooks/__tests__/useMemoryCheck.test.ts
@@ -1,13 +1,11 @@
 import DeviceInfo from 'react-native-device-info';
 import {renderHook} from '@testing-library/react-hooks';
 
-import {deviceInfo} from '../../../jest/fixtures/device-info';
 import {largeMemoryModel, localModel} from '../../../jest/fixtures/models';
 
 import {useMemoryCheck} from '../useMemoryCheck';
 
 import {l10n} from '../../utils/l10n';
-import {formatBytes} from '../../utils';
 
 describe('useMemoryCheck', () => {
   beforeEach(() => {
@@ -47,10 +45,7 @@ describe('useMemoryCheck', () => {
     }
 
     expect(result.current).toEqual({
-      memoryWarning: l10n.en.memoryWarning.replace(
-        '{{totalMemory}}',
-        formatBytes(deviceInfo.totalMemory),
-      ),
+      memoryWarning: l10n.en.memoryWarning,
       shortMemoryWarning: l10n.en.shortMemoryWarning,
     });
   });

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -53,8 +53,10 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
     const [integrityError, setIntegrityError] = useState<string | null>(null);
 
     const {memoryWarning, shortMemoryWarning} = useMemoryCheck(model);
-    const {isOk: storageOk, message: storageNOkMessage} =
-      useStorageCheck(model);
+    const {isOk: storageOk, message: storageNOkMessage} = useStorageCheck(
+      model,
+      {enablePeriodicCheck: true, checkInterval: 10000},
+    );
 
     const isActiveModel = activeModelId === model.id;
     const isDownloaded = model.isDownloaded;

--- a/src/utils/l10n.ts
+++ b/src/utils/l10n.ts
@@ -24,7 +24,7 @@ export const l10n = {
     pleaseLoadModel: 'Load a model to chat.',
     shortMemoryWarning: 'Memory Warning',
     memoryWarning:
-      "Warning: Model size is close to or exceeds your device's total memory ({{totalMemory}}). This may cause unexpected behavior such as slow performance or system instability.",
+      'Warning: Model size may exceed available memory. This could affect performance and stability of your device.',
     load: 'Load',
     cancel: 'Cancel',
     download: 'Download',
@@ -163,7 +163,7 @@ export const l10n = {
     pleaseLoadModel: 'Cargue un modelo para chatear.',
     shortMemoryWarning: 'Advertencia de memoria',
     memoryWarning:
-      'Advertencia: El tamaño del modelo está cerca de o excede la memoria total de su dispositivo ({{totalMemory}}). Esto puede causar comportamientos inesperados como rendimiento lento o inestabilidad del sistema.',
+      'Advertencia: El tamaño del modelo puede exceder la memoria disponible. Esto podría afectar el rendimiento y la estabilidad de su dispositivo.',
     load: 'Cargar',
     cancel: 'Cancelar',
     download: 'Descargar',
@@ -295,7 +295,7 @@ export const l10n = {
     pleaseLoadModel: '채팅을 위해 모델을 로드하세요.',
     shortMemoryWarning: '메모리 경고',
     memoryWarning:
-      '경고: 모델 크기가 또는 장치의 총 메모리를 초과합니다 ({{totalMemory}}). 이는 속도가 느려지거나 시스템 불안정성을 일으킬 수 있는 예기치 않은 동작을 일으켜 초래할 수 있습니다.',
+      '경고: 모델 크기가 사용 가능한 메모리를 초과할 수 있습니다. 이는 장치의 성능과 안정성에 영향을 미칠 수 있습니다.',
     load: '로드',
     cancel: '취소',
     download: '다운로드',
@@ -408,7 +408,7 @@ export const l10n = {
     pleaseLoadModel: 'Załaduj model, aby czatować.',
     shortMemoryWarning: 'Ostrzeżenie o pamięci',
     memoryWarning:
-      'Ostrzeżenie: Rozmiar modelu jest bliski lub przekracza całkowitą pamięć swojego urządzenia ({{totalMemory}}). To może spowodować nieoczekiwane zachowanie, takie jak wolne wydajność lub niestabilność systemu.',
+      'Ostrzeżenie: Rozmiar modelu może przekraczać dostępną pamięć. Może to wpłynąć na wydajność i stabilność urządzenia.',
     load: 'Załaduj',
     cancel: 'Anuluj',
     download: 'Pobierz',
@@ -535,7 +535,7 @@ export const l10n = {
     pleaseLoadModel: 'Carregue um modelo para conversar.',
     shortMemoryWarning: 'Advertência de memória',
     memoryWarning:
-      'Advertência: O tamanho do modelo está próximo ou excede a memória total do seu dispositivo ({{totalMemory}}). Isso pode causar comportamentos inesperados como desempenho lento ou instabilidade do sistema.',
+      'Advertência: O tamanho do modelo pode exceder a memória disponível. Isso pode afetar o desempenho e a estabilidade do seu dispositivo.',
     load: 'Carregar',
     cancel: 'Cancelar',
     download: 'Baixar',
@@ -663,7 +663,7 @@ export const l10n = {
     pleaseLoadModel: 'Загрузите модель для общения.',
     shortMemoryWarning: 'Предупреждение о памяти',
     memoryWarning:
-      'Предупреждение: Размер модели близок или превышает общую память вашего устройства ({{totalMemory}}). Это может привести к непредвиденным поведением, таким как медленная производительность или нестабильность системы.',
+      'Предупреждение: Размер модели может превышать доступную память. Это может повлиять на производительность и стабильность вашего устройства.',
     load: 'Загрузить',
     cancel: 'Отменить',
     download: 'Скачать',
@@ -793,7 +793,7 @@ export const l10n = {
     pleaseLoadModel: 'Sohbet için model yükleyin.',
     shortMemoryWarning: 'Hafıza Uyarısı',
     memoryWarning:
-      'Uyarı: Model boyutu cihazınızın toplam hafızasına yakın veya onu aşıyor ({{totalMemory}}). Bu, beklenmedik davranışlar, örneğin yavaş performans veya sistem istikrarının oluşmasına neden olabilir.',
+      'Uyarı: Model boyutu kullanılabilir hafızayı aşabilir. Bu, cihazınızın performansını ve kararlılığını etkileyebilir.',
     load: 'Yükle',
     cancel: 'İptal',
     download: 'İndir',
@@ -915,7 +915,7 @@ export const l10n = {
     pleaseLoadModel: 'Завантажте модель для спілкування.',
     shortMemoryWarning: 'Предупреждение о памяти',
     memoryWarning:
-      'Предупреждение: Размер модели близок или превышает общую память вашего устройства ({{totalMemory}}). Это может привести к непредвиденным поведением, таким как медленная производительность или нестабильность системы.',
+      "Попередження: Розмір моделі може перевищувати доступну пам'ять. Це може вплинути на продуктивність і стабільність вашого пристрою.",
     load: 'Загрузить',
     cancel: 'Отменить',
     download: 'Скачать',
@@ -1045,7 +1045,7 @@ export const l10n = {
     pleaseLoadModel: 'Carregueu un model per xatejar.',
     shortMemoryWarning: 'Advertència de memòria',
     memoryWarning:
-      'Advertència: La mida del model està prop o supera la memòria total del dispositiu ({{totalMemory}}). Això pot causar comportaments inesperats com baix rendiment o inestabilitat del sistema.',
+      "Advertència: La mida del model pot excedir la memòria disponible. Això podria afectar el rendiment i l'estabilitat del vostre dispositiu.",
     load: 'Carregar',
     cancel: 'Cancel·lar',
     download: 'Descarregar',


### PR DESCRIPTION
## Description
This PR refactors the memory check logic to estimate model memory requirements using benchmark-derived parameters.

The warning criteria is now based on a simple linear fit from [AI Phone Leaderboard](https://huggingface.co/spaces/a-ghorbani/ai-phone-leaderboard) data.

Replaces the old check:

```javascript
model.size >= 0.7 * totalMemory
```

with:

```javascript
memoryRequirement >= min(totalMemory * 0.65, totalMemory - 1.2GB)
```

Where `memoryRequirement` is estimated as:

```javascript
memoryRequirement = model.size * 0.92 + 0.43
```

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.


<img width="923" alt="Screenshot 2025-03-26 at 18 54 09" src="https://github.com/user-attachments/assets/1e32e85c-d82a-4eba-98f0-bf4933eb4662" />
