### PR TITLE
chore: remove the extra ja: '日本語 (JA)',

### DIFF
--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -34,7 +34,7 @@ const languageNames: Record<AvailableLanguage, string> = {
   en: 'English (EN)',
   //es: 'Español (ES)',
   //de: 'Deutsch (DE)',
-  //ja: '日本語 (JA)',
+  ja: '日本語 (JA)',
   //ko: '한국어 (KO)',
   //pl: 'Polski (PL)',
   //pt: 'Português (PT)',
@@ -42,7 +42,6 @@ const languageNames: Record<AvailableLanguage, string> = {
   //tr: 'Türkçe (TR)',
   //uk: 'Українська (UK)',
   //ca: 'Català (CA)',
-  ja: '日本語 (JA)',
   zh: '中文 (ZH)',
 };
 


### PR DESCRIPTION
## Description

Remove the extra `ja: '日本語 (JA)',`

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
