### PR TITLE
fix(iPad): add support for upside down orientation

### DIFF
--- a/ios/PocketPal/Info.plist
+++ b/ios/PocketPal/Info.plist
@@ -53,9 +53,16 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
## Description

Unlike iPhone apps, iPad apps are supposed to work with the device in any orientation including upside down. Previously, PocketPal AI was enforcing the phone-related restriction on upside down use on the iPad.

## Platform Affected

- [x] iOS
- [ ] Android

## Checklist

- [ ] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
