### PR TITLE
chore(deps): upgrade llama.rn to 0.11.0 stable

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.11.0-rc.4):
+  - llama-rn (0.11.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3655,7 +3655,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 1f92acc15976986825338aa257fcb52998233a6c
+  llama-rn: 6b65dfb9c61c93aa1c0f5ed55d0febcf3c3b6cc5
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.11.0-rc.4",
+    "llama.rn": "0.11.0",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,10 +6500,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.11.0-rc.4:
-  version "0.11.0-rc.4"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.0-rc.4.tgz#4a17b2e072415bee83435534baf529d793129b47"
-  integrity sha512-ahUP809+q77aPlSh77QdXdcC/bmm0b55RCvi2eLd38c8rY2Nd/myJZ7GeXkhXItIs8DjLPBJ6I10HwrSn3YLfQ==
+llama.rn@0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.0.tgz#62efab6571a102b1f01052e484d5cd0d924607a0"
+  integrity sha512-FLQwBdg1n7H9lqnQinOSv0Cly7Du1NEhMktaNJDGGsMEd/qFG0l8Iwyqsk8c2ZIIn2b6C4FPUCL2yDvlL41IBw==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Upgrades `llama.rn` from `0.11.0-rc.4` to `0.11.0` (stable release)
- Zero TypeScript API changes — drop-in replacement
- 3 files changed: `package.json`, `yarn.lock`, `ios/Podfile.lock`

## What changed in llama.rn 0.11.0
- llama.cpp updated from build b7951 to b7992
- Android: CMakeLists.txt fix to skip unsupported ABIs
- Internal C++ header rename (`llama-sampling.h` → `llama-sampler.h`) — PocketPal does not reference this directly

## Verification
- [x] `yarn typecheck` — 0 errors
- [x] `yarn lint` — 0 errors
- [x] `yarn test` — 1446 passed, 0 failed
- [x] `pod install` — llama-rn 0.11.0 resolved
- [x] iOS Release build — succeeded
- [x] Android Release build — succeeded

## Test plan
- [x] Load a model and run inference on iOS
- [x] Load a model and run inference on Android
- [x] Verify streaming output works correctly
- [ ] Verify Apple Shortcuts inference still works (iOS physical device)

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)