### PR TITLE
feat: add use jinja param to use and set it to true by default

### DIFF
--- a/__mocks__/utils/completionSettingsVersions.js
+++ b/__mocks__/utils/completionSettingsVersions.js
@@ -1,6 +1,6 @@
 // Mock for completionSettingsVersions.ts
 
-export const CURRENT_COMPLETION_SETTINGS_VERSION = 1;
+export const CURRENT_COMPLETION_SETTINGS_VERSION = 2;
 
 export const defaultCompletionParams = {
   // App-specific properties
@@ -27,6 +27,7 @@ export const defaultCompletionParams = {
   seed: -1,
   n_probs: 0,
   stop: ['</s>'],
+  jinja: true,
 };
 
 export function migrateCompletionSettings(settings) {
@@ -44,6 +45,12 @@ export function migrateCompletionSettings(settings) {
     migratedSettings.include_thinking_in_context =
       defaultCompletionParams.include_thinking_in_context;
     migratedSettings.version = 1;
+  }
+
+  if (migratedSettings.version < 2) {
+    // Migration to version 2: Add jinja parameter
+    migratedSettings.jinja = defaultCompletionParams.jinja;
+    migratedSettings.version = 2;
   }
 
   return migratedSettings;

--- a/src/components/CompletionSettings/CompletionSettings.tsx
+++ b/src/components/CompletionSettings/CompletionSettings.tsx
@@ -172,6 +172,7 @@ export const CompletionSettings: React.FC<Props> = ({settings, onChange}) => {
         </>
       )}
       {renderIntegerInput({name: 'seed'})}
+      {renderSwitch('jinja')}
     </View>
   );
 };

--- a/src/utils/completionSettingsVersions.ts
+++ b/src/utils/completionSettingsVersions.ts
@@ -14,7 +14,7 @@ import {CompletionParams} from './completionTypes';
 
 // Current version of the completion settings schema
 // Increment this when adding new settings or changing existing ones
-export const CURRENT_COMPLETION_SETTINGS_VERSION = 1;
+export const CURRENT_COMPLETION_SETTINGS_VERSION = 2;
 
 /**
  * Default completion parameters used throughout the app
@@ -44,6 +44,7 @@ export const defaultCompletionParams: CompletionParams = {
   seed: -1,
   n_probs: 0, // If greater than 0, the response also contains the probabilities of top N tokens for each generated token given the sampling settings.
   stop: ['</s>'],
+  jinja: true, // Whether to use Jinja templating for chat formatting
   // emit_partial_completion: true, // This is not used in the current version of llama.rn
 };
 
@@ -69,11 +70,17 @@ export function migrateCompletionSettings(settings: any): any {
     migratedSettings.version = 1;
   }
 
+  if (migratedSettings.version < 2) {
+    // Migration to version 2: Add jinja parameter
+    migratedSettings.jinja = defaultCompletionParams.jinja;
+    migratedSettings.version = 2;
+  }
+
   // Add future migrations here as needed
-  // if (migratedSettings.version < 2) {
-  //   // Migration to version 2
+  // if (migratedSettings.version < 3) {
+  //   // Migration to version 3
   //   migratedSettings.new_field = defaultCompletionParams.new_field;
-  //   migratedSettings.version = 2;
+  //   migratedSettings.version = 3;
   // }
 
   return migratedSettings;

--- a/src/utils/l10n.ts
+++ b/src/utils/l10n.ts
@@ -345,6 +345,8 @@ export const l10n = {
     completionParams: {
       include_thinking_in_context:
         'Include AI thinking/reasoning parts in the context sent to the model. Disabling this can save context space. It might impact performance.',
+      jinja:
+        'Enable Jinja templating for chat formatting. When enabled, uses Jinja-based chat template processing for better compatibility with modern models.',
       grammar:
         'Enforce specific grammar rules to ensure the generated text follows a particular structure or format',
       stop: 'Define specific phrases that will stop text generation',
@@ -1362,6 +1364,8 @@ export const l10n = {
     completionParams: {
       include_thinking_in_context:
         'AIの思考/推論部分をモデルに送信するコンテキストに含めます。無効にするとコンテキスト容量を節約できますが、パフォーマンスに影響する可能性があります。',
+      jinja:
+        'チャットフォーマットにJinjaテンプレートを使用します。有効にすると、最新のモデルとの互換性を向上させるためにJinjaベースのチャットテンプレート処理を使用します。',
       grammar:
         '生成テキストが特定の構造や形式に従うよう、文法ルールを適用します',
       stop: 'テキスト生成を停止する特定のフレーズを設定します',
@@ -2356,6 +2360,8 @@ export const l10n = {
     completionParams: {
       include_thinking_in_context:
         '在发送给模型的上下文中包含AI的思考/推理部分，禁用此选项可以节省上下文空间，但可能会影响性能',
+      jinja:
+        '启用Jinja模板进行聊天格式化。启用时，使用基于Jinja的聊天模板处理以提高与现代模型的兼容性。',
       grammar: '应用特定的语法规则，以确保生成的文本遵循特定的结构或格式',
       stop: '定义将停止文本生成的特定短语',
       n_predict: '设置生成响应的长度（以token为单位）',

--- a/src/utils/modelSettings.ts
+++ b/src/utils/modelSettings.ts
@@ -112,6 +112,10 @@ export const COMPLETION_PARAMS_METADATA: Partial<
     validation: {type: 'boolean', required: false},
     defaultValue: defaultCompletionParams.include_thinking_in_context,
   },
+  jinja: {
+    validation: {type: 'boolean', required: false},
+    defaultValue: defaultCompletionParams.jinja,
+  },
 };
 
 // Validation helpers


### PR DESCRIPTION
## Description

This PR adds jinja param to the ui and sets it by default to true. 
ERNIE doesn't support legacy chat formatting. 

## Platform Affected

- [ ] iOS
- [ ] Android

## Checklist

- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
