### PR TITLE
chore(deps): upgrade llama.rn to 0.11.0-rc.4

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.11.0-rc.3):
+  - llama-rn (0.11.0-rc.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3655,7 +3655,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 03974fd682bcc0f1e0d7e536d988337076b83e57
+  llama-rn: 1f92acc15976986825338aa257fcb52998233a6c
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.11.0-rc.3",
+    "llama.rn": "0.11.0-rc.4",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,10 +6500,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.11.0-rc.3:
-  version "0.11.0-rc.3"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.0-rc.3.tgz#b774ba3f64bc1d9c94f7a39aca61e28a0867852b"
-  integrity sha512-PyEk31kdn9dWt5BejjYZgJGcKLkvth3sDfaTC144bSPXEJmkGetYqvSEI9YeqEq0aYfwSDGyqwDRWzNO9LfzvA==
+llama.rn@0.11.0-rc.4:
+  version "0.11.0-rc.4"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.0-rc.4.tgz#4a17b2e072415bee83435534baf529d793129b47"
+  integrity sha512-ahUP809+q77aPlSh77QdXdcC/bmm0b55RCvi2eLd38c8rY2Nd/myJZ7GeXkhXItIs8DjLPBJ6I10HwrSn3YLfQ==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Upgrade llama.rn from 0.11.0-rc.3 to 0.11.0-rc.4
- Update package.json, yarn.lock, and ios/Podfile.lock
- All tests pass (1419/1433, 14 skipped)
- Coverage: 66.93% (above 60% threshold)
- iOS and Android Release builds verified

## Test Plan
- [X] Lint passes (0 errors)
- [X] TypeCheck passes
- [X] Full test suite passes (1419/1433)
- [X] Coverage above 60% threshold
- [X] Pod install succeeds
- [X] iOS Release build succeeds
- [X] Android Release build succeeds

## Changes
**Files Modified**: 3
- package.json: llama.rn version 0.11.0-rc.3 → 0.11.0-rc.4
- yarn.lock: Updated checksums and dependency tree
- ios/Podfile.lock: Updated native iOS dependencies

**Pattern**: Follows previous llama.rn upgrades (f91144d, f8669db, 623ad08)

**Breaking Changes**: None - API compatible with rc.3

## Story
TASK-20260206-1330

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)