### PR TITLE
fix: add missing l10n for chat menu

### DIFF
--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -408,6 +408,13 @@ export const ChatView = observer(
       setSelectedMessage(null);
     }, []);
 
+    const {
+      copy: copyLabel,
+      regenerate: regenerateLabel,
+      regenerateWith: regenerateWithLabel,
+      edit: editLabel,
+    } = l10n.components.chatView.menuItems;
+
     const menuItems = React.useMemo((): MenuItem[] => {
       if (!selectedMessage || selectedMessage.type !== 'text') {
         return [];
@@ -419,7 +426,7 @@ export const ChatView = observer(
 
       const baseItems: MenuItem[] = [
         {
-          label: l10n.components.chatView.menuItems.copy,
+          label: copyLabel,
           onPress: () => {
             handleCopy(selectedMessage);
             handleMenuDismiss();
@@ -431,7 +438,7 @@ export const ChatView = observer(
 
       if (!isAuthor) {
         baseItems.push({
-          label: l10n.components.chatView.menuItems.regenerate,
+          label: regenerateLabel,
           onPress: () => {
             handleTryAgain(selectedMessage);
             handleMenuDismiss();
@@ -441,7 +448,7 @@ export const ChatView = observer(
         });
 
         baseItems.push({
-          label: l10n.components.chatView.menuItems.regenerateWith,
+          label: regenerateWithLabel,
           icon: () => <GridIcon stroke={theme.colors.primary} />,
           disabled: false,
           submenu: models.map(model => ({
@@ -457,7 +464,7 @@ export const ChatView = observer(
 
       if (isAuthor) {
         baseItems.push({
-          label: l10n.components.chatView.menuItems.edit,
+          label: editLabel,
           onPress: () => {
             handleEdit(selectedMessage);
             handleMenuDismiss();
@@ -478,6 +485,10 @@ export const ChatView = observer(
       handleMenuDismiss,
       size.width,
       theme.colors.primary,
+      copyLabel,
+      regenerateLabel,
+      regenerateWithLabel,
+      editLabel,
     ]);
 
     const renderMenuItem = React.useCallback(

--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -37,6 +37,7 @@ import {chatSessionStore, modelStore, palStore} from '../../store';
 
 import {MessageType, User} from '../../utils/types';
 import {calculateChatMessages, unwrap, UserContext} from '../../utils';
+import {L10nContext} from '../../utils';
 import {PalType} from '../PalsSheets/types';
 
 import {
@@ -175,6 +176,7 @@ export const ChatView = observer(
     usePreviewData = true,
     user,
   }: ChatProps) => {
+    const l10n = React.useContext(L10nContext);
     const theme = useTheme();
     const styles = createStyles({theme});
 
@@ -417,7 +419,7 @@ export const ChatView = observer(
 
       const baseItems: MenuItem[] = [
         {
-          label: 'Copy',
+          label: l10n.components.chatView.menuItems.copy,
           onPress: () => {
             handleCopy(selectedMessage);
             handleMenuDismiss();
@@ -429,7 +431,7 @@ export const ChatView = observer(
 
       if (!isAuthor) {
         baseItems.push({
-          label: 'Regenerate',
+          label: l10n.components.chatView.menuItems.regenerate,
           onPress: () => {
             handleTryAgain(selectedMessage);
             handleMenuDismiss();
@@ -439,7 +441,7 @@ export const ChatView = observer(
         });
 
         baseItems.push({
-          label: 'Regenerate with',
+          label: l10n.components.chatView.menuItems.regenerateWith,
           icon: () => <GridIcon stroke={theme.colors.primary} />,
           disabled: false,
           submenu: models.map(model => ({
@@ -455,7 +457,7 @@ export const ChatView = observer(
 
       if (isAuthor) {
         baseItems.push({
-          label: 'Edit',
+          label: l10n.components.chatView.menuItems.edit,
           onPress: () => {
             handleEdit(selectedMessage);
             handleMenuDismiss();

--- a/src/utils/l10n.ts
+++ b/src/utils/l10n.ts
@@ -754,6 +754,14 @@ export const l10n = {
         },
         byteSizes: ['Bytes', 'KB', 'MB', 'GB'],
       },
+      chatView: {
+        menuItems: {
+          copy: 'Copy',
+          regenerate: 'Regenerate',
+          regenerateWith: 'Regenerate with',
+          edit: 'Edit',
+        },
+      },
     },
     palsScreen: {
       systemPrompt: 'System Prompt',
@@ -1762,6 +1770,14 @@ export const l10n = {
         },
         byteSizes: ['B', 'KB', 'MB', 'GB'],
       },
+      chatView: {
+        menuItems: {
+          copy: 'コピー',
+          regenerate: '再生成',
+          regenerateWith: '再生成（モデル選択）',
+          edit: '編集',
+        },
+      },
     },
     palsScreen: {
       systemPrompt: 'システムプロンプト',
@@ -2719,6 +2735,14 @@ export const l10n = {
           usage: '使用率: ',
         },
         byteSizes: ['字节', 'KB', 'MB', 'GB'],
+      },
+      chatView: {
+        menuItems: {
+          copy: '复制',
+          regenerate: '重新生成',
+          regenerateWith: '重新生成（选择模型）',
+          edit: '编辑',
+        },
       },
     },
     palsScreen: {


### PR DESCRIPTION
## Description
Fixes #353 
the Japanese text is translated using an LLM

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
