### PR TITLE
feat: add UI controls for use_mmap and use_mlock

### DIFF
--- a/__mocks__/external/llama.rn.ts
+++ b/__mocks__/external/llama.rn.ts
@@ -33,8 +33,11 @@ export const LlamaContext = jest
   .fn()
   .mockImplementation((params: any) => new MockLlamaContext(params));
 
+export const loadLlamaModelInfo = jest.fn();
+
 export default {
   LlamaContext,
   initLlama: jest.fn(),
   CompletionParams: jest.fn(),
+  loadLlamaModelInfo,
 };

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -58,6 +58,7 @@ export const SettingsScreen: React.FC = observer(() => {
   const [showKeyCacheMenu, setShowKeyCacheMenu] = useState(false);
   const [showValueCacheMenu, setShowValueCacheMenu] = useState(false);
   const [showLanguageMenu, setShowLanguageMenu] = useState(false);
+  const [showMmapMenu, setShowMmapMenu] = useState(false);
   const [showHfTokenDialog, setShowHfTokenDialog] = useState(false);
   const [keyCacheAnchor, setKeyCacheAnchor] = useState<{x: number; y: number}>({
     x: 0,
@@ -68,12 +69,17 @@ export const SettingsScreen: React.FC = observer(() => {
     y: number;
   }>({x: 0, y: 0});
   const [languageAnchor, setLanguageAnchor] = useState<{x: number; y: number}>({
-    x: 0,
-    y: 0,
+    x: 0.0,
+    y: 0.0,
+  });
+  const [mmapAnchor, setMmapAnchor] = useState<{x: number; y: number}>({
+    x: 0.0,
+    y: 0.0,
   });
   const keyCacheButtonRef = useRef<View>(null);
   const valueCacheButtonRef = useRef<View>(null);
   const languageButtonRef = useRef<View>(null);
+  const mmapButtonRef = useRef<View>(null);
 
   const debouncedUpdateStore = useRef(
     debounce((value: number) => {
@@ -99,6 +105,7 @@ export const SettingsScreen: React.FC = observer(() => {
     setShowKeyCacheMenu(false);
     setShowValueCacheMenu(false);
     setShowLanguageMenu(false);
+    setShowMmapMenu(false);
   };
 
   const handleContextSizeChange = (text: string) => {
@@ -123,10 +130,29 @@ export const SettingsScreen: React.FC = observer(() => {
     {label: 'IQ4_NL', value: CacheType.IQ4_NL},
   ];
 
+  const mmapOptions = [
+    {label: l10n.settings.useMmapTrue, value: 'true' as const},
+    {label: l10n.settings.useMmapFalse, value: 'false' as const},
+    ...(Platform.OS === 'android'
+      ? [{label: l10n.settings.useMmapSmart, value: 'smart' as const}]
+      : []),
+  ];
+
   const getCacheTypeLabel = (value: CacheType) => {
     return (
       cacheTypeOptions.find(option => option.value === value)?.label || value
     );
+  };
+
+  const getMmapLabel = (value: 'true' | 'false' | 'smart') => {
+    return mmapOptions.find(option => option.value === value)?.label || '';
+  };
+
+  const handleMmapPress = () => {
+    mmapButtonRef.current?.measure((x, y, width, height, pageX, pageY) => {
+      setMmapAnchor({x: pageX, y: pageY + height});
+      setShowMmapMenu(true);
+    });
   };
 
   const handleKeyCachePress = () => {
@@ -490,6 +516,80 @@ export const SettingsScreen: React.FC = observer(() => {
                   </View>
                 </View>
               </List.Accordion>
+            </Card.Content>
+          </Card>
+
+          {/* Memory Settings */}
+          <Card elevation={0} style={styles.card}>
+            <Card.Title title={l10n.settings.memorySettings} />
+            <Card.Content>
+              <View style={styles.settingItemContainer}>
+                {/* Use Memory Lock */}
+                <View style={styles.switchContainer}>
+                  <View style={styles.textContainer}>
+                    <Text variant="titleMedium" style={styles.textLabel}>
+                      {l10n.settings.useMlock}
+                    </Text>
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {l10n.settings.useMlockDescription}
+                    </Text>
+                  </View>
+                  <Switch
+                    testID="use-mlock-switch"
+                    value={modelStore.use_mlock}
+                    onValueChange={value => modelStore.setUseMlock(value)}
+                  />
+                </View>
+              </View>
+              <Divider />
+
+              {/* Memory Mapping */}
+              <View style={styles.settingItemContainer}>
+                <View style={styles.switchContainer}>
+                  <View style={styles.textContainer}>
+                    <Text variant="titleMedium" style={styles.textLabel}>
+                      {l10n.settings.useMmap}
+                    </Text>
+                    <Text variant="labelSmall" style={styles.textDescription}>
+                      {l10n.settings.useMmapDescription}
+                    </Text>
+                  </View>
+                  <View style={styles.menuContainer}>
+                    <Button
+                      ref={mmapButtonRef}
+                      mode="outlined"
+                      onPress={handleMmapPress}
+                      style={styles.menuButton}
+                      contentStyle={styles.buttonContent}
+                      icon={({size, color}) => (
+                        <Icon source="chevron-down" size={size} color={color} />
+                      )}>
+                      {getMmapLabel(modelStore.use_mmap)}
+                    </Button>
+                    <Menu
+                      visible={showMmapMenu}
+                      onDismiss={() => setShowMmapMenu(false)}
+                      anchor={mmapAnchor}
+                      selectable>
+                      {mmapOptions.map(option => (
+                        <Menu.Item
+                          key={option.value}
+                          style={styles.menu}
+                          label={option.label}
+                          selected={option.value === modelStore.use_mmap}
+                          onPress={() => {
+                            modelStore.setUseMmap(option.value);
+                            setShowMmapMenu(false);
+                          }}
+                        />
+                      ))}
+                    </Menu>
+                  </View>
+                </View>
+              </View>
+              <Text variant="labelSmall" style={styles.textDescription}>
+                {l10n.settings.modelReloadNotice}
+              </Text>
             </Card.Content>
           </Card>
 

--- a/src/utils/__tests__/memorySettings.test.ts
+++ b/src/utils/__tests__/memorySettings.test.ts
@@ -1,0 +1,120 @@
+import {Platform} from 'react-native';
+import {isRepackableQuantization, resolveUseMmap} from '../memorySettings';
+import {loadLlamaModelInfo} from '@pocketpalai/llama.rn';
+
+// Mock Platform
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'android',
+  },
+}));
+
+const mockLoadLlamaModelInfo = loadLlamaModelInfo as jest.MockedFunction<
+  typeof loadLlamaModelInfo
+>;
+
+describe('memorySettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isRepackableQuantization', () => {
+    it('should return true for Q4_0 quantization', async () => {
+      mockLoadLlamaModelInfo.mockResolvedValue({
+        'general.file_type': 'Q4_0',
+      });
+
+      const result = await isRepackableQuantization('/path/to/model.gguf');
+      expect(result).toBe(true);
+    });
+
+    it('should return true for IQ4_NL quantization', async () => {
+      mockLoadLlamaModelInfo.mockResolvedValue({
+        'general.file_type': 'IQ4_NL',
+      });
+
+      const result = await isRepackableQuantization('/path/to/model.gguf');
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-repackable quantization', async () => {
+      mockLoadLlamaModelInfo.mockResolvedValue({
+        'general.file_type': 'Q8_0',
+      });
+
+      const result = await isRepackableQuantization('/path/to/model.gguf');
+      expect(result).toBe(false);
+    });
+
+    it('should return false when general.file_type is missing', async () => {
+      mockLoadLlamaModelInfo.mockResolvedValue({
+        'other.field': 'value',
+      });
+
+      const result = await isRepackableQuantization('/path/to/model.gguf');
+      expect(result).toBe(false);
+    });
+
+    it('should return false when loadLlamaModelInfo throws error', async () => {
+      mockLoadLlamaModelInfo.mockRejectedValue(
+        new Error('Failed to load model info'),
+      );
+
+      const result = await isRepackableQuantization('/path/to/model.gguf');
+      expect(result).toBe(false);
+    });
+
+    it('should handle case-insensitive matching', async () => {
+      mockLoadLlamaModelInfo.mockResolvedValue({
+        'general.file_type': 'q4_0',
+      });
+
+      const result = await isRepackableQuantization('/path/to/model.gguf');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('resolveUseMmap', () => {
+    it('should return true for "true" setting', async () => {
+      const result = await resolveUseMmap('true', '/path/to/model.gguf');
+      expect(result).toBe(true);
+    });
+
+    it('should return false for "false" setting', async () => {
+      const result = await resolveUseMmap('false', '/path/to/model.gguf');
+      expect(result).toBe(false);
+    });
+
+    it('should return true for "smart" setting on non-Android platforms', async () => {
+      (Platform as any).OS = 'ios';
+      const result = await resolveUseMmap('smart', '/path/to/model.gguf');
+      expect(result).toBe(true);
+    });
+
+    it('should return true for "smart" setting without model path', async () => {
+      (Platform as any).OS = 'android';
+      const result = await resolveUseMmap('smart', '');
+      expect(result).toBe(true);
+    });
+
+    it('should return false for "smart" setting with repackable quantization on Android', async () => {
+      (Platform as any).OS = 'android';
+      mockLoadLlamaModelInfo.mockResolvedValue({
+        'general.file_type': 'Q4_0',
+      });
+
+      const result = await resolveUseMmap('smart', '/path/to/model.gguf');
+      expect(result).toBe(false);
+    });
+
+    it('should return true for "smart" setting with non-repackable quantization on Android', async () => {
+      (Platform as any).OS = 'android';
+      mockLoadLlamaModelInfo.mockResolvedValue({
+        'general.file_type': 'Q8_0',
+      });
+
+      const result = await resolveUseMmap('smart', '/path/to/model.gguf');
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/utils/l10n.ts
+++ b/src/utils/l10n.ts
@@ -74,6 +74,23 @@ export const l10n = {
       valueCacheTypeDescription: 'Select the cache type for value computation',
       valueCacheTypeDisabledDescription:
         'Enable Flash Attention to change cache type',
+      // Memory Settings
+      memorySettings: 'Memory Settings',
+      useMlock: 'Use Memory Lock',
+      useMlockDescription:
+        'Force system to keep model in RAM rather than swapping or compressing',
+      useMmap: 'Memory Mapping',
+      useMmapDescription: 'Use memory-mapped files for faster model loading',
+      useMmapTrue: 'Enabled',
+      useMmapFalse: 'Disabled',
+      useMmapSmart: 'Smart',
+      useMmapTrueDescription: 'Always use memory mapping for faster loading',
+      useMmapFalseDescription:
+        'Never use memory mapping (slower loading but may reduce memory usage)',
+      useMmapSmartDescription:
+        'Automatically choose based on model type (Android only)',
+      useMmapRecommended:
+        'Recommended for performance - Memory-mapped with locked pages. Combines fast loading with consistent performance',
       // Model Loading Settings
       modelLoadingSettings: 'Model Loading Settings',
       // Auto Offload/Load
@@ -1140,6 +1157,22 @@ export const l10n = {
       valueCacheTypeDescription: '値計算用のキャッシュタイプを選択',
       valueCacheTypeDisabledDescription:
         'キャッシュタイプを変更するにはFlash Attentionを有効にしてください',
+      // Memory Settings
+      memorySettings: 'メモリ設定',
+      useMlock: 'メモリロックを使用',
+      useMlockDescription: 'モデルをRAMに保持し、スワップや圧縮を防ぎます',
+      useMmap: 'メモリマッピング',
+      useMmapDescription:
+        'メモリマップファイルを使用してモデルの読み込みを高速化',
+      useMmapTrue: '有効',
+      useMmapFalse: '無効',
+      useMmapSmart: 'スマート',
+      useMmapTrueDescription: '常にメモリマッピングを使用して高速読み込み',
+      useMmapFalseDescription:
+        'メモリマッピングを使用しない（読み込みは遅くなりますがメモリ使用量を削減する可能性があります）',
+      useMmapSmartDescription: 'モデルタイプに基づいて自動選択（Androidのみ）',
+      useMmapRecommended:
+        'パフォーマンス推奨 - ロックされたページでメモリマップ。高速読み込みと一貫したパフォーマンスを組み合わせます',
       // Model Loading Settings
       modelLoadingSettings: 'モデル読み込み設定',
       // Auto Offload/Load
@@ -2208,6 +2241,20 @@ export const l10n = {
       valueCacheType: '值缓存类型',
       valueCacheTypeDescription: '选择值计算的缓存类型',
       valueCacheTypeDisabledDescription: '启用Flash Attention以更改缓存类型',
+      // Memory Settings
+      memorySettings: '内存设置',
+      useMlock: '使用内存锁定',
+      useMlockDescription: '强制系统将模型保留在RAM中，而不是交换或压缩',
+      useMmap: '内存映射',
+      useMmapDescription: '使用内存映射文件加快模型加载速度',
+      useMmapTrue: '启用',
+      useMmapFalse: '禁用',
+      useMmapSmart: '智能',
+      useMmapTrueDescription: '始终使用内存映射以实现更快的加载',
+      useMmapFalseDescription: '从不使用内存映射（加载较慢但可能减少内存使用）',
+      useMmapSmartDescription: '根据模型类型自动选择（仅限Android）',
+      useMmapRecommended:
+        '推荐性能设置 - 带锁定页面的内存映射。结合快速加载和一致的性能',
       // Model Loading Settings
       modelLoadingSettings: '模型加载设置',
       // Auto Offload/Load

--- a/src/utils/memorySettings.ts
+++ b/src/utils/memorySettings.ts
@@ -1,0 +1,124 @@
+import {Platform} from 'react-native';
+import {loadLlamaModelInfo} from '@pocketpalai/llama.rn';
+
+/**
+ * Quantization types that are repackable and should use use_mmap=false
+ */
+const REPACKABLE_QUANTS = ['Q4_0', 'IQ4_NL'];
+
+/**
+ * LlamaFileType enum values for repackable quantizations
+ * Based on the LlamaFileType enum from llama.cpp
+ */
+const REPACKABLE_FILE_TYPES = {
+  MOSTLY_Q4_0: 2, // Q4_0 quantization
+  MOSTLY_IQ4_NL: 25, // IQ4_NL quantization
+};
+
+/**
+ * Detects if a model uses repackable quantization types (Q4_0 or IQ4_NL)
+ */
+export async function isRepackableQuantization(
+  modelPath: string,
+): Promise<boolean> {
+  try {
+    const modelInfo = await loadLlamaModelInfo(modelPath);
+
+    // Check if model info is valid and contains file_type
+    if (
+      !modelInfo ||
+      typeof modelInfo !== 'object' ||
+      !('general.file_type' in modelInfo)
+    ) {
+      return false;
+    }
+
+    const fileType = (modelInfo as any)['general.file_type'];
+
+    // Ensure fileType exists
+    if (fileType === undefined || fileType === null) {
+      return false;
+    }
+
+    if (typeof fileType === 'string') {
+      const numericValue = parseInt(fileType, 10);
+      if (!isNaN(numericValue)) {
+        const isRepackable = Object.values(REPACKABLE_FILE_TYPES).includes(
+          numericValue,
+        );
+        if (isRepackable) {
+          console.log(
+            'Detected repackable quantization:',
+            fileType,
+            '(enum value:',
+            numericValue,
+            ')',
+          );
+        }
+        return isRepackable;
+      }
+
+      const isRepackable = REPACKABLE_QUANTS.some(quant =>
+        fileType.toUpperCase().includes(quant.toUpperCase()),
+      );
+      if (isRepackable) {
+        console.log('Detected repackable quantization from string:', fileType);
+      }
+      return isRepackable;
+    }
+
+    // Handle numeric fileType (just in case)
+    if (typeof fileType === 'number') {
+      const isRepackable = Object.values(REPACKABLE_FILE_TYPES).includes(
+        fileType,
+      );
+      if (isRepackable) {
+        console.log('Detected repackable quantization from number:', fileType);
+      }
+      return isRepackable;
+    }
+
+    return false;
+  } catch (error) {
+    console.warn(
+      'Failed to detect quantization type, defaulting to false:',
+      error,
+    );
+    return false;
+  }
+}
+
+/**
+ * Resolves the effective use_mmap value based on the setting and model characteristics
+ *
+ * @param setting - The user's mmap setting ('true', 'false', or 'smart')
+ * @param modelPath - Path to the model file (used for smart detection)
+ * @returns Promise<boolean> - The resolved use_mmap value
+ */
+export async function resolveUseMmap(
+  setting: 'true' | 'false' | 'smart',
+  modelPath: string,
+): Promise<boolean> {
+  switch (setting) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    case 'smart':
+      // Smart mode: only available on Android
+      if (Platform.OS !== 'android') {
+        return true; // Default to true on non-Android platforms
+      }
+
+      if (!modelPath) {
+        console.log('No model path provided, defaulting to use_mmap=true');
+        return true; // Default to true if no model path provided
+      }
+
+      // For Android: use mmap=false for repackable quants, true otherwise
+      const isRepackable = await isRepackableQuantization(modelPath);
+      return !isRepackable;
+    default:
+      return true;
+  }
+}


### PR DESCRIPTION
## Description

Exposes `use_mmap` and `use_mlock` settings in the ui.

Fixes #402 

## Platform Affected

- [ ] iOS
- [ ] Android

## Checklist

- [ ] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [ ] Unit tests and integration tests pass locally.
