### PR TITLE
feat: don't render the ThinkingBubble if content is empty

### DIFF
--- a/src/components/MarkdownView/MarkdownView.tsx
+++ b/src/components/MarkdownView/MarkdownView.tsx
@@ -26,7 +26,20 @@ interface MarkdownViewProps {
   selectable?: boolean;
 }
 
+// Helper function to check if content is empty
+const isEmptyContent = (content: string): boolean => {
+  console.log('isEmptyContent: ', content);
+  return !content || content.trim() === '';
+};
+
 const ThinkingRenderer = ({TDefaultRenderer, ...props}: any) => {
+  // Check if the content is empty
+  const content = props.tnode?.domNode?.children?.[0]?.data || '';
+  // If content is empty, don't render the ThinkingBubble
+  if (isEmptyContent(content)) {
+    return null;
+  }
+
   return (
     <ThinkingBubble>
       <TDefaultRenderer {...props} />


### PR DESCRIPTION
## Description

Qwen3 models have a /no_think switch that turns off thinking mode but still outputs an empty <think> tag, resulting in the rendering of an empty thinking bubble in the chat. This PR adds a feature to prevent rendering the ThinkingBubble if its content is empty.

Fixes #297

## Platform Affected

- [ ] iOS
- [ ] Android

## Checklist

- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
