### PR TITLE
fix(ci/ios): use macos-15 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,29 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
+      - name: Create dummy google-services.json for CI
+        run: |
+          cat > android/app/google-services.json << 'EOL'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "dummy-project-for-ci",
+              "storage_bucket": "dummy-project-for-ci.appspot.com"
+            },
+            "client": [{
+              "client_info": {
+                "mobilesdk_app_id": "1:000000000000:android:0000000000000000",
+                "android_client_info": {
+                  "package_name": "com.pocketpalai"
+                }
+              },
+              "api_key": [{
+                "current_key": "dummy-api-key-for-ci-builds"
+              }]
+            }]
+          }
+          EOL
+
       - name: Build Android
         run: yarn build:android # TODO: change to build:android:release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
+      
+      - name: Install CocoaPods dependencies
+        run: |
+          cd ios
+          pod install
+          cd ..
 
       - name: Build iOS
         run: yarn ios:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       # Step 2: Set up Node.js environment
       - name: Set up Node.js
@@ -68,8 +66,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install Yarn
         run: npm install -g yarn
@@ -107,8 +103,6 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install Yarn
         run: npm install -g yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-
-        
+
       # Step 2: Set up Node.js environment
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
-      
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -95,7 +95,7 @@ jobs:
 
   # Job for iOS build
   build-ios:
-    runs-on: macos-latest  # macOS runner required for iOS builds
+    runs-on: macos-15  # macOS 15 with Xcode 16
     needs: build-and-test
     steps:
       - name: Check out code
@@ -108,7 +108,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-    
+            ${{ runner.os }}-node-
 
       - name: Install Yarn
         run: npm install -g yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
 
   # Job 2: iOS Build and Upload (runs on macOS)
   build_ios:
-    runs-on: macos-latest
+    runs-on: macos-15 # macOS 15 with Xcode 16
     needs: build_android
 
     steps:


### PR DESCRIPTION
## Description

Fixes:
```
 [Application Loader Error Output]: ERROR: [ContentDelivery.Uploader] Validation failed (409) SDK version issue. This app was built with the iOS 17.5 SDK. All iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution. (ID: 18ce17ec-6370-48c1-81c5-ef6aafe96841)
```

## Platform Affected

- [ ] iOS
- [ ] Android

## Checklist

- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
