### PR TITLE
chore(deps): upgrade llama.rn to 0.11.0-rc.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.11.0-rc.2):
+  - llama-rn (0.11.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3655,7 +3655,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 5ef85105315906ec955b886532f6cb1fd52f2d2f
+  llama-rn: 03974fd682bcc0f1e0d7e536d988337076b83e57
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.11.0-rc.2",
+    "llama.rn": "0.11.0-rc.3",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,10 +6500,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.11.0-rc.2:
-  version "0.11.0-rc.2"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.0-rc.2.tgz#aff34e95c2bf7d7b17f1776322f053604935374a"
-  integrity sha512-wMBIKTO5Rfvt8bvWTPhKirMzbzmWIfYf6YfFUizUggS3aCIf3agkHYrVf6S1heSp4oFlQYBfENn8dlwe40mRtQ==
+llama.rn@0.11.0-rc.3:
+  version "0.11.0-rc.3"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.0-rc.3.tgz#b774ba3f64bc1d9c94f7a39aca61e28a0867852b"
+  integrity sha512-PyEk31kdn9dWt5BejjYZgJGcKLkvth3sDfaTC144bSPXEJmkGetYqvSEI9YeqEq0aYfwSDGyqwDRWzNO9LfzvA==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Upgraded llama.rn from 0.11.0-rc.2 to 0.11.0-rc.3
- Updated yarn.lock with new dependency resolution
- Updated ios/Podfile.lock with new iOS native dependencies

## Changes
| File | Change |
|------|--------|
| package.json | Bumped llama.rn version to 0.11.0-rc.3 |
| yarn.lock | Auto-updated by yarn install |
| ios/Podfile.lock | Auto-updated by pod install |

## Testing
- All 1364 tests pass (2 skipped)
- Lint passes (3 pre-existing warnings, no new issues)
- TypeScript typecheck passes
- iOS Release build verified
- Android Release build verified

## Release Notes
Version 0.11.0-rc.3 includes:
- Bug fix for parallel decoding callbacks
- llama.cpp sync to b7836
- No breaking changes

## Verification
No code changes required - this is a straightforward dependency upgrade following the established pattern from previous llama.rn upgrades.

Story: TASK-20260201-2039

---
🤖 Generated by PocketPal Dev Team