### PR TITLE
fix(android): prevent backdrop from blocking interaction on chat screen

### DIFF
--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -10,6 +10,7 @@ import {
   Image,
 } from 'react-native';
 import {launchCamera, launchImageLibrary} from 'react-native-image-picker';
+import {useCameraPermission} from 'react-native-vision-camera';
 
 import Color from 'tinycolor2';
 import {observer} from 'mobx-react';
@@ -110,6 +111,9 @@ export const ChatInput = observer(
     const activePalId = chatSessionStore.activePalId;
     const activePal = palStore.pals.find(pal => pal.id === activePalId);
 
+    // Camera permission hook from react-native-vision-camera
+    const {hasPermission, requestPermission} = useCameraPermission();
+
     const hasActiveModel = !!modelStore.activeModelId;
 
     // Use `defaultValue` if provided
@@ -190,9 +194,23 @@ export const ChatInput = observer(
       setShowImageUploadMenu(true);
     };
 
-    // Handle taking a photo with the camera
+    // Need to figure this out:
+    // Handle taking a photo with the camera using react-native-image-picker
+    // but with permission checking from react-native-vision-camera
     const handleTakePhoto = async () => {
       try {
+        if (!hasPermission) {
+          const permissionResult = await requestPermission();
+          if (!permissionResult) {
+            Alert.alert(
+              l10n.camera.permissionTitle,
+              l10n.camera.permissionMessage,
+            );
+            setShowImageUploadMenu(false);
+            return;
+          }
+        }
+
         // Disable auto-release during camera operation
         // this is only needed on Android.
         modelStore.disableAutoRelease('camera-photo');

--- a/src/components/ChatPalModelPickerSheet/ChatPalModelPickerSheet.tsx
+++ b/src/components/ChatPalModelPickerSheet/ChatPalModelPickerSheet.tsx
@@ -311,7 +311,7 @@ export const ChatPalModelPickerSheet = observer(
         enablePanDownToClose
         snapPoints={snapPoints} // Dynamic sizing is not working properly in all situations, like keyboard open/close android/ios ...
         enableDynamicSizing={false}
-        backdropComponent={CustomBackdrop}
+        backdropComponent={isVisible ? CustomBackdrop : null} // on android we need this check to ensure it doenst' block interaction
         backgroundStyle={{
           backgroundColor: theme.colors.background,
         }}


### PR DESCRIPTION
## Description

Ensures CustomBackdrop is only rendered when visible, avoiding blocked touches on Android. 
This was affecting the ChatPalModelPickerSheet on the chat screen.

## Platform Affected

- [ ] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
