### PR TITLE
ci: skip native builds for translation-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,44 @@ permissions:
   contents: read
 
 jobs:
+  # Detect if changes are translation-only (src/locales/ files)
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      translation_only: ${{ steps.check.outputs.translation_only }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check if translation-only
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            CHANGED=$(git diff --name-only HEAD~1)
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          # Check if ALL changed files are under src/locales/
+          TRANSLATION_ONLY="true"
+          while IFS= read -r file; do
+            if [ -z "$file" ]; then
+              continue
+            fi
+            case "$file" in
+              src/locales/*) ;;
+              *) TRANSLATION_ONLY="false"; break ;;
+            esac
+          done <<< "$CHANGED"
+
+          echo "translation_only=$TRANSLATION_ONLY" >> "$GITHUB_OUTPUT"
+          echo "Translation only: $TRANSLATION_ONLY"
+
   # Job for linting, type checking, unit testing
   build-and-test:
     runs-on: ubuntu-latest
@@ -60,7 +98,8 @@ jobs:
   # Job for Android build
   build-android:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test, detect-changes]
+    if: needs.detect-changes.outputs.translation_only != 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -169,7 +208,8 @@ jobs:
   # Job for iOS build
   build-ios:
     runs-on: macos-15  # macOS 15 with Xcode 16
-    needs: build-and-test
+    needs: [build-and-test, detect-changes]
+    if: needs.detect-changes.outputs.translation_only != 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

- Adds a `detect-changes` job to CI that checks if all changed files are under `src/locales/`
- Skips `build-android` and `build-ios` when only translation files changed
- `build-and-test` (lint, typecheck, tests, l10n validation) always runs

## Motivation

Weblate opens PRs and pushes commits as translators work. Each commit triggers the full CI pipeline including expensive native builds (~15 min Android on Ubuntu, ~25 min iOS on macOS-15). Translation-only changes cannot affect native builds, so these are wasted CI minutes.

## How it works

1. New `detect-changes` job runs `git diff --name-only` to get changed files
2. Uses a shell `case` statement to check if ALL files match `src/locales/*`
3. Outputs `translation_only=true` or `false`
4. `build-android` and `build-ios` have `if: needs.detect-changes.outputs.translation_only != 'true'`

## Test plan

- [ ] Push a PR that only changes `src/locales/*.json` → verify `build-android` and `build-ios` are skipped, `build-and-test` still runs
- [ ] Push a PR that changes files outside `src/locales/` → verify all jobs run

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)