### PR TITLE
feat: add pinned/starred chat sessions

### DIFF
--- a/__mocks__/repositories/ChatSessionRepository.js
+++ b/__mocks__/repositories/ChatSessionRepository.js
@@ -113,8 +113,9 @@ class ChatSessionRepository {
     return; // Mock: do nothing
   }
 
-  async toggleSessionPinned(sessionId) {
-    return true; // Mock: return new pinned state
+  async setSessionPinned(sessionId, pinned) {
+    this._pinned = this._pinned || {};
+    this._pinned[sessionId] = pinned;
   }
 
   // Update session completion settings

--- a/__mocks__/repositories/ChatSessionRepository.js
+++ b/__mocks__/repositories/ChatSessionRepository.js
@@ -113,6 +113,10 @@ class ChatSessionRepository {
     return; // Mock: do nothing
   }
 
+  async toggleSessionPinned(sessionId) {
+    return true; // Mock: return new pinned state
+  }
+
   // Update session completion settings
   async updateSessionCompletionSettings(sessionId, settings) {
     return; // Mock: do nothing

--- a/__mocks__/stores/chatSessionStore.ts
+++ b/__mocks__/stores/chatSessionStore.ts
@@ -89,7 +89,9 @@ export const mockChatSessionStore = {
   deselectAllSessions: jest.fn(),
   bulkDeleteSessions: jest.fn().mockResolvedValue(undefined),
   bulkExportSessions: jest.fn().mockResolvedValue(undefined),
+  togglePinSession: jest.fn().mockResolvedValue(undefined),
   dateGroupNames: {
+    pinned: 'Pinned',
     today: 'Today',
     yesterday: 'Yesterday',
     thisWeek: 'This week',

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -18,6 +18,7 @@ import {
   PalIcon,
   SettingsIcon,
   ShareIcon,
+  StarIcon,
   TrashIcon,
   AppInfoIcon,
 } from '../../assets/icons';
@@ -33,11 +34,13 @@ const isDebugMode = __DEV__;
 interface SessionItemProps {
   session: SessionMetaData;
   isActive: boolean;
+  isPinned: boolean;
   onPress: (sessionId: string) => void;
   onLongPress: (sessionId: string, event: any) => void;
   menuVisible: string | null;
   menuPosition: {x: number; y: number};
   onMenuDismiss: () => void;
+  onPressPin: (sessionId: string) => void;
   onPressRename: (session: SessionMetaData) => void;
   onPressDelete: (sessionId: string) => void;
   onPressExport: (sessionId: string) => void;
@@ -55,11 +58,13 @@ const SessionItem = React.memo<SessionItemProps>(
   ({
     session,
     isActive,
+    isPinned,
     onPress,
     onLongPress,
     menuVisible,
     menuPosition,
     onMenuDismiss,
+    onPressPin,
     onPressRename,
     onPressDelete,
     onPressExport,
@@ -114,6 +119,23 @@ const SessionItem = React.memo<SessionItemProps>(
             style={styles.menu}
             contentStyle={{}}
             anchorPosition="bottom">
+            <Menu.Item
+              onPress={() => {
+                onPressPin(session.id);
+                onMenuDismiss();
+              }}
+              label={
+                isPinned
+                  ? l10n.components.sidebarContent.unpin
+                  : l10n.components.sidebarContent.pin
+              }
+              leadingIcon={() => (
+                <StarIcon
+                  stroke={theme.colors.primary}
+                  fill={isPinned ? theme.colors.primary : 'none'}
+                />
+              )}
+            />
             <Menu.Item
               onPress={() => {
                 onPressRename(session);
@@ -349,6 +371,10 @@ export const SidebarContent: React.FC<DrawerContentComponentProps> = observer(
       [l10n, closeMenu],
     );
 
+    const handlePressPin = React.useCallback(async (sessionId: string) => {
+      await chatSessionStore.togglePinSession(sessionId);
+    }, []);
+
     const handlePressExport = React.useCallback(
       async (sessionId: string) => {
         try {
@@ -449,11 +475,13 @@ export const SidebarContent: React.FC<DrawerContentComponentProps> = observer(
           <SessionItem
             session={item}
             isActive={isActive}
+            isPinned={item.pinned || false}
             onPress={handleSessionPress}
             onLongPress={handleSessionLongPress}
             menuVisible={menuVisible}
             menuPosition={menuPosition}
             onMenuDismiss={closeMenu}
+            onPressPin={handlePressPin}
             onPressRename={handlePressRename}
             onPressDelete={onPressDelete}
             onPressExport={handlePressExport}
@@ -473,6 +501,7 @@ export const SidebarContent: React.FC<DrawerContentComponentProps> = observer(
         menuVisible,
         menuPosition,
         closeMenu,
+        handlePressPin,
         handlePressRename,
         onPressDelete,
         handlePressExport,

--- a/src/components/SidebarContent/SidebarContent.tsx
+++ b/src/components/SidebarContent/SidebarContent.tsx
@@ -109,6 +109,17 @@ const SessionItem = React.memo<SessionItemProps>(
             active={isActive}
             label={session.title}
             style={styles.sessionDrawerItem}
+            right={
+              isPinned
+                ? () => (
+                    <StarIcon
+                      width={14}
+                      height={14}
+                      fill={theme.colors.primary}
+                    />
+                  )
+                : undefined
+            }
           />
         </TouchableOpacity>
         {!isSelectionMode && (
@@ -120,6 +131,7 @@ const SessionItem = React.memo<SessionItemProps>(
             contentStyle={{}}
             anchorPosition="bottom">
             <Menu.Item
+              testID={`session-pin-${session.id}`}
               onPress={() => {
                 onPressPin(session.id);
                 onMenuDismiss();
@@ -131,11 +143,18 @@ const SessionItem = React.memo<SessionItemProps>(
               }
               leadingIcon={() => (
                 <StarIcon
-                  stroke={theme.colors.primary}
-                  fill={isPinned ? theme.colors.primary : 'none'}
+                  width={20}
+                  height={20}
+                  // star.svg is stroke-only and .svgrrc binds that stroke to the
+                  // fill prop, so fill='none' paints nothing. Omitting fill is
+                  // what yields an outline; no test can catch this (svg is mocked).
+                  {...(isPinned
+                    ? {fill: theme.colors.primary}
+                    : {stroke: theme.colors.primary})}
                 />
               )}
             />
+            <Divider style={styles.menuDivider} />
             <Menu.Item
               onPress={() => {
                 onPressRename(session);

--- a/src/components/SidebarContent/__tests__/SidebarContent.pinned.test.tsx
+++ b/src/components/SidebarContent/__tests__/SidebarContent.pinned.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {Text} from 'react-native';
+import {runInAction} from 'mobx';
+
+import {NavigationContainer} from '@react-navigation/native';
+import {
+  createDrawerNavigator,
+  DrawerContentComponentProps,
+} from '@react-navigation/drawer';
+// Uses the repo render helper because paper's Menu renders through a Portal and
+// needs PaperProvider at the root.
+import {render, fireEvent} from '../../../../jest/test-utils';
+
+import {SidebarContent} from '../SidebarContent';
+
+import {chatSessionStore} from '../../../store';
+
+// The shared `.svg` mock is the string 'SvgMock', so every icon re-exported
+// from assets/icons resolves to undefined and rendering the context menu
+// throws. Map each icon to a host-component name so the menu can mount.
+jest.mock(
+  '../../../assets/icons',
+  () =>
+    new Proxy(
+      {__esModule: true},
+      {
+        get: (target: Record<string, unknown>, prop: string) =>
+          prop in target ? target[prop] : String(prop),
+      },
+    ),
+);
+
+const ChatScreen = () => <Text>Chat Screen</Text>;
+const Drawer = createDrawerNavigator();
+
+const renderSidebarContent = (props: DrawerContentComponentProps) => (
+  <SidebarContent {...props} />
+);
+
+const TestNavigator = () => (
+  <NavigationContainer>
+    <Drawer.Navigator drawerContent={renderSidebarContent}>
+      <Drawer.Screen name="Chat" component={ChatScreen} />
+    </Drawer.Navigator>
+  </NavigationContainer>
+);
+
+const openMenuFor = (getByText: (text: string) => any, title: string) => {
+  fireEvent(getByText(title), 'longPress', {
+    nativeEvent: {pageX: 0, pageY: 0},
+  });
+};
+
+// groupedSessions is a getter on the real store, so the mock's plain-object
+// stand-in needs a mutable view to seed a pinned group.
+const mockStore = chatSessionStore as unknown as {
+  groupedSessions: Record<string, any[]>;
+};
+
+describe('SidebarContent pin/unpin menu item', () => {
+  const originalGroups = mockStore.groupedSessions;
+
+  beforeEach(() => {
+    runInAction(() => {
+      chatSessionStore.isSelectionMode = false;
+    });
+  });
+
+  afterEach(() => {
+    runInAction(() => {
+      mockStore.groupedSessions = originalGroups;
+    });
+  });
+
+  it('offers Pin and toggles the long-pressed session', () => {
+    const {getByText, getByTestId} = render(<TestNavigator />);
+
+    openMenuFor(getByText, 'Session 1');
+
+    expect(getByText('Pin')).toBeTruthy();
+    fireEvent.press(getByTestId('session-pin-session-1'));
+
+    expect(chatSessionStore.togglePinSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('offers Unpin for a session that is already pinned', () => {
+    runInAction(() => {
+      mockStore.groupedSessions = {
+        Pinned: [{...originalGroups.Today[0], pinned: true}],
+      };
+    });
+
+    const {getByText} = render(<TestNavigator />);
+
+    expect(getByText('Pinned')).toBeTruthy();
+    openMenuFor(getByText, 'Session 1');
+
+    expect(getByText('Unpin')).toBeTruthy();
+  });
+});

--- a/src/database/__tests__/schema.test.ts
+++ b/src/database/__tests__/schema.test.ts
@@ -1,0 +1,62 @@
+import migrations from '../migrations';
+import schema from '../schema';
+
+// The watermelondb mock's `addColumns` takes (table, columns) where the real API
+// takes a single {table, columns} object, so a mocked step nests the payload
+// under `step.table`. Unwrap either shape.
+function stepPayload(step: any): {table: string; columns: any[]} {
+  return typeof step.table === 'object' ? step.table : step;
+}
+
+const migrationList: any[] = (migrations as any).migrations;
+
+describe('database schema and migrations agree', () => {
+  it('schema version equals the highest migration toVersion', () => {
+    const maxToVersion = Math.max(...migrationList.map(m => m.toVersion));
+    expect((schema as any).version).toBe(maxToVersion);
+  });
+
+  it('migration toVersions are contiguous and start at 2', () => {
+    const versions = migrationList.map(m => m.toVersion).sort((a, b) => a - b);
+    expect(versions[0]).toBe(2);
+    versions.forEach((version, index) => {
+      expect(version).toBe(index + 2);
+    });
+  });
+
+  it('every added column exists in the schema with a matching definition', () => {
+    const tables: Record<string, any> = {};
+    for (const table of (schema as any).tables) {
+      tables[table.name] = table;
+    }
+
+    for (const migration of migrationList) {
+      for (const step of migration.steps) {
+        if (step.type !== 'add_columns') {
+          continue;
+        }
+        const {table, columns} = stepPayload(step);
+
+        expect(tables[table]).toBeDefined();
+
+        for (const column of columns) {
+          const declared = tables[table].columns.find(
+            (c: any) => c.name === column.name,
+          );
+          expect(declared).toBeDefined();
+          expect(declared.type).toBe(column.type);
+          expect(Boolean(declared.isOptional)).toBe(Boolean(column.isOptional));
+        }
+      }
+    }
+  });
+
+  it('declares pinned on chat_sessions as a non-optional boolean', () => {
+    const chatSessions = (schema as any).tables.find(
+      (t: any) => t.name === 'chat_sessions',
+    );
+    const pinned = chatSessions.columns.find((c: any) => c.name === 'pinned');
+
+    expect(pinned).toEqual({name: 'pinned', type: 'boolean'});
+  });
+});

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -143,5 +143,15 @@ export default schemaMigrations({
         }),
       ],
     },
+    // Migration to version 8: Add pinned column to chat_sessions
+    {
+      toVersion: 8,
+      steps: [
+        addColumns({
+          table: 'chat_sessions',
+          columns: [{name: 'pinned', type: 'boolean'}],
+        }),
+      ],
+    },
   ],
 });

--- a/src/database/models/ChatSession.ts
+++ b/src/database/models/ChatSession.ts
@@ -16,6 +16,7 @@ export default class ChatSession extends Model {
   @text('date') date!: string;
   @text('active_pal_id') activePalId?: string;
   @text('settings_source') settingsSource?: string;
+  @field('pinned') pinned!: boolean;
   @field('created_at') createdAt!: number;
   @field('updated_at') updatedAt!: number;
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -1,7 +1,7 @@
 import {appSchema, tableSchema} from '@nozbe/watermelondb';
 
 export default appSchema({
-  version: 7,
+  version: 8,
   tables: [
     tableSchema({
       name: 'chat_sessions',
@@ -10,6 +10,7 @@ export default appSchema({
         {name: 'date', type: 'string'},
         {name: 'active_pal_id', type: 'string', isOptional: true},
         {name: 'settings_source', type: 'string', isOptional: true},
+        {name: 'pinned', type: 'boolean'},
         {name: 'created_at', type: 'number'},
         {name: 'updated_at', type: 'number'},
       ],

--- a/src/locales/__tests__/locales.test.ts
+++ b/src/locales/__tests__/locales.test.ts
@@ -434,3 +434,23 @@ describe('t() interpolation helper', () => {
     expect(result).toBe('{{a}} and {{b}}');
   });
 });
+
+// ChatSessionStore.groupedSessions keys its result map by these translated
+// labels, so two equal values silently drop a whole group from the sidebar and
+// an empty one renders a blank header. Nothing else guards that.
+describe('sidebar date-group labels stay usable as map keys', () => {
+  it.each(ALL_LANGUAGES)(
+    'l10n.%s dateGroups are distinct and non-empty',
+    lang => {
+      const dateGroups = l10n[lang].components.sidebarContent.dateGroups;
+      const values = Object.values(dateGroups);
+
+      for (const value of values) {
+        expect(typeof value).toBe('string');
+        expect(value.trim()).not.toBe('');
+      }
+
+      expect(new Set(values).size).toBe(values.length);
+    },
+  );
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -971,7 +971,10 @@
       "bulkDeleteError": "Failed to delete chat sessions. Please try again.",
       "exportError": "Failed to export chat session. Please try again.",
       "bulkExportError": "Failed to export chat sessions. Please try again.",
+      "pin": "Pin",
+      "unpin": "Unpin",
       "dateGroups": {
+        "pinned": "Pinned",
         "today": "Today",
         "yesterday": "Yesterday",
         "thisWeek": "This week",

--- a/src/repositories/ChatSessionRepository.ts
+++ b/src/repositories/ChatSessionRepository.ts
@@ -634,26 +634,19 @@ class ChatSessionRepository {
     });
   }
 
-  // Toggle pinned status for a session
-  async toggleSessionPinned(sessionId: string): Promise<boolean> {
+  // Set pinned status for a session.
+  // Deliberately does not swallow a missing record the way the sibling setters
+  // do: the store must not mirror a pin it could not persist.
+  async setSessionPinned(sessionId: string, pinned: boolean): Promise<void> {
     const session = await database.collections
       .get('chat_sessions')
-      .find(sessionId)
-      .catch(() => null);
-
-    if (!session) {
-      return false;
-    }
-
-    const newPinned = !(session as unknown as ChatSession).pinned;
+      .find(sessionId);
 
     await database.write(async () => {
       await session.update((record: any) => {
-        record.pinned = newPinned;
+        record.pinned = pinned;
       });
     });
-
-    return newPinned;
   }
 
   // Set active pal for a session

--- a/src/repositories/ChatSessionRepository.ts
+++ b/src/repositories/ChatSessionRepository.ts
@@ -634,6 +634,28 @@ class ChatSessionRepository {
     });
   }
 
+  // Toggle pinned status for a session
+  async toggleSessionPinned(sessionId: string): Promise<boolean> {
+    const session = await database.collections
+      .get('chat_sessions')
+      .find(sessionId)
+      .catch(() => null);
+
+    if (!session) {
+      return false;
+    }
+
+    const newPinned = !(session as unknown as ChatSession).pinned;
+
+    await database.write(async () => {
+      await session.update((record: any) => {
+        record.pinned = newPinned;
+      });
+    });
+
+    return newPinned;
+  }
+
   // Set active pal for a session
   async setSessionActivePal(sessionId: string, palId?: string): Promise<void> {
     const session = await database.collections

--- a/src/repositories/__tests__/ChatSessionRepository.pinned.test.ts
+++ b/src/repositories/__tests__/ChatSessionRepository.pinned.test.ts
@@ -1,0 +1,105 @@
+// jest/setup.ts globally replaces this module with
+// __mocks__/repositories/ChatSessionRepository.js, so the unmock +
+// requireActual below are load-bearing: without them every assertion here
+// would pass against a stub that always reports success.
+const mockFind = jest.fn();
+const mockWrite = jest.fn();
+
+jest.mock('../../database', () => ({
+  database: {
+    write: (callback: () => Promise<void>) => mockWrite(callback),
+    collections: {
+      get: () => ({
+        find: (id: string) => mockFind(id),
+      }),
+    },
+  },
+}));
+
+jest.unmock('../ChatSessionRepository');
+
+const {chatSessionRepository} = jest.requireActual('../ChatSessionRepository');
+
+function makeRecord(pinned: boolean) {
+  const record: {
+    pinned: boolean;
+    update: (m: (r: any) => void) => Promise<void>;
+  } = {
+    pinned,
+    update: async mutator => {
+      mutator(record);
+    },
+  };
+  return record;
+}
+
+describe('ChatSessionRepository.setSessionPinned', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWrite.mockImplementation(async (callback: () => Promise<void>) =>
+      callback(),
+    );
+  });
+
+  it('persists pinned=true', async () => {
+    const record = makeRecord(false);
+    mockFind.mockResolvedValue(record);
+
+    await chatSessionRepository.setSessionPinned('session1', true);
+
+    expect(mockFind).toHaveBeenCalledWith('session1');
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(record.pinned).toBe(true);
+  });
+
+  it('persists pinned=false', async () => {
+    const record = makeRecord(true);
+    mockFind.mockResolvedValue(record);
+
+    await chatSessionRepository.setSessionPinned('session1', false);
+
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    expect(record.pinned).toBe(false);
+  });
+
+  // Guards the lost-toggle defect: an absolute setter must never derive the
+  // written value from the stored one, so a stale read cannot swallow a tap.
+  it('writes the value it was given rather than negating the stored value', async () => {
+    const record = makeRecord(true);
+    mockFind.mockResolvedValue(record);
+
+    await chatSessionRepository.setSessionPinned('session1', true);
+
+    expect(record.pinned).toBe(true);
+  });
+
+  it('applies each of two overlapping calls independently', async () => {
+    const written: boolean[] = [];
+    const record = makeRecord(false);
+    record.update = async mutator => {
+      mutator(record);
+      written.push(record.pinned);
+    };
+    mockFind.mockResolvedValue(record);
+
+    await Promise.all([
+      chatSessionRepository.setSessionPinned('session1', true),
+      chatSessionRepository.setSessionPinned('session1', false),
+    ]);
+
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+    expect(written).toEqual([true, false]);
+  });
+
+  // Guards the silent-unpin defect: a missing row must be distinguishable from
+  // a successful unpin, so the store can decline to mirror an unconfirmed write.
+  it('rejects and performs no write when the session is missing', async () => {
+    mockFind.mockRejectedValue(new Error('Record not found'));
+
+    await expect(
+      chatSessionRepository.setSessionPinned('missing', true),
+    ).rejects.toThrow();
+
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -1,5 +1,5 @@
 import {makeAutoObservable, runInAction} from 'mobx';
-import {format, isToday, isYesterday} from 'date-fns';
+import {isToday, isYesterday} from 'date-fns';
 import * as RNFS from '@dr.pogodin/react-native-fs';
 
 import {
@@ -1135,14 +1135,13 @@ class ChatSessionStore {
   }
 
   get groupedSessions(): SessionGroup {
-    // Separate pinned and unpinned sessions
     const pinnedSessions = this.sessions.filter(s => s.pinned);
     const unpinnedSessions = this.sessions.filter(s => !s.pinned);
 
     const groups: SessionGroup = unpinnedSessions.reduce(
       (acc: SessionGroup, session) => {
         const date = new Date(session.date);
-        let dateKey: string = format(date, 'MMMM dd, yyyy');
+        let dateKey: string;
         const today = new Date();
         const daysAgo = Math.ceil(
           (today.getTime() - date.getTime()) / (1000 * 3600 * 24),
@@ -1190,7 +1189,6 @@ class ChatSessionStore {
       this.dateGroupNames.older,
     ];
 
-    // Build ordered result, starting with Pinned if any exist
     const orderedGroups: SessionGroup = {};
 
     if (pinnedSessions.length > 0) {
@@ -1455,16 +1453,18 @@ class ChatSessionStore {
   }
 
   async togglePinSession(sessionId: string): Promise<void> {
-    try {
-      const newPinned =
-        await chatSessionRepository.toggleSessionPinned(sessionId);
+    const session = this.sessions.find(s => s.id === sessionId);
+    if (!session) {
+      return;
+    }
 
-      const session = this.sessions.find(s => s.id === sessionId);
-      if (session) {
-        runInAction(() => {
-          session.pinned = newPinned;
-        });
-      }
+    const pinned = !session.pinned;
+
+    try {
+      await chatSessionRepository.setSessionPinned(sessionId, pinned);
+      runInAction(() => {
+        session.pinned = pinned;
+      });
     } catch (error) {
       console.error('Failed to toggle pin session:', error);
     }

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -43,6 +43,7 @@ export interface SessionMetaData {
   messages: MessageType.Any[];
   completionSettings: CompletionParams;
   activePalId?: string;
+  pinned?: boolean;
   settingsSource: 'pal' | 'custom'; // Explicit choice: use pal settings or custom settings
   messagesLoaded?: boolean; // Track if messages are loaded for lazy loading
 }
@@ -53,6 +54,7 @@ interface SessionGroup {
 
 // Default group names in English as fallback
 const DEFAULT_GROUP_NAMES = {
+  pinned: 'Pinned',
   today: 'Today',
   yesterday: 'Yesterday',
   thisWeek: 'This week',
@@ -304,6 +306,7 @@ class ChatSessionStore {
           completionSettings,
           activePalId: session.activePalId,
           settingsSource: (session.settingsSource as 'pal' | 'custom') || 'pal',
+          pinned: session.pinned || false,
           messagesLoaded: false, // Mark as not loaded for lazy loading
         });
       }
@@ -598,6 +601,7 @@ class ChatSessionStore {
         messages,
         completionSettings: settings,
         settingsSource: birthSource, // 'custom' if a thinking override was staged, else stored source
+        pinned: false,
         messagesLoaded: true, // Mark as loaded since we have the messages
       };
 
@@ -1131,7 +1135,11 @@ class ChatSessionStore {
   }
 
   get groupedSessions(): SessionGroup {
-    const groups: SessionGroup = this.sessions.reduce(
+    // Separate pinned and unpinned sessions
+    const pinnedSessions = this.sessions.filter(s => s.pinned);
+    const unpinnedSessions = this.sessions.filter(s => !s.pinned);
+
+    const groups: SessionGroup = unpinnedSessions.reduce(
       (acc: SessionGroup, session) => {
         const date = new Date(session.date);
         let dateKey: string = format(date, 'MMMM dd, yyyy');
@@ -1182,8 +1190,15 @@ class ChatSessionStore {
       this.dateGroupNames.older,
     ];
 
-    // Create a new object with keys in the desired order
+    // Build ordered result, starting with Pinned if any exist
     const orderedGroups: SessionGroup = {};
+
+    if (pinnedSessions.length > 0) {
+      orderedGroups[this.dateGroupNames.pinned] = pinnedSessions.sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      );
+    }
+
     orderedKeys.forEach(key => {
       if (groups[key]) {
         orderedGroups[key] = groups[key].sort(
@@ -1436,6 +1451,22 @@ class ChatSessionStore {
       }
     } else {
       this.newChatPalId = palId;
+    }
+  }
+
+  async togglePinSession(sessionId: string): Promise<void> {
+    try {
+      const newPinned =
+        await chatSessionRepository.toggleSessionPinned(sessionId);
+
+      const session = this.sessions.find(s => s.id === sessionId);
+      if (session) {
+        runInAction(() => {
+          session.pinned = newPinned;
+        });
+      }
+    } catch (error) {
+      console.error('Failed to toggle pin session:', error);
     }
   }
 

--- a/src/store/__tests__/ChatSessionStore.test.ts
+++ b/src/store/__tests__/ChatSessionStore.test.ts
@@ -25,7 +25,7 @@ jest.spyOn(chatSessionRepository, 'getGlobalCompletionSettings');
 jest.spyOn(chatSessionRepository, 'saveGlobalCompletionSettings');
 jest.spyOn(chatSessionRepository, 'setSessionActivePal');
 jest.spyOn(chatSessionRepository, 'setSessionSettingsSource');
-jest.spyOn(chatSessionRepository, 'toggleSessionPinned');
+jest.spyOn(chatSessionRepository, 'setSessionPinned');
 
 describe('chatSessionStore', () => {
   const mockMessage = {
@@ -2468,74 +2468,112 @@ describe('chatSessionStore', () => {
   });
 
   describe('pinned sessions', () => {
+    const pinnedSession = (overrides: Record<string, unknown> = {}) => ({
+      id: 'session1',
+      title: 'Test Session',
+      date: new Date().toISOString(),
+      messages: [],
+      completionSettings: defaultCompletionSettings,
+      settingsSource: 'pal' as const,
+      pinned: false,
+      ...overrides,
+    });
+
     describe('togglePinSession', () => {
-      it('pins an unpinned session', async () => {
-        const session = {
-          id: 'session1',
-          title: 'Test Session',
-          date: new Date().toISOString(),
-          messages: [],
-          completionSettings: defaultCompletionSettings,
-          settingsSource: 'pal' as const,
-          pinned: false,
-        };
-
-        chatSessionStore.sessions = [session];
-
-        (
-          chatSessionRepository.toggleSessionPinned as jest.Mock
-        ).mockResolvedValue(true);
+      it('asks the repository for the target state and mirrors it', async () => {
+        chatSessionStore.sessions = [pinnedSession()];
+        (chatSessionRepository.setSessionPinned as jest.Mock).mockResolvedValue(
+          undefined,
+        );
 
         await chatSessionStore.togglePinSession('session1');
 
-        expect(chatSessionRepository.toggleSessionPinned).toHaveBeenCalledWith(
+        expect(chatSessionRepository.setSessionPinned).toHaveBeenCalledWith(
           'session1',
+          true,
         );
         expect(chatSessionStore.sessions[0].pinned).toBe(true);
       });
 
       it('unpins a pinned session', async () => {
-        const session = {
-          id: 'session1',
-          title: 'Test Session',
-          date: new Date().toISOString(),
-          messages: [],
-          completionSettings: defaultCompletionSettings,
-          settingsSource: 'pal' as const,
-          pinned: true,
-        };
-
-        chatSessionStore.sessions = [session];
-
-        (
-          chatSessionRepository.toggleSessionPinned as jest.Mock
-        ).mockResolvedValue(false);
+        chatSessionStore.sessions = [pinnedSession({pinned: true})];
+        (chatSessionRepository.setSessionPinned as jest.Mock).mockResolvedValue(
+          undefined,
+        );
 
         await chatSessionStore.togglePinSession('session1');
 
+        expect(chatSessionRepository.setSessionPinned).toHaveBeenCalledWith(
+          'session1',
+          false,
+        );
         expect(chatSessionStore.sessions[0].pinned).toBe(false);
       });
 
-      it('handles errors gracefully', async () => {
-        chatSessionStore.sessions = [
-          {
-            id: 'session1',
-            title: 'Test Session',
-            date: new Date().toISOString(),
-            messages: [],
-            completionSettings: defaultCompletionSettings,
-            settingsSource: 'pal' as const,
-            pinned: false,
-          },
-        ];
-
-        (
-          chatSessionRepository.toggleSessionPinned as jest.Mock
-        ).mockRejectedValue(new Error('DB error'));
+      // Seeded pinned:true on purpose — seeding false would let an
+      // implementation that writes false in its catch block pass too.
+      it('leaves the pin untouched when the write fails', async () => {
+        chatSessionStore.sessions = [pinnedSession({pinned: true})];
+        (chatSessionRepository.setSessionPinned as jest.Mock).mockRejectedValue(
+          new Error('DB error'),
+        );
 
         await chatSessionStore.togglePinSession('session1');
 
-        // Should remain unchanged on error
+        expect(chatSessionStore.sessions[0].pinned).toBe(true);
+      });
+
+      it('does not touch the store when the row is gone from the database', async () => {
+        chatSessionStore.sessions = [pinnedSession({pinned: true})];
+        (chatSessionRepository.setSessionPinned as jest.Mock).mockRejectedValue(
+          new Error('Record not found'),
+        );
+
+        await chatSessionStore.togglePinSession('session1');
+
+        expect(chatSessionStore.sessions[0].pinned).toBe(true);
+      });
+
+      it('does not write for a session it does not know', async () => {
+        chatSessionStore.sessions = [];
+
+        await chatSessionStore.togglePinSession('nonexistent');
+
+        expect(chatSessionRepository.setSessionPinned).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('persistence across a reload', () => {
+      const loadWithPinned = async (pinned: boolean | undefined) => {
+        const session = {
+          id: '1',
+          title: 'Session 1',
+          date: new Date().toISOString(),
+          pinned,
+        };
+        (chatSessionRepository.getAllSessions as jest.Mock).mockResolvedValue([
+          session,
+        ]);
+        (
+          chatSessionRepository.getSessionMetadataWithSettings as jest.Mock
+        ).mockResolvedValue({
+          session,
+          completionSettings: {getSettings: () => defaultCompletionSettings},
+        });
+
+        await chatSessionStore.loadSessionList();
+      };
+
+      it('hydrates a pinned session as pinned', async () => {
+        await loadWithPinned(true);
+
+        expect(chatSessionStore.sessions[0].pinned).toBe(true);
+        expect(Object.keys(chatSessionStore.groupedSessions)[0]).toBe('Pinned');
+      });
+
+      it('hydrates a session with no stored flag as unpinned', async () => {
+        await loadWithPinned(undefined);
+
         expect(chatSessionStore.sessions[0].pinned).toBe(false);
       });
     });
@@ -2545,52 +2583,33 @@ describe('chatSessionStore', () => {
         const today = new Date();
 
         chatSessionStore.sessions = [
-          {
+          pinnedSession({
             id: '1',
             title: 'Pinned Session',
             date: today.toISOString(),
-            messages: [],
-            completionSettings: defaultCompletionSettings,
-            settingsSource: 'pal' as const,
             pinned: true,
-          },
-          {
+          }),
+          pinnedSession({
             id: '2',
             title: 'Regular Session',
             date: today.toISOString(),
-            messages: [],
-            completionSettings: defaultCompletionSettings,
-            settingsSource: 'pal' as const,
-            pinned: false,
-          },
+          }),
         ];
 
         const grouped = chatSessionStore.groupedSessions;
         const keys = Object.keys(grouped);
 
-        // Pinned should be the first group
         expect(keys[0]).toBe('Pinned');
         expect(grouped.Pinned).toHaveLength(1);
         expect(grouped.Pinned[0].id).toBe('1');
 
-        // Regular session should be in Today
         expect(grouped.Today).toHaveLength(1);
         expect(grouped.Today[0].id).toBe('2');
       });
 
       it('does not show pinned group when no sessions are pinned', () => {
-        const today = new Date();
-
         chatSessionStore.sessions = [
-          {
-            id: '1',
-            title: 'Regular Session',
-            date: today.toISOString(),
-            messages: [],
-            completionSettings: defaultCompletionSettings,
-            settingsSource: 'pal' as const,
-            pinned: false,
-          },
+          pinnedSession({id: '1', date: new Date().toISOString()}),
         ];
 
         const grouped = chatSessionStore.groupedSessions;
@@ -2599,18 +2618,12 @@ describe('chatSessionStore', () => {
       });
 
       it('pinned sessions are excluded from date groups', () => {
-        const today = new Date();
-
         chatSessionStore.sessions = [
-          {
+          pinnedSession({
             id: '1',
-            title: 'Pinned Today',
-            date: today.toISOString(),
-            messages: [],
-            completionSettings: defaultCompletionSettings,
-            settingsSource: 'pal' as const,
+            date: new Date().toISOString(),
             pinned: true,
-          },
+          }),
         ];
 
         const grouped = chatSessionStore.groupedSessions;
@@ -2618,51 +2631,42 @@ describe('chatSessionStore', () => {
         expect(grouped.Today).toBeUndefined();
       });
 
-      it('sorts multiple pinned sessions by date (newest first)', () => {
-        const older = new Date('2024-01-01');
-        const newer = new Date('2024-06-01');
-
+      it('drops the pinned group once the last pinned session is removed', () => {
         chatSessionStore.sessions = [
-          {
+          pinnedSession({
+            id: '1',
+            date: new Date().toISOString(),
+            pinned: true,
+          }),
+        ];
+        expect(chatSessionStore.groupedSessions.Pinned).toHaveLength(1);
+
+        chatSessionStore.sessions = [];
+
+        expect(chatSessionStore.groupedSessions.Pinned).toBeUndefined();
+      });
+
+      it('sorts multiple pinned sessions by date (newest first)', () => {
+        chatSessionStore.sessions = [
+          pinnedSession({
             id: '1',
             title: 'Older Pinned',
-            date: older.toISOString(),
-            messages: [],
-            completionSettings: defaultCompletionSettings,
-            settingsSource: 'pal' as const,
+            date: new Date('2024-01-01').toISOString(),
             pinned: true,
-          },
-          {
+          }),
+          pinnedSession({
             id: '2',
             title: 'Newer Pinned',
-            date: newer.toISOString(),
-            messages: [],
-            completionSettings: defaultCompletionSettings,
-            settingsSource: 'pal' as const,
+            date: new Date('2024-06-01').toISOString(),
             pinned: true,
-          },
+          }),
         ];
 
         const grouped = chatSessionStore.groupedSessions;
         expect(grouped.Pinned).toHaveLength(2);
-        expect(grouped.Pinned[0].id).toBe('2'); // Newer first
+        expect(grouped.Pinned[0].id).toBe('2');
         expect(grouped.Pinned[1].id).toBe('1');
       });
-    });
-
-    it('togglePinSession handles non-existent session in store', async () => {
-      chatSessionStore.sessions = [];
-
-      (
-        chatSessionRepository.toggleSessionPinned as jest.Mock
-      ).mockResolvedValue(true);
-
-      // Should not throw even though session doesn't exist locally
-      await chatSessionStore.togglePinSession('nonexistent');
-
-      expect(chatSessionRepository.toggleSessionPinned).toHaveBeenCalledWith(
-        'nonexistent',
-      );
     });
   });
 });

--- a/src/store/__tests__/ChatSessionStore.test.ts
+++ b/src/store/__tests__/ChatSessionStore.test.ts
@@ -25,6 +25,7 @@ jest.spyOn(chatSessionRepository, 'getGlobalCompletionSettings');
 jest.spyOn(chatSessionRepository, 'saveGlobalCompletionSettings');
 jest.spyOn(chatSessionRepository, 'setSessionActivePal');
 jest.spyOn(chatSessionRepository, 'setSessionSettingsSource');
+jest.spyOn(chatSessionRepository, 'toggleSessionPinned');
 
 describe('chatSessionStore', () => {
   const mockMessage = {
@@ -2463,6 +2464,205 @@ describe('chatSessionStore', () => {
         // The active session's live snapshot is untouched by the bulk op.
         expect(chatSessionStore.lastCompletionResult).toBeDefined();
       });
+    });
+  });
+
+  describe('pinned sessions', () => {
+    describe('togglePinSession', () => {
+      it('pins an unpinned session', async () => {
+        const session = {
+          id: 'session1',
+          title: 'Test Session',
+          date: new Date().toISOString(),
+          messages: [],
+          completionSettings: defaultCompletionSettings,
+          settingsSource: 'pal' as const,
+          pinned: false,
+        };
+
+        chatSessionStore.sessions = [session];
+
+        (
+          chatSessionRepository.toggleSessionPinned as jest.Mock
+        ).mockResolvedValue(true);
+
+        await chatSessionStore.togglePinSession('session1');
+
+        expect(
+          chatSessionRepository.toggleSessionPinned,
+        ).toHaveBeenCalledWith('session1');
+        expect(chatSessionStore.sessions[0].pinned).toBe(true);
+      });
+
+      it('unpins a pinned session', async () => {
+        const session = {
+          id: 'session1',
+          title: 'Test Session',
+          date: new Date().toISOString(),
+          messages: [],
+          completionSettings: defaultCompletionSettings,
+          settingsSource: 'pal' as const,
+          pinned: true,
+        };
+
+        chatSessionStore.sessions = [session];
+
+        (
+          chatSessionRepository.toggleSessionPinned as jest.Mock
+        ).mockResolvedValue(false);
+
+        await chatSessionStore.togglePinSession('session1');
+
+        expect(chatSessionStore.sessions[0].pinned).toBe(false);
+      });
+
+      it('handles errors gracefully', async () => {
+        chatSessionStore.sessions = [
+          {
+            id: 'session1',
+            title: 'Test Session',
+            date: new Date().toISOString(),
+            messages: [],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as const,
+            pinned: false,
+          },
+        ];
+
+        (
+          chatSessionRepository.toggleSessionPinned as jest.Mock
+        ).mockRejectedValue(new Error('DB error'));
+
+        await chatSessionStore.togglePinSession('session1');
+
+        // Should remain unchanged on error
+        expect(chatSessionStore.sessions[0].pinned).toBe(false);
+      });
+    });
+
+    describe('groupedSessions with pinned', () => {
+      it('shows pinned sessions in a separate group at the top', () => {
+        const today = new Date();
+
+        chatSessionStore.sessions = [
+          {
+            id: '1',
+            title: 'Pinned Session',
+            date: today.toISOString(),
+            messages: [],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as const,
+            pinned: true,
+          },
+          {
+            id: '2',
+            title: 'Regular Session',
+            date: today.toISOString(),
+            messages: [],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as const,
+            pinned: false,
+          },
+        ];
+
+        const grouped = chatSessionStore.groupedSessions;
+        const keys = Object.keys(grouped);
+
+        // Pinned should be the first group
+        expect(keys[0]).toBe('Pinned');
+        expect(grouped.Pinned).toHaveLength(1);
+        expect(grouped.Pinned[0].id).toBe('1');
+
+        // Regular session should be in Today
+        expect(grouped.Today).toHaveLength(1);
+        expect(grouped.Today[0].id).toBe('2');
+      });
+
+      it('does not show pinned group when no sessions are pinned', () => {
+        const today = new Date();
+
+        chatSessionStore.sessions = [
+          {
+            id: '1',
+            title: 'Regular Session',
+            date: today.toISOString(),
+            messages: [],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as const,
+            pinned: false,
+          },
+        ];
+
+        const grouped = chatSessionStore.groupedSessions;
+        expect(grouped.Pinned).toBeUndefined();
+        expect(grouped.Today).toHaveLength(1);
+      });
+
+      it('pinned sessions are excluded from date groups', () => {
+        const today = new Date();
+
+        chatSessionStore.sessions = [
+          {
+            id: '1',
+            title: 'Pinned Today',
+            date: today.toISOString(),
+            messages: [],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as const,
+            pinned: true,
+          },
+        ];
+
+        const grouped = chatSessionStore.groupedSessions;
+        expect(grouped.Pinned).toHaveLength(1);
+        expect(grouped.Today).toBeUndefined();
+      });
+
+      it('sorts multiple pinned sessions by date (newest first)', () => {
+        const older = new Date('2024-01-01');
+        const newer = new Date('2024-06-01');
+
+        chatSessionStore.sessions = [
+          {
+            id: '1',
+            title: 'Older Pinned',
+            date: older.toISOString(),
+            messages: [],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as const,
+            pinned: true,
+          },
+          {
+            id: '2',
+            title: 'Newer Pinned',
+            date: newer.toISOString(),
+            messages: [],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as const,
+            pinned: true,
+          },
+        ];
+
+        const grouped = chatSessionStore.groupedSessions;
+        expect(grouped.Pinned).toHaveLength(2);
+        expect(grouped.Pinned[0].id).toBe('2'); // Newer first
+        expect(grouped.Pinned[1].id).toBe('1');
+      });
+    });
+
+    it('togglePinSession handles non-existent session in store', async () => {
+      chatSessionStore.sessions = [];
+
+      (
+        chatSessionRepository.toggleSessionPinned as jest.Mock
+      ).mockResolvedValue(true);
+
+      // Should not throw even though session doesn't exist locally
+      await chatSessionStore.togglePinSession('nonexistent');
+
+      expect(
+        chatSessionRepository.toggleSessionPinned,
+      ).toHaveBeenCalledWith('nonexistent');
     });
   });
 });

--- a/src/store/__tests__/ChatSessionStore.test.ts
+++ b/src/store/__tests__/ChatSessionStore.test.ts
@@ -2488,9 +2488,9 @@ describe('chatSessionStore', () => {
 
         await chatSessionStore.togglePinSession('session1');
 
-        expect(
-          chatSessionRepository.toggleSessionPinned,
-        ).toHaveBeenCalledWith('session1');
+        expect(chatSessionRepository.toggleSessionPinned).toHaveBeenCalledWith(
+          'session1',
+        );
         expect(chatSessionStore.sessions[0].pinned).toBe(true);
       });
 
@@ -2660,9 +2660,9 @@ describe('chatSessionStore', () => {
       // Should not throw even though session doesn't exist locally
       await chatSessionStore.togglePinSession('nonexistent');
 
-      expect(
-        chatSessionRepository.toggleSessionPinned,
-      ).toHaveBeenCalledWith('nonexistent');
+      expect(chatSessionRepository.toggleSessionPinned).toHaveBeenCalledWith(
+        'nonexistent',
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add ability to pin chat sessions so they always appear at the top of the sidebar under a dedicated "Pinned" section
- Long-press a session in the sidebar to access the new Pin/Unpin option in the context menu
- Pinned sessions are persisted via a new `pinned` boolean column on `chat_sessions` (schema v7→v8)

## Details
- **Schema**: Adds `pinned` boolean column to `chat_sessions` table, bumps schema to v8 with migration
- **Store**: `groupedSessions` getter separates pinned sessions into a "Pinned" group rendered before date groups; `togglePinSession()` derives the target and persists via the repository's absolute `setSessionPinned(sessionId, pinned)` setter
- **UI**: Pin/Unpin menu item added to the session long-press context menu; pinned rows also carry a star so the state stays visible when section headers scroll out of view
- **l10n**: Adds `pin`, `unpin`, and `dateGroups.pinned` strings to `en.json`
- **Tests**: repository coverage for the new setter, store coverage for a pin surviving a reload, a component test for the menu item, a schema/migrations invariant test, and a locale guard keeping the sidebar group labels distinct

## Test plan
- [ ] Fresh install: verify migration creates `pinned` column, all sessions default to unpinned
- [ ] Long-press a session → verify Pin option appears in context menu
- [ ] Pin a session → verify it moves to "Pinned" section at top of sidebar
- [ ] Pin multiple sessions → verify they sort by date (newest first) within Pinned section
- [ ] Unpin a session → verify it returns to its date group
- [ ] Verify pinned state persists across app restarts
- [ ] Run `yarn test` — all tests pass
- [ ] Run `yarn lint` and `yarn typecheck` — no errors

Closes #602
