### PR TITLE
Fix(feedback): fix iOS TextInput flickering by using defaultValue prop

### DIFF
--- a/src/api/__tests__/feedback.test.ts
+++ b/src/api/__tests__/feedback.test.ts
@@ -1,0 +1,233 @@
+import axios from 'axios';
+import {Platform} from 'react-native';
+import DeviceInfo from 'react-native-device-info';
+import {submitFeedback} from '../feedback';
+import * as utils from '../../utils';
+import {urls} from '../../config';
+
+// Mock dependencies
+jest.mock('axios');
+jest.mock('react-native-device-info');
+jest.mock('../../utils', () => {
+  const originalModule = jest.requireActual('../../utils');
+  return {
+    ...originalModule,
+    checkConnectivity: jest.fn(),
+    getAppCheckToken: jest.fn(),
+    initializeAppCheck: jest.fn(),
+    NetworkError: class NetworkError extends Error {
+      constructor(message) {
+        super(message);
+        this.name = 'NetworkError';
+      }
+    },
+    AppCheckError: class AppCheckError extends Error {
+      constructor(message) {
+        super(message);
+        this.name = 'AppCheckError';
+      }
+    },
+    ServerError: class ServerError extends Error {
+      constructor(message) {
+        super(message);
+        this.name = 'ServerError';
+      }
+    },
+  };
+});
+jest.mock('../../store', () => ({
+  feedbackStore: {
+    feedbackId: 'mock-feedback-id',
+  },
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedUtils = utils as jest.Mocked<typeof utils>;
+const mockedDeviceInfo = DeviceInfo as jest.Mocked<typeof DeviceInfo>;
+
+describe('submitFeedback', () => {
+  const mockFeedbackData = {
+    useCase: 'Test use case',
+    featureRequests: 'Test feature request',
+    generalFeedback: 'Test feedback',
+    usageFrequency: 'daily',
+  };
+
+  const mockAppCheckToken = 'mock-app-check-token';
+  const mockResponse = {
+    data: {
+      message: 'Feedback submitted successfully',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mocks for success case
+    Platform.OS = 'ios';
+    mockedUtils.checkConnectivity.mockResolvedValue(true);
+    mockedUtils.getAppCheckToken.mockResolvedValue(mockAppCheckToken);
+    mockedDeviceInfo.getVersion.mockReturnValue('1.0.0');
+    mockedDeviceInfo.getBuildNumber.mockReturnValue('100');
+    mockedAxios.post.mockResolvedValue(mockResponse);
+    mockedAxios.isAxiosError.mockReturnValue(true);
+  });
+
+  it('should successfully submit feedback', async () => {
+    const result = await submitFeedback(mockFeedbackData);
+
+    // Verify connectivity check
+    expect(mockedUtils.checkConnectivity).toHaveBeenCalled();
+
+    // Verify AppCheck initialization and token retrieval
+    expect(mockedUtils.initializeAppCheck).toHaveBeenCalled();
+    expect(mockedUtils.getAppCheckToken).toHaveBeenCalled();
+
+    // Verify API call
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      urls.feedbackSubmit(),
+      {
+        ...mockFeedbackData,
+        appFeedbackId: 'mock-feedback-id',
+        appVersion: '1.0.0',
+        appBuild: '100',
+      },
+      {
+        headers: {
+          'X-Firebase-AppCheck': mockAppCheckToken,
+          'Content-Type': 'application/json',
+        },
+        timeout: 10000,
+      },
+    );
+
+    // Verify response
+    expect(result).toEqual({
+      message: 'Feedback submitted successfully',
+    });
+  });
+
+  it('should throw NetworkError when there is no internet connection', async () => {
+    mockedUtils.checkConnectivity.mockResolvedValue(false);
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.NetworkError,
+    );
+
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('should throw AppCheckError when AppCheck token is not available', async () => {
+    mockedUtils.getAppCheckToken.mockResolvedValue('');
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.AppCheckError,
+    );
+
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('should throw NetworkError on axios network error', async () => {
+    const error = {
+      isAxiosError: true,
+      response: undefined,
+    };
+    mockedAxios.post.mockRejectedValue(error);
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.NetworkError,
+    );
+  });
+
+  it('should throw AppCheckError on 401/403 responses', async () => {
+    const unauthorizedError = {
+      isAxiosError: true,
+      response: {
+        status: 401,
+        data: {},
+      },
+    };
+    mockedAxios.post.mockRejectedValue(unauthorizedError);
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.AppCheckError,
+    );
+
+    // Test 403 error
+    const forbiddenError = {
+      isAxiosError: true,
+      response: {
+        status: 403,
+        data: {},
+      },
+    };
+    mockedAxios.post.mockRejectedValue(forbiddenError);
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.AppCheckError,
+    );
+  });
+
+  it('should throw ServerError on 500+ responses', async () => {
+    const serverError = {
+      isAxiosError: true,
+      response: {
+        status: 500,
+        data: {
+          message: 'Internal Server Error',
+        },
+      },
+    };
+    mockedAxios.post.mockRejectedValue(serverError);
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.ServerError,
+    );
+  });
+
+  it('should throw ServerError with error message from server if available', async () => {
+    const serverError = {
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          message: 'Invalid feedback data',
+        },
+      },
+    };
+    mockedAxios.post.mockRejectedValue(serverError);
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.ServerError,
+    );
+  });
+
+  it('should handle AppCheck initialization errors', async () => {
+    mockedUtils.initializeAppCheck.mockImplementation(() => {
+      throw new Error('AppCheck init error');
+    });
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.AppCheckError,
+    );
+  });
+
+  it('should propagate unknown errors', async () => {
+    const unknownError = new Error('Unknown error');
+    mockedAxios.post.mockRejectedValue(unknownError);
+    mockedAxios.isAxiosError.mockReturnValue(false);
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrow(
+      'App verification failed. Feedback submission is only available for official builds from Apple App Store.',
+    );
+  });
+
+  it('should handle different platform messages', async () => {
+    Platform.OS = 'android';
+    mockedUtils.getAppCheckToken.mockResolvedValue('');
+
+    await expect(submitFeedback(mockFeedbackData)).rejects.toThrowError(
+      utils.AppCheckError,
+    );
+  });
+});

--- a/src/api/feedback.ts
+++ b/src/api/feedback.ts
@@ -19,7 +19,6 @@ type FeedbackData = {
   featureRequests: string;
   generalFeedback: string;
   usageFrequency: string;
-  email?: string;
   appFeedbackId: string;
 };
 

--- a/src/screens/AboutScreen/AboutScreen.tsx
+++ b/src/screens/AboutScreen/AboutScreen.tsx
@@ -50,7 +50,6 @@ export const AboutScreen: React.FC = () => {
   const [useCase, setUseCase] = useState('');
   const [featureRequests, setFeatureRequests] = useState('');
   const [generalFeedback, setGeneralFeedback] = useState('');
-  const [email, setEmail] = useState('');
   const [usageFrequency, setUsageFrequency] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -85,7 +84,6 @@ export const AboutScreen: React.FC = () => {
         featureRequests,
         generalFeedback,
         usageFrequency,
-        email: email || undefined,
       });
       Alert.alert('Success', l10n.feedback.success);
       setShowFeedback(false);
@@ -93,7 +91,6 @@ export const AboutScreen: React.FC = () => {
       setUseCase('');
       setFeatureRequests('');
       setGeneralFeedback('');
-      setEmail('');
       setUsageFrequency('');
     } catch (error) {
       const errorMessage =
@@ -184,11 +181,11 @@ export const AboutScreen: React.FC = () => {
           <View style={styles.field}>
             <Text style={styles.label}>{l10n.feedback.useCase.label}</Text>
             <TextInput
-              value={useCase}
+              defaultValue={useCase}
               onChangeText={setUseCase}
               placeholder={l10n.feedback.useCase.placeholder}
               multiline
-              numberOfLines={3}
+              numberOfLines={4}
             />
           </View>
 
@@ -197,11 +194,11 @@ export const AboutScreen: React.FC = () => {
               {l10n.feedback.featureRequests.label}
             </Text>
             <TextInput
-              value={featureRequests}
+              defaultValue={featureRequests}
               onChangeText={setFeatureRequests}
               placeholder={l10n.feedback.featureRequests.placeholder}
               multiline
-              numberOfLines={3}
+              numberOfLines={4}
             />
           </View>
 
@@ -210,11 +207,11 @@ export const AboutScreen: React.FC = () => {
               {l10n.feedback.generalFeedback.label}
             </Text>
             <TextInput
-              value={generalFeedback}
+              defaultValue={generalFeedback}
               onChangeText={setGeneralFeedback}
               placeholder={l10n.feedback.generalFeedback.placeholder}
               multiline
-              numberOfLines={3}
+              numberOfLines={4}
             />
           </View>
 
@@ -244,17 +241,6 @@ export const AboutScreen: React.FC = () => {
                 },
               ]}
               style={styles.segmentedButtons}
-            />
-          </View>
-
-          <View style={styles.field}>
-            <Text style={styles.label}>Email (optional)</Text>
-            <TextInput
-              value={email}
-              onChangeText={setEmail}
-              placeholder={l10n.feedback.email.placeholder}
-              keyboardType="email-address"
-              autoCapitalize="none"
             />
           </View>
         </Sheet.ScrollView>

--- a/src/screens/AboutScreen/__tests__/AboutScreen.test.tsx
+++ b/src/screens/AboutScreen/__tests__/AboutScreen.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import {Alert, Linking, Platform} from 'react-native';
+import {render, fireEvent, act} from '../../../../jest/test-utils';
+import {AboutScreen} from '../AboutScreen';
+import {submitFeedback} from '../../../api/feedback';
+import {l10n} from '../../../utils/l10n';
+
+// Mock DeviceInfo
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+  getBuildNumber: jest.fn().mockReturnValue('100'),
+}));
+
+// Mock Clipboard
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  setString: jest.fn(),
+}));
+
+// Mock Linking
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn().mockImplementation(() => Promise.resolve()),
+}));
+
+// Mock feedback API
+jest.mock('../../../api/feedback', () => ({
+  submitFeedback: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.spyOn(Alert, 'alert');
+
+describe('AboutScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const {getByText} = render(<AboutScreen />);
+
+    expect(getByText('PocketPal AI')).toBeTruthy();
+    expect(getByText('v1.0.0 (100)')).toBeTruthy();
+    expect(getByText(l10n.en.about.supportProject)).toBeTruthy();
+    expect(getByText(l10n.en.about.githubButton)).toBeTruthy();
+  });
+
+  it('copies version to clipboard when version button is pressed', () => {
+    const {getByText} = render(<AboutScreen />);
+
+    fireEvent.press(getByText('v1.0.0 (100)'));
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      l10n.en.about.versionCopiedTitle,
+      l10n.en.about.versionCopiedDescription,
+    );
+  });
+
+  it('opens GitHub URL when GitHub button is pressed', () => {
+    const {getByText} = render(<AboutScreen />);
+
+    fireEvent.press(getByText('Star on GitHub'));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      'https://github.com/a-ghorbani/pocketpal-ai',
+    );
+  });
+
+  it('opens Buy Me a Coffee URL when sponsor button is pressed on non-iOS platforms', () => {
+    Platform.OS = 'android';
+    const {getByText} = render(<AboutScreen />);
+
+    fireEvent.press(getByText(l10n.en.about.sponsorButton));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      'https://www.buymeacoffee.com/aghorbani',
+    );
+  });
+
+  it('does not show sponsor button on iOS', () => {
+    Platform.OS = 'ios';
+    const {queryByText} = render(<AboutScreen />);
+
+    expect(queryByText(l10n.en.about.sponsorButton)).toBeNull();
+  });
+
+  it('opens feedback form when share thoughts button is pressed', async () => {
+    const {getByText, findByText} = render(<AboutScreen />);
+
+    fireEvent.press(getByText(l10n.en.feedback.shareThoughtsButton));
+
+    expect(await findByText(l10n.en.feedback.useCase.label)).toBeTruthy();
+    expect(
+      await findByText(l10n.en.feedback.featureRequests.label),
+    ).toBeTruthy();
+    expect(
+      await findByText(l10n.en.feedback.generalFeedback.label),
+    ).toBeTruthy();
+    expect(
+      await findByText(l10n.en.feedback.usageFrequency.label),
+    ).toBeTruthy();
+  });
+
+  it('submits feedback successfully', async () => {
+    const {findByText, getByText, findByPlaceholderText} = render(
+      <AboutScreen />,
+    );
+
+    // Open feedback form
+    fireEvent.press(getByText(l10n.en.feedback.shareThoughtsButton));
+
+    const useCaseInput = await findByPlaceholderText(
+      l10n.en.feedback.useCase.placeholder,
+    );
+    fireEvent.changeText(useCaseInput, 'Test use case');
+
+    const featureRequestsInput = await findByPlaceholderText(
+      l10n.en.feedback.featureRequests.placeholder,
+    );
+    fireEvent.changeText(featureRequestsInput, 'Test feature request');
+
+    const generalFeedbackInput = await findByPlaceholderText(
+      l10n.en.feedback.generalFeedback.placeholder,
+    );
+    fireEvent.changeText(generalFeedbackInput, 'Test feedback');
+
+    const dailyButton = await findByText(
+      l10n.en.feedback.usageFrequency.options.daily,
+    );
+    fireEvent.press(dailyButton);
+
+    // Submit form
+    const submitButton = await findByText(l10n.en.feedback.submit);
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    expect(submitFeedback).toHaveBeenCalledWith({
+      useCase: 'Test use case',
+      featureRequests: 'Test feature request',
+      generalFeedback: 'Test feedback',
+      usageFrequency: 'daily',
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Success',
+      'Thank you for your feedback!',
+    );
+  });
+
+  it('shows validation error when submitting empty feedback', async () => {
+    const {getByText, findByText} = render(<AboutScreen />);
+
+    // Open feedback form
+    fireEvent.press(getByText(l10n.en.feedback.shareThoughtsButton));
+
+    // Submit empty form
+    const submitButton = await findByText(l10n.en.feedback.submit);
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      l10n.en.feedback.validation.required,
+    );
+    expect(submitFeedback).not.toHaveBeenCalled();
+  });
+
+  it('handles feedback submission error', async () => {
+    (submitFeedback as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
+
+    const {getByText, findByText, findByPlaceholderText} = render(
+      <AboutScreen />,
+    );
+
+    // Open feedback form
+    fireEvent.press(getByText(l10n.en.feedback.shareThoughtsButton));
+
+    // Fill out form
+    fireEvent.changeText(
+      await findByPlaceholderText(l10n.en.feedback.useCase.placeholder),
+      'Test use case',
+    );
+
+    // Submit form
+    const submitButton = await findByText(l10n.en.feedback.submit);
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith('Error', 'API Error');
+  });
+});


### PR DESCRIPTION
## Description

Changed the TextInput implementation to use `defaultValue` instead of `value` in the feedback component.
Removed the email from feedback.

Added a few additional tests.

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [ ] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
