### PR TITLE
Fix benchmark screen hang when no models downloaded

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -50,9 +50,14 @@ export const Menu: React.FC<MenuProps> & {
   const handleSubmenuOpen = () => setHasActiveSubmenu(true);
   const handleSubmenuClose = () => setHasActiveSubmenu(false);
 
+  // Guard: don't open menu with no children (prevents PaperMenu layout hang)
+  const effectiveVisible =
+    menuProps.visible && React.Children.toArray(children).length > 0;
+
   return (
     <PaperMenu
       {...menuProps}
+      visible={effectiveVisible}
       style={[
         styles.menu,
         hasActiveSubmenu && styles.menuWithSubmenu,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1028,7 +1028,8 @@
   "benchmark": {
     "title": "Benchmark",
     "modelSelector": {
-      "prompt": "Select Model"
+      "prompt": "Select Model",
+      "noModels": "No models downloaded"
     },
     "buttons": {
       "advancedSettings": "Advanced Settings",

--- a/src/screens/BenchmarkScreen/BenchmarkScreen.tsx
+++ b/src/screens/BenchmarkScreen/BenchmarkScreen.tsx
@@ -312,16 +312,24 @@ export const BenchmarkScreen: React.FC = observer(() => {
             l10n.benchmark.modelSelector.prompt}
         </Button>
       }>
-      {modelStore.availableModels.map(model => (
+      {modelStore.availableModels.length === 0 ? (
         <Menu.Item
-          key={model.id}
-          onPress={() => handleModelSelect(model)}
-          label={model.name}
-          leadingIcon={
-            model.id === modelStore.activeModelId ? 'check' : undefined
-          }
+          key="no-models"
+          label={l10n.benchmark.modelSelector.noModels}
+          disabled
         />
-      ))}
+      ) : (
+        modelStore.availableModels.map(model => (
+          <Menu.Item
+            key={model.id}
+            onPress={() => handleModelSelect(model)}
+            label={model.name}
+            leadingIcon={
+              model.id === modelStore.activeModelId ? 'check' : undefined
+            }
+          />
+        ))
+      )}
     </Menu>
   );
 

--- a/src/screens/BenchmarkScreen/__tests__/BenchmarkScreen.test.tsx
+++ b/src/screens/BenchmarkScreen/__tests__/BenchmarkScreen.test.tsx
@@ -96,6 +96,22 @@ describe('BenchmarkScreen', () => {
       });
     });
 
+    it('should show placeholder when no models are available', () => {
+      const originalModels = modelStore.models;
+      modelStore.models = [];
+
+      const {getByText} = render(<BenchmarkScreen />);
+
+      // Open model selector
+      fireEvent.press(getByText('Select Model'));
+
+      // Verify placeholder is shown
+      expect(getByText('No models downloaded')).toBeDefined();
+
+      // Restore
+      modelStore.models = originalModels;
+    });
+
     it('should initialize model when selected', async () => {
       const {getByText} = render(<BenchmarkScreen />);
       const modelToSelect = modelStore.availableModels[0];


### PR DESCRIPTION
## Summary

- Show a disabled "No models downloaded" placeholder in the benchmark model selector when no models are available, preventing the app from freezing
- Add a defense-in-depth guard in the `Menu` component wrapper to force `visible={false}` when the menu has zero valid children, preventing PaperMenu's infinite layout loop app-wide
- Add l10n key `benchmark.modelSelector.noModels` for the placeholder text

Closes #586

## Details

The root cause is that react-native-paper's `Menu` component enters an infinite layout/measurement loop when opened with zero children. The fix addresses this at two levels:

1. **BenchmarkScreen** (`src/screens/BenchmarkScreen/BenchmarkScreen.tsx`): Renders a disabled `Menu.Item` placeholder when `modelStore.availableModels` is empty
2. **Menu wrapper** (`src/components/Menu/Menu.tsx`): Computes `effectiveVisible` using `React.Children.toArray(children).length > 0` to guard against the zero-children hang for any Menu usage across the app
3. **l10n** (`src/locales/en.json`): Added `benchmark.modelSelector.noModels` key

## Test plan

- [x] New test: "should show placeholder when no models are available" (22/22 BenchmarkScreen tests pass)
- [x] All 353 Menu-related tests pass (37 suites)
- [x] Lint: 0 errors (16 pre-existing warnings)
- [x] TypeCheck: passes
- [x] No native changes required

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)