### PR TITLE
Upgrade llama.rn to 0.11.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.11.0):
+  - llama-rn (0.11.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3655,7 +3655,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 6b65dfb9c61c93aa1c0f5ed55d0febcf3c3b6cc5
+  llama-rn: f88cb4425f70567f2da0552d122458a2033bc6b4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.11.0",
+    "llama.rn": "0.11.3",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,10 +6500,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.0.tgz#62efab6571a102b1f01052e484d5cd0d924607a0"
-  integrity sha512-FLQwBdg1n7H9lqnQinOSv0Cly7Du1NEhMktaNJDGGsMEd/qFG0l8Iwyqsk8c2ZIIn2b6C4FPUCL2yDvlL41IBw==
+llama.rn@0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.3.tgz#a4720b58e075ca8a8d06b082871eb963db67b8ca"
+  integrity sha512-op4re/djQDYmtnxdO1FwdkJQsXsPIYHfrvr03nIFbxNzhVyMiFi96+c84+P6t9/Cxuxe4ckAJaMsqfGpK2j/Nw==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Upgrades `llama.rn` from `0.11.0` to `0.11.3` (latest stable)
- Versions 0.11.1-0.11.3 contain llama.cpp upstream syncs and an Android build fix
- No API changes -- drop-in version bump

## Changes
- `package.json`: version bump `0.11.0` -> `0.11.3`
- `yarn.lock`: auto-updated
- `ios/Podfile.lock`: auto-updated via `pod install`

## Verification
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors)
- [x] `pod install` succeeds
- [x] iOS Release build succeeds
- [x] Android Release build (via CI)

## Test plan
- [x] CI passes (Android build, lint, typecheck)
- [x] E2E smoke test verifies native library loads and runs inference

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)