### PR TITLE
feat: add thought tag and sync llama.rn

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -140,7 +140,7 @@ PODS:
   - hermes-engine (0.76.3):
     - hermes-engine/Pre-built (= 0.76.3)
   - hermes-engine/Pre-built (0.76.3)
-  - llama-rn (0.5.6-1):
+  - llama-rn (0.5.8):
     - React-Core
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
@@ -2264,7 +2264,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: ee5c2d2242816773fbf79e5b0563f5355ef1c315
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   hermes-engine: 0555a84ea495e8e3b4bde71b597cd87fbb382888
-  llama-rn: 7bd8afdcee95d4a0d50f53896869341d24b72b26
+  llama-rn: 57452365d8ea328ab8127f982b4619d6c587b5a8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 84578c8756030547307e4572ab1947de1685c599

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@flyerhq/react-native-link-preview": "^1.6.0",
     "@gorhom/bottom-sheet": "^5.0.6",
     "@hookform/resolvers": "^3.10.0",
-    "@pocketpalai/llama.rn": "^0.5.6-1",
+    "@pocketpalai/llama.rn": "^0.5.8",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",
     "@react-native-community/blur": "^4.4.1",

--- a/src/components/MarkdownView/MarkdownView.tsx
+++ b/src/components/MarkdownView/MarkdownView.tsx
@@ -48,6 +48,14 @@ export const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
           tagName: 'think',
           contentModel: HTMLContentModel.block,
         }),
+        thought: HTMLElementModel.fromCustomModel({
+          tagName: 'thought',
+          contentModel: HTMLContentModel.block,
+        }),
+        thinking: HTMLElementModel.fromCustomModel({
+          tagName: 'thinking',
+          contentModel: HTMLContentModel.block,
+        }),
       }),
       [],
     );
@@ -55,6 +63,8 @@ export const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
     const renderers = useMemo(
       () => ({
         think: props => ThinkRenderer(props, styles),
+        thought: props => ThinkRenderer(props, styles),
+        thinking: props => ThinkRenderer(props, styles),
       }),
       [styles],
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,10 +2188,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pocketpalai/llama.rn@^0.5.6-1":
-  version "0.5.6-1"
-  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.5.6-1.tgz#fce74f40c3d6063c90d34a51a1f459d249ab2e9f"
-  integrity sha512-mUNoWTVKrYnZ9M8RzfqcLQ1ReiEZP32dOJHRp0Dcu4F9L4DP46y6ZVjmusQPG/5+7do8E7g1njPtvdOhteRK7w==
+"@pocketpalai/llama.rn@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.5.8.tgz#7302b0fcfad6bdb88caccf36b42337513f8e96f8"
+  integrity sha512-Lgrz7GzceNdajlHID+zS9vl0TcRhuVzQG2t6weMrVd27rbsPwjutQa6K0dVV3EagvqRIkTrZsY2pBh8U+oH0ew==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## Description

This PR adds support for rendering <thought> tags used by reasoning models like EXAONE.

Additionally, it syncs llama.rn/llama.cpp to support RWKV-7 models.

Fixes #248 
Fixes #245 (but with this caveat: https://github.com/a-ghorbani/pocketpal-ai/issues/245#issuecomment-2755997684)

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [ ] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
