### PR TITLE
Feat: add preset completion settings

### DIFF
--- a/src/components/ChatGenerationSettingsSheet/ChatGenerationSettingsSheet.tsx
+++ b/src/components/ChatGenerationSettingsSheet/ChatGenerationSettingsSheet.tsx
@@ -174,9 +174,10 @@ export const ChatGenerationSettingsSheet = ({
     onCloseSheet();
   };
 
-  const handleApplyToFutureSessions = () => {
+  const handleApplyToPreset = () => {
     if (session) {
       // Apply current session settings to preset settings
+      handleSaveSettings(); // First save the current UI settings to the session
       chatSessionStore.applySessionSettingsToGlobal();
       Alert.alert(
         'Success',
@@ -225,9 +226,7 @@ export const ChatGenerationSettingsSheet = ({
           />
           <View style={styles.rightButtons}>
             {!isEditingPresetSettings && (
-              <Button
-                mode="contained-tonal"
-                onPress={handleApplyToFutureSessions}>
+              <Button mode="contained-tonal" onPress={handleApplyToPreset}>
                 Save as Preset
               </Button>
             )}

--- a/src/components/ChatGenerationSettingsSheet/ChatGenerationSettingsSheet.tsx
+++ b/src/components/ChatGenerationSettingsSheet/ChatGenerationSettingsSheet.tsx
@@ -11,6 +11,66 @@ import {
 import {Alert, View} from 'react-native';
 import {Button} from 'react-native-paper';
 import {L10nContext} from '../../utils';
+import {ChevronDownIcon} from '../../assets/icons';
+import {Menu} from '../Menu';
+
+interface ResetButtonProps {
+  session: any;
+  resetMenuVisible: boolean;
+  setResetMenuVisible: (visible: boolean) => void;
+  handleResetToDefault: () => void;
+  handleResetToPreset: () => void;
+}
+
+const ChevronDownButtonIcon = ({color}: {color: string}) => (
+  <ChevronDownIcon width={16} height={16} stroke={color} />
+);
+
+// Reset button component - conditionally renders based on session
+const ResetButton = ({
+  session,
+  resetMenuVisible,
+  setResetMenuVisible,
+  handleResetToDefault,
+  handleResetToPreset,
+}: ResetButtonProps) => {
+  if (!session) {
+    // Simple button for preset settings
+    return (
+      <Button
+        mode="text"
+        onPress={handleResetToDefault}
+        style={styles.resetButton}>
+        Reset to System Defaults
+      </Button>
+    );
+  }
+
+  // Menu button for session settings
+  return (
+    <Menu
+      visible={resetMenuVisible}
+      onDismiss={() => setResetMenuVisible(false)}
+      anchor={
+        <View style={styles.resetWrapper}>
+          <Button
+            mode="text"
+            onPress={() => setResetMenuVisible(true)}
+            style={styles.resetButton}
+            contentStyle={styles.resetButtonContent}
+            icon={ChevronDownButtonIcon}>
+            Reset
+          </Button>
+        </View>
+      }>
+      <Menu.Item onPress={handleResetToPreset} label="Reset to Preset" />
+      <Menu.Item
+        onPress={handleResetToDefault}
+        label="Reset to System Defaults"
+      />
+    </Menu>
+  );
+};
 
 export const ChatGenerationSettingsSheet = ({
   isVisible,
@@ -26,6 +86,10 @@ export const ChatGenerationSettingsSheet = ({
   const [settings, setSettings] = useState<CompletionParams>(
     session?.completionSettings ?? chatSessionStore.newChatCompletionSettings,
   );
+
+  const [resetMenuVisible, setResetMenuVisible] = useState(false);
+
+  const isEditingPresetSettings = !session;
 
   useEffect(() => {
     setSettings(
@@ -110,19 +174,39 @@ export const ChatGenerationSettingsSheet = ({
     onCloseSheet();
   };
 
-  const handleResetSettings = () => {
-    setSettings(defaultCompletionSettings);
+  const handleApplyToFutureSessions = () => {
+    if (session) {
+      // Apply current session settings to preset settings
+      chatSessionStore.applySessionSettingsToGlobal();
+      Alert.alert(
+        'Success',
+        'These settings will be applied to all future sessions',
+        [{text: 'OK'}],
+      );
+    }
   };
 
-  const handleCancelSettings = () => {
-    onCloseSheet();
+  const handleResetToPreset = () => {
+    if (session) {
+      // For session-specific settings, reset to match Preset settings
+      setSettings({...chatSessionStore.newChatCompletionSettings});
+    }
+    setResetMenuVisible(false);
+  };
+
+  const handleResetToDefault = () => {
+    // Reset to system defaults
+    setSettings({...defaultCompletionSettings});
+    setResetMenuVisible(false);
   };
 
   const i10n = useContext(L10nContext);
 
   return (
     <Sheet
-      title={i10n.chatGenerationSettings}
+      title={
+        i10n.chatGenerationSettings + (session ? ' (Session)' : ' (Preset)')
+      }
       isVisible={isVisible}
       onClose={onCloseSheet}>
       <Sheet.ScrollView
@@ -131,17 +215,27 @@ export const ChatGenerationSettingsSheet = ({
         <CompletionSettings settings={settings} onChange={updateSettings} />
       </Sheet.ScrollView>
       <Sheet.Actions>
-        <View style={styles.secondaryButtons}>
-          <Button mode="text" onPress={handleResetSettings}>
-            {i10n.reset}
-          </Button>
-          <Button mode="text" onPress={handleCancelSettings}>
-            {i10n.cancel}
-          </Button>
+        <View style={styles.actionsContainer}>
+          <ResetButton
+            session={session}
+            resetMenuVisible={resetMenuVisible}
+            setResetMenuVisible={setResetMenuVisible}
+            handleResetToDefault={handleResetToDefault}
+            handleResetToPreset={handleResetToPreset}
+          />
+          <View style={styles.rightButtons}>
+            {!isEditingPresetSettings && (
+              <Button
+                mode="contained-tonal"
+                onPress={handleApplyToFutureSessions}>
+                Save as Preset
+              </Button>
+            )}
+            <Button mode="contained" onPress={handleSaveSettings}>
+              {session ? 'Save' : i10n.saveChanges}
+            </Button>
+          </View>
         </View>
-        <Button mode="contained" onPress={handleSaveSettings}>
-          {i10n.saveChanges}
-        </Button>
       </Sheet.Actions>
     </Sheet>
   );

--- a/src/components/ChatGenerationSettingsSheet/__tests__/ChatGenerationSettingsSheet.test.tsx
+++ b/src/components/ChatGenerationSettingsSheet/__tests__/ChatGenerationSettingsSheet.test.tsx
@@ -146,7 +146,7 @@ describe('ChatGenerationSettingsSheet', () => {
     );
 
     await act(async () => {
-      fireEvent.press(getByText('Save Changes'));
+      fireEvent.press(getByText('Save'));
     });
 
     expect(chatSessionStore.updateSessionCompletionSettings).toHaveBeenCalled();
@@ -182,26 +182,18 @@ describe('ChatGenerationSettingsSheet', () => {
       fireEvent.press(getByText('Reset'));
     });
 
+    await act(async () => {
+      fireEvent.press(getByText('Reset to System Defaults'));
+    });
+
     // After reset, saving should use default settings
     await act(async () => {
-      fireEvent.press(getByText('Save Changes'));
+      fireEvent.press(getByText('Save'));
     });
 
     expect(
       chatSessionStore.updateSessionCompletionSettings,
     ).toHaveBeenCalledWith(defaultCompletionSettings);
-  });
-
-  it('handles cancel correctly', async () => {
-    const {getByText} = render(
-      <ChatGenerationSettingsSheet {...defaultProps} />,
-    );
-
-    await act(async () => {
-      fireEvent.press(getByText('Cancel'));
-    });
-
-    expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
   it('validates numeric values before saving', async () => {
@@ -222,7 +214,7 @@ describe('ChatGenerationSettingsSheet', () => {
     });
 
     await act(async () => {
-      fireEvent.press(getByText('Save Changes'));
+      fireEvent.press(getByText('Save'));
     });
 
     // Should show alert for invalid value

--- a/src/components/ChatGenerationSettingsSheet/styles.ts
+++ b/src/components/ChatGenerationSettingsSheet/styles.ts
@@ -6,6 +6,27 @@ export const styles = StyleSheet.create({
   },
   secondaryButtons: {
     flexDirection: 'row',
-    gap: 10,
+    gap: 8,
+  },
+  actionsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+  },
+  resetWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  resetButton: {
+    marginRight: 0,
+  },
+  resetButtonContent: {
+    flexDirection: 'row-reverse',
+  },
+  rightButtons: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
   },
 });

--- a/src/screens/BenchmarkScreen/BenchResultCard/__tests__/BenchResultCard.test.tsx
+++ b/src/screens/BenchmarkScreen/BenchResultCard/__tests__/BenchResultCard.test.tsx
@@ -1,53 +1,378 @@
 import React from 'react';
-
-import {render} from '../../../../../jest/test-utils';
-import {mockResult} from '../../../../../jest/fixtures/benchmark';
-
+import {Linking, Alert} from 'react-native';
+import {fireEvent, render, act, waitFor} from '../../../../../jest/test-utils';
 import {BenchResultCard} from '../BenchResultCard';
+import {BenchmarkResult, CacheType} from '../../../../utils/types';
+import {
+  NetworkError,
+  AppCheckError,
+  ServerError,
+} from '../../../../utils/errors';
 
-import {formatNumber} from '../../../../utils';
+// Mock Linking
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn().mockImplementation(() => Promise.resolve()),
+}));
+
+// Mock Alert
+jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
 
 describe('BenchResultCard', () => {
-  it('renders benchmark results correctly', () => {
-    const {getByText} = render(
-      <BenchResultCard
-        result={mockResult}
-        onDelete={() => {}}
-        onShare={() => Promise.resolve()}
-      />,
-    );
+  const mockResult: BenchmarkResult = {
+    config: {
+      pp: 1,
+      tg: 1,
+      pl: 512,
+      nr: 3,
+      label: 'Default',
+    },
+    modelDesc: 'Test Model',
+    modelSize: 1000 * 1000 * 500, // 500 MB
+    modelNParams: 7000000000, // 7B
+    ppAvg: 20.5,
+    ppStd: 1.2,
+    tgAvg: 30.5,
+    tgStd: 2.1,
+    timestamp: new Date().toISOString(),
+    modelId: 'test-model-id',
+    modelName: 'Test Model',
+    filename: 'test-model.gguf',
+    uuid: 'test-uuid',
+    oid: 'model-oid', // This is needed for sharing
+    initSettings: {
+      n_context: 2048,
+      n_batch: 512,
+      n_ubatch: 128,
+      n_threads: 4,
+      n_gpu_layers: 20,
+      flash_attn: true,
+      cache_type_k: CacheType.F16,
+      cache_type_v: CacheType.F16,
+    },
+    wallTimeMs: 5000, // 5 seconds
+    peakMemoryUsage: {
+      total: 8 * 1000 * 1000 * 1000, // 8 GB
+      used: 4 * 1000 * 1000 * 1000, // 4 GB
+      percentage: 50,
+    },
+  };
 
-    expect(getByText(mockResult.modelName)).toBeDefined();
-    expect(getByText(`${mockResult.ppAvg.toFixed(2)} t/s`)).toBeDefined();
-    expect(getByText(`${mockResult.tgAvg.toFixed(2)} t/s`)).toBeDefined();
+  const mockSubmittedResult = {
+    ...mockResult,
+    submitted: true,
+  };
+
+  const mockLocalModelResult = {
+    ...mockResult,
+    oid: undefined, // Local models don't have an OID
+  };
+
+  const mockOnDelete = jest.fn();
+  const mockOnShare = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnShare.mockResolvedValue(undefined);
   });
 
-  it('shows standard deviations', () => {
+  it('renders benchmark result data correctly', () => {
     const {getByText} = render(
       <BenchResultCard
         result={mockResult}
-        onDelete={() => {}}
-        onShare={() => Promise.resolve()}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
       />,
     );
 
-    expect(getByText(`±${mockResult.ppStd.toFixed(2)}`)).toBeDefined();
-    expect(getByText(`±${mockResult.tgStd.toFixed(2)}`)).toBeDefined();
+    // Model info
+    expect(getByText('Test Model')).toBeTruthy();
+    expect(getByText(/500 MB/)).toBeTruthy();
+    expect(getByText(/7B params/)).toBeTruthy();
+
+    // Benchmark results
+    expect(getByText('20.50 t/s')).toBeTruthy();
+    expect(getByText('30.50 t/s')).toBeTruthy();
+    expect(getByText('±1.20')).toBeTruthy();
+    expect(getByText('±2.10')).toBeTruthy();
+
+    // Configuration
+    expect(getByText(/PP: 1 • TG: 1 • PL: 512 • Rep: 3/)).toBeTruthy();
+
+    // Memory & time
+    expect(getByText('5s')).toBeTruthy();
+    expect(getByText('50.0%')).toBeTruthy();
+    expect(getByText(/4 GB \/ 8 GB/)).toBeTruthy();
   });
 
-  it('displays model parameters and size', () => {
-    const {getByText} = render(
+  it('formats different durations correctly', () => {
+    // Test with milliseconds
+    const shortResult = {...mockResult, wallTimeMs: 500};
+    const {getByText, rerender} = render(
+      <BenchResultCard
+        result={shortResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+    expect(getByText('500ms')).toBeTruthy();
+
+    // Test with seconds
+    const secondsResult = {...mockResult, wallTimeMs: 3500};
+    rerender(
+      <BenchResultCard
+        result={secondsResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+    expect(getByText('3s')).toBeTruthy();
+
+    // Test with minutes and seconds
+    const minutesResult = {...mockResult, wallTimeMs: 125000}; // 2m 5s
+    rerender(
+      <BenchResultCard
+        result={minutesResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+    expect(getByText('2m 5s')).toBeTruthy();
+  });
+
+  it('handles delete button press', () => {
+    const {getByTestId} = render(
       <BenchResultCard
         result={mockResult}
-        onDelete={() => {}}
-        onShare={() => Promise.resolve()}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
       />,
     );
 
-    expect(
-      getByText(formatNumber(mockResult.modelNParams, 2, true, false), {
-        exact: false,
-      }),
-    ).toBeDefined();
+    const deleteButton = getByTestId('delete-result-button');
+    fireEvent.press(deleteButton);
+
+    expect(mockOnDelete).toHaveBeenCalledWith(mockResult.timestamp);
+  });
+
+  it('shows submitted state correctly', () => {
+    const {getByText} = render(
+      <BenchResultCard
+        result={mockSubmittedResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    expect(getByText(/✓ Shared to/)).toBeTruthy();
+    expect(getByText(/AI Phone Leaderboard ↗/)).toBeTruthy();
+  });
+
+  it('disables sharing for local models', () => {
+    const {getByText} = render(
+      <BenchResultCard
+        result={mockLocalModelResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    expect(getByText('Cannot share')).toBeTruthy();
+  });
+
+  it('opens leaderboard when link is clicked', () => {
+    const {getByText} = render(
+      <BenchResultCard
+        result={mockResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    const leaderboardLink = getByText('View leaderboard ↗');
+    fireEvent.press(leaderboardLink);
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      'https://huggingface.co/spaces/a-ghorbani/ai-phone-leaderboard',
+    );
+  });
+
+  it('submits benchmark data when submit button is pressed', async () => {
+    const {getByTestId} = render(
+      <BenchResultCard
+        result={mockResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    const submitButton = getByTestId('submit-benchmark-button');
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    expect(mockOnShare).toHaveBeenCalledWith(mockResult);
+  });
+
+  it('handles network errors', async () => {
+    mockOnShare.mockRejectedValueOnce(
+      new NetworkError('No internet connection. Please connect and try again.'),
+    );
+
+    const {getByTestId, getByText} = render(
+      <BenchResultCard
+        result={mockResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    const submitButton = getByTestId('submit-benchmark-button');
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(getByText(/📶.*No internet connection/)).toBeTruthy();
+      expect(getByText('Check connection & retry')).toBeTruthy();
+    });
+  });
+
+  it('handles app check errors', async () => {
+    mockOnShare.mockRejectedValueOnce(
+      new AppCheckError('App verification failed.'),
+    );
+
+    const {getByTestId, getByText} = render(
+      <BenchResultCard
+        result={mockResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    const submitButton = getByTestId('submit-benchmark-button');
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(getByText(/🔒.*App verification failed/)).toBeTruthy();
+      expect(getByText('Retry submission')).toBeTruthy();
+    });
+  });
+
+  it('handles server errors', async () => {
+    mockOnShare.mockRejectedValueOnce(
+      new ServerError('Our servers are experiencing issues.'),
+    );
+
+    const {getByTestId, getByText} = render(
+      <BenchResultCard
+        result={mockResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    const submitButton = getByTestId('submit-benchmark-button');
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(getByText(/🖥️.*Our servers are experiencing issues/)).toBeTruthy();
+      expect(getByText('Try again later')).toBeTruthy();
+    });
+  });
+
+  it('handles unknown errors', async () => {
+    mockOnShare.mockRejectedValueOnce(new Error('Unknown error occurred'));
+
+    const {getByTestId, getByText} = render(
+      <BenchResultCard
+        result={mockResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    const submitButton = getByTestId('submit-benchmark-button');
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(getByText(/❌.*Unknown error occurred/)).toBeTruthy();
+      expect(getByText('Retry')).toBeTruthy();
+    });
+  });
+
+  it('allows retrying after a network error', async () => {
+    mockOnShare.mockRejectedValueOnce(new NetworkError('Network error'));
+
+    const {getByTestId, getByText} = render(
+      <BenchResultCard
+        result={mockResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    // First attempt - triggers error
+    const submitButton = getByTestId('submit-benchmark-button');
+    await act(async () => {
+      fireEvent.press(submitButton);
+    });
+
+    // Clear the mock so the retry will succeed
+    mockOnShare.mockClear();
+    mockOnShare.mockResolvedValueOnce(undefined);
+
+    // Retry
+    await waitFor(() => {
+      const retryButton = getByText('Check connection & retry');
+      fireEvent.press(retryButton);
+    });
+
+    expect(mockOnShare).toHaveBeenCalledWith(mockResult);
+  });
+
+  it('opens leaderboard when link is clicked on submitted results', () => {
+    const {getByText} = render(
+      <BenchResultCard
+        result={mockSubmittedResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    const leaderboardText = getByText(/AI Phone Leaderboard ↗/);
+    fireEvent.press(leaderboardText);
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      'https://huggingface.co/spaces/a-ghorbani/ai-phone-leaderboard',
+    );
+  });
+
+  it('renders without initSettings or peakMemoryUsage', () => {
+    const minimalResult = {
+      ...mockResult,
+      initSettings: undefined,
+      peakMemoryUsage: undefined,
+      wallTimeMs: undefined,
+    };
+
+    const {queryByText} = render(
+      <BenchResultCard
+        result={minimalResult}
+        onDelete={mockOnDelete}
+        onShare={mockOnShare}
+      />,
+    );
+
+    // These should not be in the DOM
+    expect(queryByText('Model Settings')).toBeNull();
+    expect(queryByText('Peak Memory')).toBeNull();
+    expect(queryByText('Total Time')).toBeNull();
   });
 });

--- a/src/screens/BenchmarkScreen/DeviceInfoCard/__tests__/DeviceInfoCard.test.tsx
+++ b/src/screens/BenchmarkScreen/DeviceInfoCard/__tests__/DeviceInfoCard.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {Platform} from 'react-native';
+import {fireEvent, render, waitFor} from '../../../../../jest/test-utils';
+import {DeviceInfoCard} from '../DeviceInfoCard';
+
+// Mock react-native-device-info
+jest.mock('react-native-device-info', () => ({
+  getModel: jest.fn().mockReturnValue('iPhone 13'),
+  getBrand: jest.fn().mockReturnValue('Apple'),
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+  getBuildNumber: jest.fn().mockReturnValue('100'),
+  supportedAbis: jest.fn().mockResolvedValue(['arm64']),
+  isEmulator: jest.fn().mockResolvedValue(false),
+  getDevice: jest.fn().mockResolvedValue('iPhone14,2'),
+  getDeviceId: jest.fn().mockResolvedValue('device-id-123'),
+  getTotalMemory: jest.fn().mockResolvedValue(6 * 1024 * 1024 * 1024), // 6GB
+}));
+
+describe('DeviceInfoCard', () => {
+  const mockOnDeviceInfo = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Platform.OS = 'ios';
+  });
+
+  it('renders basic device information correctly', async () => {
+    const {getByText, getByTestId, debug} = render(
+      <DeviceInfoCard onDeviceInfo={mockOnDeviceInfo} />,
+    );
+
+    debug();
+
+    // Wait for the device info to load
+    await waitFor(() => {
+      expect(getByText('Device Information')).toBeTruthy();
+      expect(getByText(/iPhone 13/)).toBeTruthy();
+    });
+
+    // Check that card exists
+    expect(getByTestId('device-info-card')).toBeTruthy();
+  });
+
+  it('can be expanded and collapsed', async () => {
+    const {getByText, queryByText} = render(
+      <DeviceInfoCard onDeviceInfo={mockOnDeviceInfo} />,
+    );
+
+    // Wait for the device info to load
+    await waitFor(() => {
+      expect(getByText('Device Information')).toBeTruthy();
+    });
+
+    // Initially, detailed info should not be visible
+    expect(queryByText('Basic Info')).toBeNull();
+
+    // Expand the card
+    fireEvent.press(getByText('Device Information'));
+
+    // Now detailed info should be visible
+    expect(getByText('Basic Info')).toBeTruthy();
+    expect(getByText('Architecture')).toBeTruthy();
+    expect(getByText('Total Memory')).toBeTruthy();
+    expect(getByText('Device ID')).toBeTruthy();
+    expect(getByText('CPU Details')).toBeTruthy();
+
+    // Collapse the card
+    fireEvent.press(getByText('Device Information'));
+
+    // Detailed info should be hidden again
+    expect(queryByText('Basic Info')).toBeNull();
+  });
+
+  it('calls onDeviceInfo with device information when loaded', async () => {
+    render(<DeviceInfoCard onDeviceInfo={mockOnDeviceInfo} />);
+
+    // Wait for device info to be loaded and callback to be called
+    await waitFor(() => {
+      expect(mockOnDeviceInfo).toHaveBeenCalled();
+      const deviceInfo = mockOnDeviceInfo.mock.calls[0][0];
+
+      // Check the passed deviceInfo object
+      expect(deviceInfo.model).toBe('iPhone 13');
+      expect(deviceInfo.brand).toBe('Apple');
+      expect(deviceInfo.systemName).toBe('iOS');
+      expect(deviceInfo.cpuArch).toEqual(['arm64']);
+      expect(deviceInfo.totalMemory).toBe(6 * 1024 * 1024 * 1024);
+    });
+  });
+
+  it('allows specifying a custom testId', async () => {
+    const {getByTestId} = render(
+      <DeviceInfoCard
+        onDeviceInfo={mockOnDeviceInfo}
+        testId="custom-device-info"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('custom-device-info')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds support for user-defined presets in chat completion settings.

- Presets are used as defaults for all new chats.

Also updates the UI to clearly distinguish between session and preset settings, and includes buttons to save, reset to preset, or reset to system defaults. 

Fixes #229 

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
