### PR TITLE
feat: upgrade llama.rn (hence llama.cpp) to support gemma 3n

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -140,7 +140,7 @@ PODS:
   - hermes-engine (0.76.3):
     - hermes-engine/Pre-built (= 0.76.3)
   - hermes-engine/Pre-built (0.76.3)
-  - llama-rn (0.6.0-rc.7):
+  - llama-rn (0.6.0-rc.8):
     - React-Core
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
@@ -2387,7 +2387,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: ee5c2d2242816773fbf79e5b0563f5355ef1c315
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   hermes-engine: 77f19b2923ed39b21649b7551471674e3ace7a0a
-  llama-rn: cfa35c898700dbfcbca7c4256e2fb6ea2207b6f7
+  llama-rn: c6f350d100e6b079194a09ee07f93857f16a4465
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: aac5a2e8a7b6b8108945e58a66d08f78b800a1ea

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@gorhom/bottom-sheet": "^5.0.6",
     "@hookform/resolvers": "^3.10.0",
     "@nozbe/watermelondb": "^0.28.0",
-    "@pocketpalai/llama.rn": "^0.6.0-rc.7",
+    "@pocketpalai/llama.rn": "^0.6.0-rc.8",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",
     "@react-native-community/blur": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,10 +2114,10 @@
     rxjs "^7.8.1"
     sql-escape-string "^1.1.0"
 
-"@pocketpalai/llama.rn@^0.6.0-rc.7":
-  version "0.6.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.6.0-rc.7.tgz#b48a366da0b568212673d24b36f63d191bc9a4db"
-  integrity sha512-k+oXfIxwZzv23Ty0vroc7wbF7UKi8MkbcyfUhb6rIiSv7U37SiwJYbnK5/OLomkMoRVzwyNRA1rjPufkb6rI+w==
+"@pocketpalai/llama.rn@^0.6.0-rc.8":
+  version "0.6.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@pocketpalai/llama.rn/-/llama.rn-0.6.0-rc.8.tgz#6ceb5bada24de5b9d1815c60d1115e617fb4e887"
+  integrity sha512-z1Gi6XTVS2kXDjNDyHdfzFeDXa6D5TwbqD4Xxe8PhZnlbXYa/5mYpj0AXSGjsuCy5Se/KERWgMbFaNqsw+Zr1g==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## Description

Upgrades llama.rn => syncs llama.cpp to support gemma 3n. 

## Platform Affected

- [ ] iOS
- [ ] Android

## Checklist

- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
