### PR TITLE
chore: replace app info placeholder icon

### DIFF
--- a/src/assets/icons/app-info.svg
+++ b/src/assets/icons/app-info.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 11V15M11 7H11.01M21 11C21 16.5228 16.5228 21 11 21C5.47715 21 1 16.5228 1 11C1 5.47715 5.47715 1 11 1C16.5228 1 21 5.47715 21 11Z" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -38,3 +38,4 @@ export {default as ShareIcon} from './share.svg';
 export {default as TrashIcon} from './trash.svg';
 export {default as UploadIcon} from './upload.svg';
 export {default as VideoRecorderIcon} from './video-recorder.svg';
+export {default as AppInfoIcon} from './app-info.svg';

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -18,9 +18,9 @@ import {
   EditIcon,
   ModelIcon,
   PalIcon,
-  PlaceholderIcon,
   SettingsIcon,
   TrashIcon,
+  AppInfoIcon,
 } from '../../assets/icons';
 import {L10nContext} from '../../utils';
 import {ROUTES} from '../../utils/navigationConstants';
@@ -126,7 +126,7 @@ export const SidebarContent: React.FC<DrawerContentComponentProps> = observer(
               <Drawer.Item
                 label={l10n.components.sidebarContent.menuItems.appInfo}
                 icon={() => (
-                  <PlaceholderIcon
+                  <AppInfoIcon
                     width={24}
                     height={24}
                     stroke={theme.colors.primary}


### PR DESCRIPTION
## Description

Replace placeholder icon for app info in left sidebar menu with Google Fonts icon
<img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/6c48cb3b-2b3a-4fc5-8e3b-810c76a8c350" />


## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.
