### PR TITLE
chore(e2e): add thinking toggle feature test

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,6 +15,7 @@ yarn install
 |------|---------------|----------|
 | `quick-smoke` | Full user journey: navigate to Models → search HuggingFace → download SmolLM2-135M → load model → chat → verify inference completes | ~50-70s/device |
 | `load-stress` | Download model, run multiple load/unload cycles with inference between each. Catches crash-on-reload bugs | ~5-10 min/device |
+| `thinking` | Loads Qwen3-0.6B (thinking model), verifies thinking toggle, thinking bubble appears, toggle off suppresses it | ~3-5 min/device |
 | `diagnostic` | Dumps Appium page source XML at each screen. For debugging selectors, not a real test | ~10s |
 
 ## Local Testing
@@ -176,7 +177,10 @@ e2e/
 ├── specs/                        # Test specifications
 │   ├── quick-smoke.spec.ts       # Core smoke test (model download + chat)
 │   ├── load-stress.spec.ts       # Load/unload cycle crash repro
-│   └── diagnostic.spec.ts        # Page source dumper for debugging
+│   ├── diagnostic.spec.ts        # Page source dumper for debugging
+│   └── features/                 # Feature-level tests
+│       ├── thinking.spec.ts      # Thinking toggle + reasoning bubble
+│       └── language.spec.ts      # Language switching UI validation
 ├── pages/                        # Page Object Model
 │   ├── BasePage.ts               # Abstract base (waitFor, tap, type)
 │   ├── ChatPage.ts               # Chat screen interactions
@@ -186,7 +190,8 @@ e2e/
 │   └── ModelDetailsSheet.ts      # Model details + download
 ├── helpers/
 │   ├── selectors.ts              # Cross-platform element selectors
-│   └── gestures.ts               # Swipe/scroll gestures (W3C Actions)
+│   ├── gestures.ts               # Swipe/scroll gestures (W3C Actions)
+│   └── model-actions.ts          # Reusable download/load/inference helpers
 ├── fixtures/
 │   ├── models.ts                 # Test model configurations + timeouts
 │   └── test-image.jpg            # For vision model tests

--- a/e2e/helpers/model-actions.ts
+++ b/e2e/helpers/model-actions.ts
@@ -1,0 +1,151 @@
+/**
+ * Reusable model actions for E2E tests
+ *
+ * Provides download-and-load flow that can be shared across specs,
+ * so each feature test doesn't need to duplicate model setup logic.
+ */
+
+import {ChatPage} from '../pages/ChatPage';
+import {DrawerPage} from '../pages/DrawerPage';
+import {ModelsPage} from '../pages/ModelsPage';
+import {HFSearchSheet} from '../pages/HFSearchSheet';
+import {ModelDetailsSheet} from '../pages/ModelDetailsSheet';
+import {Selectors} from './selectors';
+import {TIMEOUTS, ModelTestConfig} from '../fixtures/models';
+
+declare const browser: WebdriverIO.Browser;
+
+/**
+ * Dismiss memory/performance warning alert if it appears.
+ * The app shows this alert when loading models that may exceed device memory
+ * or for multimodal models on low-end devices.
+ * Taps "Continue" to proceed with loading anyway.
+ */
+export async function dismissPerformanceWarningIfPresent(): Promise<void> {
+  try {
+    await browser.pause(1500);
+    const continueButton = browser.$(Selectors.alert.continueButton);
+    const exists = await continueButton.isExisting();
+    if (exists) {
+      const isDisplayed = await continueButton.isDisplayed();
+      if (isDisplayed) {
+        console.log('Performance warning alert detected, tapping Continue...');
+        await continueButton.click();
+        await browser.pause(500);
+      }
+    }
+  } catch {
+    // No alert appeared - just continue
+  }
+}
+
+/**
+ * Download a model from HuggingFace and load it.
+ * After completion, the app auto-navigates to the Chat screen.
+ *
+ * @param model - Model config from fixtures/models.ts
+ */
+export async function downloadAndLoadModel(
+  model: ModelTestConfig,
+): Promise<void> {
+  const chatPage = new ChatPage();
+  const drawerPage = new DrawerPage();
+  const modelsPage = new ModelsPage();
+  const hfSearchSheet = new HFSearchSheet();
+  const modelDetailsSheet = new ModelDetailsSheet();
+
+  // Navigate to Models screen
+  await chatPage.openDrawer();
+  await drawerPage.waitForOpen();
+  await drawerPage.navigateToModels();
+  await modelsPage.waitForReady();
+
+  // Open HuggingFace search
+  await modelsPage.openHuggingFaceSearch();
+  await hfSearchSheet.waitForReady();
+
+  // Search and select model
+  await hfSearchSheet.search(model.searchQuery);
+  await hfSearchSheet.selectModel(model.selectorText);
+  await modelDetailsSheet.waitForReady();
+
+  // Scroll to file and start download
+  await modelDetailsSheet.scrollToFile(model.downloadFile);
+  await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+
+  // Close sheets and return to Models screen
+  await modelDetailsSheet.close();
+  await hfSearchSheet.close();
+  await modelsPage.waitForReady();
+
+  // Wait for download to complete
+  const downloadTimeout = model.downloadTimeout ?? TIMEOUTS.download;
+  const containerSelector = Selectors.modelCard.cardContainer(
+    model.downloadFile,
+  );
+  const modelCardContainer = browser.$(containerSelector);
+  await modelCardContainer.waitForDisplayed({timeout: downloadTimeout});
+
+  // Find and click load button
+  const loadBtn = modelCardContainer.$(Selectors.modelCard.loadButtonElement);
+  await loadBtn.waitForDisplayed({timeout: 10000});
+  await loadBtn.click();
+
+  // Handle potential memory/performance warning alert
+  await dismissPerformanceWarningIfPresent();
+
+  // Verify we're on chat screen (auto-navigates after load)
+  await chatPage.waitForReady();
+
+  console.log(`Model loaded successfully: ${model.id}`);
+}
+
+/**
+ * Wait for inference to complete by polling for timing info.
+ * Returns the timing text when complete.
+ *
+ * @param maxWaitMs - Maximum time to wait for completion
+ * @param pollIntervalMs - How often to check
+ */
+export async function waitForInferenceComplete(
+  maxWaitMs = 60000,
+  pollIntervalMs = 2000,
+): Promise<string> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < maxWaitMs) {
+    const timingElement = browser.$(Selectors.chat.inferenceComplete);
+    const exists = await timingElement.isExisting().catch(() => false);
+
+    if (exists) {
+      const attrName = (browser as any).isAndroid ? 'content-desc' : 'label';
+      const labelText = await timingElement
+        .getAttribute(attrName)
+        .catch(() => '');
+      const timingMatch = labelText.match(/(\d+(?:\.\d+)?ms\/token.*TTFT)/);
+      return timingMatch ? timingMatch[1] : labelText.slice(-100);
+    }
+
+    // Swipe up to scroll down while waiting (in case content is long)
+    try {
+      const {width, height} = await (browser as any).getWindowSize();
+      await (browser as any)
+        .action('pointer', {parameters: {pointerType: 'touch'}})
+        .move({x: Math.floor(width / 2), y: Math.floor(height * 0.7)})
+        .down()
+        .move({
+          x: Math.floor(width / 2),
+          y: Math.floor(height * 0.3),
+          duration: 300,
+        })
+        .up()
+        .perform();
+    } catch {
+      // Swipe failed, continue waiting
+    }
+
+    await browser.pause(pollIntervalMs);
+  }
+
+  throw new Error('Inference timed out - timing info not found');
+}

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -404,6 +404,49 @@ export const Selectors = {
     },
   },
 
+  // Thinking / generation settings
+  thinking: {
+    /** "Think" toggle button - when thinking is currently enabled */
+    get toggleEnabled(): string {
+      return byAccessibilityLabel('Disable thinking mode');
+    },
+    /** "Think" toggle button - when thinking is currently disabled */
+    get toggleDisabled(): string {
+      return byAccessibilityLabel('Enable thinking mode');
+    },
+    /** "Reasoning" header text inside the ThinkingBubble */
+    get bubble(): string {
+      return byText('Reasoning');
+    },
+    /** Chevron icon inside the ThinkingBubble */
+    get chevronIcon(): string {
+      return byTestId('chevron-icon');
+    },
+  },
+
+  // Generation settings sheet
+  generationSettings: {
+    get completionSettings(): string {
+      return byTestId('completion-settings');
+    },
+    /** Temperature slider's text input (testID: temperature-slider-input) */
+    get temperatureInput(): string {
+      return byTestId('temperature-slider-input');
+    },
+    /** Seed integer input (testID: seed-input) */
+    get seedInput(): string {
+      return byTestId('seed-input');
+    },
+    /** Save button (session context) */
+    get saveButton(): string {
+      return byText('Save');
+    },
+    /** Save changes button (preset context) */
+    get saveChangesButton(): string {
+      return byText('Save Changes');
+    },
+  },
+
   // Benchmark screen
   benchmark: {
     get startTestButton(): string {

--- a/e2e/pages/ChatPage.ts
+++ b/e2e/pages/ChatPage.ts
@@ -6,7 +6,10 @@
  */
 
 import {BasePage, ChainableElement} from './BasePage';
-import {Selectors} from '../helpers/selectors';
+import {Selectors, byText} from '../helpers/selectors';
+import {Gestures} from '../helpers/gestures';
+
+declare const browser: WebdriverIO.Browser;
 
 export class ChatPage extends BasePage {
   /**
@@ -64,5 +67,127 @@ export class ChatPage extends BasePage {
    */
   async resetChat(): Promise<void> {
     await this.tap(Selectors.chat.resetButton);
+  }
+
+  /**
+   * Check if the thinking toggle is visible (model supports thinking)
+   */
+  async isThinkingToggleVisible(): Promise<boolean> {
+    const enabled = await this.isElementDisplayed(
+      Selectors.thinking.toggleEnabled,
+      3000,
+    );
+    if (enabled) {
+      return true;
+    }
+    return this.isElementDisplayed(Selectors.thinking.toggleDisabled, 1000);
+  }
+
+  /**
+   * Check if thinking mode is currently enabled
+   */
+  async isThinkingEnabled(): Promise<boolean> {
+    return this.isElementDisplayed(Selectors.thinking.toggleEnabled, 3000);
+  }
+
+  /**
+   * Tap the thinking toggle to switch its state
+   */
+  async tapThinkingToggle(): Promise<void> {
+    // Try the enabled state first, then disabled
+    const enabledEl = browser.$(Selectors.thinking.toggleEnabled);
+    if (await enabledEl.isExisting()) {
+      await enabledEl.click();
+    } else {
+      await this.tap(Selectors.thinking.toggleDisabled);
+    }
+    await browser.pause(300);
+  }
+
+  /**
+   * Check if a thinking bubble ("Reasoning") is present in the chat
+   */
+  async isThinkingBubbleVisible(timeout = 3000): Promise<boolean> {
+    return this.isElementDisplayed(Selectors.thinking.bubble, timeout);
+  }
+
+  /**
+   * Open generation settings sheet via the menu
+   */
+  async openGenerationSettings(): Promise<void> {
+    // Tap the three-dot menu button (top right, not the hamburger)
+    const menuBtn = browser.$(Selectors.chat.menuButton);
+
+    // There are two elements with testID "menu-button": hamburger (left) and dots (right).
+    // We need the second one (dots menu). Use $$ to get all matches.
+    const menuButtons = browser.$$(Selectors.chat.menuButton);
+    const count = await menuButtons.length;
+    if (count >= 2) {
+      await menuButtons[count - 1].click();
+    } else {
+      await menuBtn.click();
+    }
+
+    await browser.pause(500);
+
+    // Tap "Generation settings" menu item
+    const genSettingsItem = browser.$(byText('Generation settings'));
+    await genSettingsItem.waitForDisplayed({timeout: 5000});
+    await genSettingsItem.click();
+    await browser.pause(500);
+  }
+
+  /**
+   * Set temperature in the generation settings sheet (must be open).
+   * Scrolls to the temperature input and sets the value.
+   */
+  async setTemperature(value: string): Promise<void> {
+    await Gestures.scrollInSheetToElement(
+      Selectors.generationSettings.temperatureInput,
+      3,
+    );
+    const input = browser.$(Selectors.generationSettings.temperatureInput);
+    await input.waitForDisplayed({timeout: 5000});
+    await input.clearValue();
+    await input.setValue(value);
+    await this.dismissKeyboard();
+  }
+
+  /**
+   * Set seed in the generation settings sheet (must be open).
+   * Scrolls to the seed input and sets the value.
+   */
+  async setSeed(value: string): Promise<void> {
+    await Gestures.scrollInSheetToElement(
+      Selectors.generationSettings.seedInput,
+      10,
+    );
+    const input = browser.$(Selectors.generationSettings.seedInput);
+    await input.waitForDisplayed({timeout: 5000});
+    await input.clearValue();
+    await input.setValue(value);
+    await this.dismissKeyboard();
+  }
+
+  /**
+   * Save generation settings (taps Save or Save changes button)
+   */
+  async saveGenerationSettings(): Promise<void> {
+    // Dismiss keyboard first - it may be covering the Save button
+    await this.dismissKeyboard();
+    await browser.pause(500);
+
+    // Try "Save changes" first (preset context), fallback to "Save" (session)
+    const saveChangesBtn = browser.$(
+      Selectors.generationSettings.saveChangesButton,
+    );
+    if (await saveChangesBtn.isDisplayed().catch(() => false)) {
+      await saveChangesBtn.click();
+    } else {
+      const saveBtn = browser.$(Selectors.generationSettings.saveButton);
+      await saveBtn.waitForDisplayed({timeout: 5000});
+      await saveBtn.click();
+    }
+    await browser.pause(500);
   }
 }

--- a/e2e/scripts/run-e2e.ts
+++ b/e2e/scripts/run-e2e.ts
@@ -514,6 +514,29 @@ function buildApps(
 // WDIO Config Selection
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve a spec name to its file path.
+ * Checks specs/{name}.spec.ts first, then specs/features/{name}.spec.ts.
+ */
+function resolveSpecPath(spec: string): string {
+  if (spec === 'all') {
+    return '';
+  }
+
+  const direct = path.join(E2E_DIR, 'specs', `${spec}.spec.ts`);
+  if (fs.existsSync(direct)) {
+    return `specs/${spec}.spec.ts`;
+  }
+
+  const feature = path.join(E2E_DIR, 'specs', 'features', `${spec}.spec.ts`);
+  if (fs.existsSync(feature)) {
+    return `specs/features/${spec}.spec.ts`;
+  }
+
+  // Fallback: assume top-level (WDIO will report the error if missing)
+  return `specs/${spec}.spec.ts`;
+}
+
 function getWdioConfig(
   platform: 'ios' | 'android',
   mode: 'local' | 'device-farm',
@@ -597,7 +620,7 @@ function runSingleTest(opts: {
   const startTime = Date.now();
 
   const configFile = getWdioConfig(platform, mode);
-  const specArg = spec === 'all' ? '' : `--spec specs/${spec}.spec.ts`;
+  const specArg = spec === 'all' ? '' : `--spec ${resolveSpecPath(spec)}`;
   const label = getRunLabel(device, model, platform);
 
   // Per-run report subdirectory
@@ -925,7 +948,7 @@ function printDryRun(
         runIndex++;
         const configFile = getWdioConfig(platform, args.mode);
         const specArg =
-          args.spec === 'all' ? '' : `--spec specs/${args.spec}.spec.ts`;
+          args.spec === 'all' ? '' : `--spec ${resolveSpecPath(args.spec)}`;
         const port = BASE_APPIUM_PORT + portIndex;
         const label = getRunLabel(device, model, platform);
 

--- a/e2e/specs/features/language.spec.ts
+++ b/e2e/specs/features/language.spec.ts
@@ -11,11 +11,11 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import {ChatPage} from '../pages/ChatPage';
-import {DrawerPage} from '../pages/DrawerPage';
-import {SettingsPage} from '../pages/SettingsPage';
-import {byText, byStaticText} from '../helpers/selectors';
-import {SCREENSHOT_DIR} from '../wdio.shared.conf';
+import {ChatPage} from '../../pages/ChatPage';
+import {DrawerPage} from '../../pages/DrawerPage';
+import {SettingsPage} from '../../pages/SettingsPage';
+import {byText, byStaticText} from '../../helpers/selectors';
+import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
 
 declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;

--- a/e2e/specs/features/thinking.spec.ts
+++ b/e2e/specs/features/thinking.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Thinking Model Feature Tests
+ *
+ * Tests thinking toggle behavior with a thinking-capable model (qwen3-0.6b).
+ * Validates:
+ * - Thinking toggle is visible and enabled by default
+ * - Thinking bubble ("Reasoning") appears during inference
+ * - AI produces a textual response
+ * - Toggling thinking off suppresses the thinking bubble
+ *
+ * Usage:
+ *   yarn e2e:ios --spec thinking --skip-build
+ *   yarn e2e:android --spec thinking --skip-build
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {expect} from '@wdio/globals';
+import {ChatPage} from '../../pages/ChatPage';
+import {Selectors, nativeTextElement} from '../../helpers/selectors';
+import {
+  downloadAndLoadModel,
+  waitForInferenceComplete,
+} from '../../helpers/model-actions';
+import {TIMEOUTS} from '../../fixtures/models';
+import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
+
+declare const driver: WebdriverIO.Browser;
+declare const browser: WebdriverIO.Browser;
+
+/** Qwen3-0.6B: small thinking-capable model */
+const THINKING_MODEL = {
+  id: 'qwen3-0.6b',
+  searchQuery: 'bartowski Qwen_Qwen3-0.6B',
+  selectorText: 'Qwen_Qwen3-0.6B',
+  downloadFile: 'Qwen_Qwen3-0.6B-Q4_0.gguf',
+  prompts: [{input: "What's up?", description: 'Casual greeting'}],
+};
+
+describe('Thinking Model Features', () => {
+  let chatPage: ChatPage;
+
+  before(async () => {
+    chatPage = new ChatPage();
+    await chatPage.waitForReady(TIMEOUTS.appReady);
+
+    // Set temperature=0 and seed=1 for deterministic output before loading model
+    await chatPage.openGenerationSettings();
+    await chatPage.setTemperature('0');
+    await chatPage.setSeed('1');
+    await chatPage.saveGenerationSettings();
+
+    // Download and load the thinking model
+    await downloadAndLoadModel(THINKING_MODEL);
+  });
+
+  beforeEach(async () => {
+    chatPage = new ChatPage();
+  });
+
+  afterEach(async function (this: Mocha.Context) {
+    if (this.currentTest?.state === 'failed') {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const testName = this.currentTest.title.replace(/\s+/g, '-');
+      try {
+        if (!fs.existsSync(SCREENSHOT_DIR)) {
+          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
+        }
+        await driver.saveScreenshot(
+          path.join(SCREENSHOT_DIR, `failure-${testName}-${timestamp}.png`),
+        );
+      } catch (e) {
+        console.error('Failed to capture screenshot:', (e as Error).message);
+      }
+    }
+  });
+
+  it('thinking toggle should be visible and enabled by default', async () => {
+    const isVisible = await chatPage.isThinkingToggleVisible();
+    expect(isVisible).toBe(true);
+
+    const isEnabled = await chatPage.isThinkingEnabled();
+    expect(isEnabled).toBe(true);
+  });
+
+  it('should show thinking bubble and produce a response', async () => {
+    await chatPage.resetChat();
+    await chatPage.sendMessage("What's up?");
+
+    // Wait for the AI message to appear
+    const aiMessageEl = browser.$(Selectors.chat.aiMessage);
+    await aiMessageEl.waitForExist({timeout: TIMEOUTS.inference});
+
+    // The thinking bubble ("Reasoning") should appear during or after inference
+    const thinkingVisible = await chatPage.isThinkingBubbleVisible(
+      TIMEOUTS.inference,
+    );
+    expect(thinkingVisible).toBe(true);
+
+    // Wait for inference to complete
+    const timingText = await waitForInferenceComplete();
+    console.log(`Thinking test timing: ${timingText}`);
+
+    // Verify there's a text response from the AI
+    const aiMessage = browser.$(Selectors.chat.aiMessage);
+    const textView = aiMessage.$(nativeTextElement());
+    const responseText = await textView
+      .getText()
+      .catch(() => 'Unable to extract');
+    console.log(`Response: ${responseText}`);
+    expect(responseText).not.toBe('Unable to extract');
+    expect(responseText.length).toBeGreaterThan(0);
+  });
+
+  it('should not show thinking bubble when thinking is toggled off', async () => {
+    // Reset chat first - new session resets thinking toggle to default (on)
+    await chatPage.resetChat();
+
+    // Now disable thinking in the new session
+    await chatPage.tapThinkingToggle();
+    const isEnabled = await chatPage.isThinkingEnabled();
+    expect(isEnabled).toBe(false);
+
+    // Send message with thinking disabled
+    await chatPage.sendMessage("What's up?");
+
+    // Wait for AI message to appear
+    const aiMessageEl = browser.$(Selectors.chat.aiMessage);
+    await aiMessageEl.waitForExist({timeout: TIMEOUTS.inference});
+
+    // Wait for inference to complete
+    await waitForInferenceComplete();
+
+    // Thinking bubble should NOT be visible
+    const thinkingVisible = await chatPage.isThinkingBubbleVisible(3000);
+    expect(thinkingVisible).toBe(false);
+
+    // Re-enable thinking for subsequent tests
+    await chatPage.tapThinkingToggle();
+  });
+});


### PR DESCRIPTION
## Summary
- Add thinking model feature tests (thinking toggle, reasoning bubble, toggle-off behavior) using Qwen3-0.6B
- Organize feature specs into `specs/features/` subdirectory with transparent path resolution (`--spec thinking` just works)
- Extract reusable `model-actions` helper (`downloadAndLoadModel`, `waitForInferenceComplete`) to reduce duplication
- Fix `dismissKeyboard()` for iOS numeric keyboards — guard with `isKeyboardShown()` and tap sheet content area instead of backdrop
- Fix "Save Changes" selector case mismatch

## Test plan
- [x] `yarn e2e:android --spec thinking --skip-build` passes
- [x] `yarn e2e:ios --spec thinking --skip-build` passes
- [x] `yarn e2e --platform ios --spec thinking --skip-build --dry-run` resolves correct spec path
- [x] `yarn typecheck` passes in e2e/
- [x] Verify existing specs still work (`--spec quick-smoke`, `--spec language`)
