### PR TITLE
fix(android): prevent screen fragments restoration on app resume

### DIFF
--- a/android/app/src/main/java/com/pocketpalai/MainActivity.kt
+++ b/android/app/src/main/java/com/pocketpalai/MainActivity.kt
@@ -4,7 +4,7 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
-import androidx.activity.enableEdgeToEdge 
+import androidx.activity.enableEdgeToEdge
 import android.os.Bundle  // Required for onCreate parameter
 
 
@@ -25,6 +25,10 @@ class MainActivity : ReactActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
       enableEdgeToEdge()
-      super.onCreate(savedInstanceState)
+      // Pass null to prevent react-native-screens fragments from being restored
+      // This fixes the "Screen fragments should never be restored" crash
+      // See: https://github.com/software-mansion/react-native-screens/issues/17
+      // and https://github.com/software-mansion/react-native-screens?tab=readme-ov-file#android
+      super.onCreate(null)
   }
 }


### PR DESCRIPTION
## Description

The app was crashing on Android when being restored from background with the following error:
```java
Caused by java.lang.IllegalStateException: Screen fragments should never be restored. Follow instructions from https://github.com/software-mansion/react-native-screens/issues/17
```

This is a known issue with `react-native-screens` where Android attempts to restore screen fragments when the app is brought back from background, which is not supported by the library.

References
[react-native-screens issue #17](https://github.com/software-mansion/react-native-screens/issues/17)

## Platform Affected

- [ ] iOS
- [x] Android

## Checklist

- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
  - [x] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
