### PR TITLE
feat: message search within conversation

### DIFF
--- a/__mocks__/stores/chatSessionStore.ts
+++ b/__mocks__/stores/chatSessionStore.ts
@@ -1,4 +1,5 @@
 import {sessionFixtures} from '../../jest/fixtures/chatSessions';
+import {derivedText} from '../../src/utils/chat';
 import type {
   BannerVariant,
   CompletionResultSnapshot,
@@ -47,6 +48,9 @@ export const mockChatSessionStore = {
   // Selection mode state
   isSelectionMode: false,
   selectedSessionIds: new Set<string>(),
+  // Search mode state
+  isSearchMode: false,
+  searchQuery: '',
   loadSessionList: jest.fn().mockResolvedValue(undefined),
   loadGlobalSettings: jest.fn().mockResolvedValue(undefined),
   deleteSession: jest.fn().mockResolvedValue(undefined),
@@ -81,6 +85,10 @@ export const mockChatSessionStore = {
   getCurrentCompletionSettings: jest
     .fn()
     .mockResolvedValue(mockDefaultCompletionSettings),
+  // Search mode methods
+  enterSearchMode: jest.fn(),
+  exitSearchMode: jest.fn(),
+  setSearchQuery: jest.fn(),
   // Selection mode methods
   enterSelectionMode: jest.fn(),
   exitSelectionMode: jest.fn(),
@@ -159,6 +167,26 @@ Object.defineProperty(mockChatSessionStore, 'shouldShowHeaderDivider', {
 
 Object.defineProperty(mockChatSessionStore, 'selectedCount', {
   get: jest.fn(() => mockChatSessionStore.selectedSessionIds.size),
+  configurable: true,
+});
+
+// Derive from state (like selectedCount / allSelected) rather than a frozen
+// constant, so search tests can't pass vacuously.
+Object.defineProperty(mockChatSessionStore, 'searchMatchCount', {
+  get: jest.fn(() => {
+    if (
+      !mockChatSessionStore.isSearchMode ||
+      !mockChatSessionStore.searchQuery.trim()
+    ) {
+      return 0;
+    }
+    const query = mockChatSessionStore.searchQuery.toLowerCase().trim();
+    const messages = (mockChatSessionStore as any)
+      .currentSessionMessages as any[];
+    return messages.filter(msg =>
+      derivedText(msg).toLowerCase().includes(query),
+    ).length;
+  }),
   configurable: true,
 });
 

--- a/src/components/ChatSearchBar/ChatSearchBar.tsx
+++ b/src/components/ChatSearchBar/ChatSearchBar.tsx
@@ -1,0 +1,111 @@
+import React, {useContext, useRef, useEffect} from 'react';
+import {View, TextInput, TouchableOpacity, StyleSheet} from 'react-native';
+
+import {observer} from 'mobx-react';
+import {Text} from 'react-native-paper';
+
+import {useTheme} from '../../hooks';
+import {chatSessionStore} from '../../store';
+
+import {SearchIcon, CloseIcon} from '../../assets/icons';
+import {L10nContext} from '../../utils';
+
+interface ChatSearchBarProps {
+  matchCount: number;
+}
+
+export const ChatSearchBar: React.FC<ChatSearchBarProps> = observer(
+  ({matchCount}) => {
+    const theme = useTheme();
+    const l10n = useContext(L10nContext);
+    const inputRef = useRef<TextInput>(null);
+
+    useEffect(() => {
+      // Auto-focus when search bar appears
+      const timer = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 100);
+      return () => clearTimeout(timer);
+    }, []);
+
+    const hasQuery = chatSessionStore.searchQuery.trim().length > 0;
+
+    return (
+      <View
+        style={[
+          styles.container,
+          {
+            backgroundColor: theme.colors.surface,
+            borderBottomColor: theme.colors.outlineVariant,
+          },
+        ]}>
+        <View style={styles.inputRow}>
+          <SearchIcon
+            width={18}
+            height={18}
+            stroke={theme.colors.onSurfaceVariant}
+          />
+          <TextInput
+            ref={inputRef}
+            style={[styles.input, {color: theme.colors.onSurface}]}
+            placeholder={l10n.chat.searchMessages}
+            placeholderTextColor={theme.colors.onSurfaceVariant}
+            value={chatSessionStore.searchQuery}
+            onChangeText={query => chatSessionStore.setSearchQuery(query)}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="search"
+            accessibilityLabel={l10n.chat.searchMessages}
+            testID="chat-search-input"
+          />
+          {hasQuery && (
+            <Text
+              variant="bodySmall"
+              style={[
+                styles.matchCount,
+                {color: theme.colors.onSurfaceVariant},
+              ]}>
+              {matchCount > 0 ? `${matchCount}` : l10n.chat.noResults}
+            </Text>
+          )}
+          <TouchableOpacity
+            onPress={() => chatSessionStore.exitSearchMode()}
+            style={styles.closeButton}
+            accessibilityRole="button"
+            accessibilityLabel={l10n.chat.closeSearch}
+            testID="search-close-button">
+            <CloseIcon
+              width={18}
+              height={18}
+              stroke={theme.colors.onSurfaceVariant}
+            />
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  },
+);
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  input: {
+    flex: 1,
+    fontSize: 15,
+    paddingVertical: 4,
+  },
+  matchCount: {
+    marginHorizontal: 4,
+  },
+  closeButton: {
+    padding: 4,
+  },
+});

--- a/src/components/ChatSearchBar/__tests__/ChatSearchBar.test.tsx
+++ b/src/components/ChatSearchBar/__tests__/ChatSearchBar.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import {render, fireEvent} from '../../../../jest/test-utils';
+
+import {ChatSearchBar} from '../ChatSearchBar';
+import {chatSessionStore} from '../../../store';
+
+describe('ChatSearchBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (chatSessionStore as any).searchQuery = '';
+    (chatSessionStore as any).isSearchMode = true;
+  });
+
+  it('renders search input', () => {
+    const {getByTestId} = render(<ChatSearchBar matchCount={0} />);
+    expect(getByTestId('chat-search-input')).toBeTruthy();
+  });
+
+  it('renders close button', () => {
+    const {getByTestId} = render(<ChatSearchBar matchCount={0} />);
+    expect(getByTestId('search-close-button')).toBeTruthy();
+  });
+
+  it('calls exitSearchMode when close button is pressed', () => {
+    const {getByTestId} = render(<ChatSearchBar matchCount={0} />);
+    fireEvent.press(getByTestId('search-close-button'));
+    expect(chatSessionStore.exitSearchMode).toHaveBeenCalled();
+  });
+
+  it('calls setSearchQuery on text change', () => {
+    const {getByTestId} = render(<ChatSearchBar matchCount={0} />);
+    fireEvent.changeText(getByTestId('chat-search-input'), 'test query');
+    expect(chatSessionStore.setSearchQuery).toHaveBeenCalledWith('test query');
+  });
+
+  it('shows match count when there are matches', () => {
+    (chatSessionStore as any).searchQuery = 'hello';
+    const {getByText} = render(<ChatSearchBar matchCount={5} />);
+    expect(getByText('5')).toBeTruthy();
+  });
+
+  it('shows no results text when query exists but no matches', () => {
+    (chatSessionStore as any).searchQuery = 'xyz';
+    const {getByText} = render(<ChatSearchBar matchCount={0} />);
+    expect(getByText('No results')).toBeTruthy();
+  });
+
+  it('does not show match count when query is empty', () => {
+    (chatSessionStore as any).searchQuery = '';
+    const {queryByText} = render(<ChatSearchBar matchCount={0} />);
+    expect(queryByText('No results')).toBeNull();
+  });
+});

--- a/src/components/ChatSearchBar/index.ts
+++ b/src/components/ChatSearchBar/index.ts
@@ -1,0 +1,1 @@
+export * from './ChatSearchBar';

--- a/src/components/HeaderRight/HeaderRight.tsx
+++ b/src/components/HeaderRight/HeaderRight.tsx
@@ -11,6 +11,7 @@ import {
   EditBoxIcon,
   EditIcon,
   GridIcon,
+  SearchIcon,
   SettingsIcon,
   ShareIcon,
   TrashIcon,
@@ -158,6 +159,21 @@ export const HeaderRight: React.FC = observer(() => {
   return (
     <View style={styles.headerRightContainer}>
       {uiStore.displayMemUsage && <UsageStats width={40} height={20} />}
+      {session?.id && (
+        <IconButton
+          icon={() => <SearchIcon stroke={theme.colors.primary} />}
+          testID="search-button"
+          accessibilityLabel={l10n.chat.searchMessages}
+          style={styles.chatBtn}
+          onPress={() => {
+            if (chatSessionStore.isSearchMode) {
+              chatSessionStore.exitSearchMode();
+            } else {
+              chatSessionStore.enterSearchMode();
+            }
+          }}
+        />
+      )}
       <IconButton
         icon={() => <EditBoxIcon stroke={theme.colors.primary} />}
         testID="reset-button"

--- a/src/components/MarkdownView/MarkdownProvider.tsx
+++ b/src/components/MarkdownView/MarkdownProvider.tsx
@@ -1,6 +1,8 @@
 import React, {useMemo} from 'react';
 
 import {
+  HTMLContentModel,
+  HTMLElementModel,
   RenderHTMLConfigProvider,
   TRenderEngineProvider,
   defaultSystemFonts,
@@ -48,16 +50,39 @@ const renderers = {
   ...tableRenderers,
 };
 
+// Element models include the `mark` tag used for in-conversation search
+// highlighting (injected by MarkdownView.highlightSearchMatches). Stable
+// at module scope so it never invalidates the render engine.
+const customHTMLElementModels = {
+  ...tableHTMLElementModels,
+  mark: HTMLElementModel.fromCustomModel({
+    tagName: 'mark',
+    contentModel: HTMLContentModel.textual,
+  }),
+};
+
 export const MarkdownProvider: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
   const theme = useTheme();
-  const tagsStyles = useMemo(() => createTagsStyles(theme), [theme]);
+  const tagsStyles = useMemo(
+    () => ({
+      ...createTagsStyles(theme),
+      // Dedicated search-highlight tokens (not the near-white tertiary
+      // container, which was invisible in light mode). borderRadius is inert on
+      // nested RN <Text>, so it's omitted.
+      mark: {
+        backgroundColor: theme.colors.searchHighlight,
+        color: theme.colors.onSearchHighlight,
+      },
+    }),
+    [theme],
+  );
 
   return (
     <TRenderEngineProvider
       tagsStyles={tagsStyles}
-      customHTMLElementModels={tableHTMLElementModels}
+      customHTMLElementModels={customHTMLElementModels}
       systemFonts={SYSTEM_FONTS}>
       <RenderHTMLConfigProvider
         defaultTextProps={DEFAULT_TEXT_PROPS}

--- a/src/components/MarkdownView/MarkdownView.tsx
+++ b/src/components/MarkdownView/MarkdownView.tsx
@@ -1,8 +1,10 @@
 import {View} from 'react-native';
-import React, {useMemo} from 'react';
+import React, {useContext, useMemo} from 'react';
 
 import {marked} from 'marked';
 import {RenderHTMLSource} from 'react-native-render-html';
+
+import {SearchQueryContext} from '../../utils';
 
 marked.use({});
 
@@ -16,11 +18,94 @@ const isEmptyContent = (content: string): boolean => {
   return !content || content.trim() === '';
 };
 
+// The five characters marked() escapes in text nodes. Decoding them before
+// matching lets the highlight agree with the store's match count, which runs
+// on the raw (unescaped) message text.
+const decodeBasicEntities = (s: string): string =>
+  s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&'); // amp last, so &amp;lt; doesn't become <
+
+const encodeBasicEntities = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;') // amp first, so the replacements below aren't re-encoded
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+// A genuine opening <pre>/<code> tag: `<code>`, `<pre class="…">`, etc. A
+// self-closing `<code/>` deliberately does NOT match — it has no closing tag
+// to unwind, so counting it would leak codeDepth and disable highlighting for
+// the rest of the message.
+const CODE_OPEN = /^<(pre|code)(\s[^>]*)?>$/;
+const CODE_CLOSE = /^<\/(pre|code)>/;
+
+/**
+ * Wrap search-query matches in `<mark>` tags within the rendered HTML.
+ *
+ * Operates on `marked()` output, so it:
+ *  - skips code/pre regions entirely (injecting elements there breaks the
+ *    code renderer), and
+ *  - decodes the basic HTML entities in each text node before matching, then
+ *    re-encodes everything except the injected `<mark>` tags — so a query
+ *    containing `'`, `&`, `<` or `>` highlights, and highlight and count come
+ *    from one definition of "match".
+ */
+export const highlightSearchMatches = (html: string, query: string): string => {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return html;
+  }
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matchRegex = new RegExp(`(${escaped})`, 'gi');
+
+  let codeDepth = 0;
+  // Split the HTML into tags and text runs.
+  return html.replace(
+    /(<[^>]+>)|([^<]+)/g,
+    (_full, tag: string, text: string) => {
+      if (tag) {
+        const lower = tag.toLowerCase();
+        if (CODE_OPEN.test(lower)) {
+          codeDepth += 1;
+        } else if (CODE_CLOSE.test(lower)) {
+          codeDepth = Math.max(0, codeDepth - 1);
+        }
+        return tag;
+      }
+      if (codeDepth > 0) {
+        return text;
+      }
+      // Decode to the plain text the store matched against, wrap matches, and
+      // re-encode the surrounding text so entities stay intact.
+      const decoded = decodeBasicEntities(text);
+      let result = '';
+      let lastIndex = 0;
+      decoded.replace(matchRegex, (match: string, _cap: string, offset) => {
+        result += encodeBasicEntities(decoded.slice(lastIndex, offset));
+        result += `<mark>${encodeBasicEntities(match)}</mark>`;
+        lastIndex = offset + match.length;
+        return match;
+      });
+      result += encodeBasicEntities(decoded.slice(lastIndex));
+      return result;
+    },
+  );
+};
+
 /**
  * Renders a markdown string inside the app-level RenderHTML provider tree.
  * The engine (parser + tagsStyles + renderers) lives on `MarkdownProvider`
  * at the app root; only `source` and `contentWidth` change here, so per-
  * token streaming updates stay cheap.
+ *
+ * When a search query is active (via `SearchQueryContext`), matches are
+ * wrapped in `<mark>` tags — the `mark` element model and style are
+ * registered on `MarkdownProvider`.
  *
  * NOTE: `selectable` is accepted for API compatibility but is currently
  * fixed at the provider level. If a caller ever needs a selectable variant
@@ -28,9 +113,17 @@ const isEmptyContent = (content: string): boolean => {
  */
 export const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
   ({markdownText, maxMessageWidth}) => {
-    const htmlContent = useMemo(
+    const searchQuery = useContext(SearchQueryContext);
+
+    // Parse markdown once per message; only re-highlight when the query
+    // changes, so keystrokes don't re-run the expensive markdown parse.
+    const parsedHtml = useMemo(
       () => marked(markdownText) as string,
       [markdownText],
+    );
+    const htmlContent = useMemo(
+      () => highlightSearchMatches(parsedHtml, searchQuery),
+      [parsedHtml, searchQuery],
     );
     const source = useMemo(() => ({html: htmlContent}), [htmlContent]);
 

--- a/src/components/MarkdownView/__tests__/MarkdownView.test.tsx
+++ b/src/components/MarkdownView/__tests__/MarkdownView.test.tsx
@@ -8,7 +8,8 @@ import {render, fireEvent} from '../../../../jest/test-utils';
 import {themeFixtures} from '../../../../jest/fixtures/theme';
 import {useTheme} from '../../../hooks';
 
-import {MarkdownView} from '../MarkdownView';
+import {MarkdownView, highlightSearchMatches} from '../MarkdownView';
+import {SearchQueryContext} from '../../../utils';
 
 describe('MarkdownView Component', () => {
   it('renders markdown content correctly', () => {
@@ -310,6 +311,119 @@ describe('MarkdownView Component', () => {
       rerender(<MarkdownView markdownText="Second" maxMessageWidth={300} />);
 
       expect(getByText('Second')).toBeTruthy();
+    });
+  });
+
+  describe('Search highlighting', () => {
+    it('renders without highlighting when search query is empty', () => {
+      const {getByText} = render(
+        <SearchQueryContext.Provider value="">
+          <MarkdownView markdownText="Hello world" maxMessageWidth={300} />
+        </SearchQueryContext.Provider>,
+      );
+
+      expect(getByText('Hello world')).toBeTruthy();
+    });
+
+    it('renders without highlighting when no context is provided', () => {
+      const {getByText} = render(
+        <MarkdownView markdownText="Hello world" maxMessageWidth={300} />,
+      );
+
+      expect(getByText('Hello world')).toBeTruthy();
+    });
+
+    // Guards the MarkdownProvider registration: without the `mark` element
+    // model + tagsStyles, the matched term would not carry the highlight token.
+    it('styles a matched term with the search-highlight token', () => {
+      const {getByText} = render(
+        <SearchQueryContext.Provider value="world">
+          <MarkdownView markdownText="Hello world" maxMessageWidth={300} />
+        </SearchQueryContext.Provider>,
+      );
+
+      const flattened =
+        StyleSheet.flatten(getByText('world').props.style) || {};
+      expect(flattened.backgroundColor).toBe(
+        themeFixtures.lightTheme.colors.searchHighlight,
+      );
+    });
+  });
+
+  describe('highlightSearchMatches', () => {
+    it('returns html unchanged for an empty or whitespace query', () => {
+      const html = '<p>Hello world</p>';
+      expect(highlightSearchMatches(html, '')).toBe(html);
+      expect(highlightSearchMatches(html, '   ')).toBe(html);
+    });
+
+    it('wraps a plain text match in a mark tag', () => {
+      expect(highlightSearchMatches('<p>Hello world</p>', 'world')).toBe(
+        '<p>Hello <mark>world</mark></p>',
+      );
+    });
+
+    it('matches case-insensitively', () => {
+      expect(highlightSearchMatches('<p>HELLO world</p>', 'hello')).toBe(
+        '<p><mark>HELLO</mark> world</p>',
+      );
+    });
+
+    it('highlights every occurrence', () => {
+      expect(highlightSearchMatches('<p>ab ab ab</p>', 'ab')).toBe(
+        '<p><mark>ab</mark> <mark>ab</mark> <mark>ab</mark></p>',
+      );
+    });
+
+    it('treats regex special characters in the query literally', () => {
+      expect(highlightSearchMatches('<p>a.b and axb</p>', 'a.b')).toBe(
+        '<p><mark>a.b</mark> and axb</p>',
+      );
+    });
+
+    it('does not highlight an entity spelling that is not in the text', () => {
+      // The text is "Tom & Jerry"; "amp" only appears in the &amp; spelling,
+      // so it must not match, and the entity must stay intact.
+      const html = '<p>Tom &amp; Jerry</p>';
+      expect(highlightSearchMatches(html, 'amp')).toBe(html);
+    });
+
+    it('highlights around an entity without corrupting it', () => {
+      expect(highlightSearchMatches('<p>a &amp; apple</p>', 'a')).toBe(
+        '<p><mark>a</mark> &amp; <mark>a</mark>pple</p>',
+      );
+    });
+
+    it('highlights a query containing an escaped character (apostrophe)', () => {
+      // marked() escapes ' to &#39;; the store counted this match on the raw
+      // text, so the highlight must agree by matching the decoded character.
+      expect(highlightSearchMatches('<p>I don&#39;t recall</p>', "don't")).toBe(
+        '<p>I <mark>don&#39;t</mark> recall</p>',
+      );
+    });
+
+    it('highlights past a self-closing <code/> instead of disabling the rest', () => {
+      // A self-closing <code/> has no closing tag; counting it would leak
+      // codeDepth and suppress every later match in the message.
+      expect(
+        highlightSearchMatches(
+          '<p><code/>hello world and more hello</p>',
+          'hello',
+        ),
+      ).toBe(
+        '<p><code/><mark>hello</mark> world and more <mark>hello</mark></p>',
+      );
+    });
+
+    it('does not inject marks inside code blocks', () => {
+      const html = '<pre><code>const amp = 1;</code></pre>';
+      expect(highlightSearchMatches(html, 'amp')).toBe(html);
+    });
+
+    it('does not match across tag boundaries', () => {
+      // "hello world" is split by a <strong> tag, so it must not match.
+      const html = '<p>hello <strong>world</strong></p>';
+      expect(highlightSearchMatches(html, 'hello world')).toBe(html);
     });
   });
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ export * from './ChatGenerationSettingsSheet';
 export * from './ChatInput';
 export * from './ChatView';
 export * from './ChatHeader';
+export * from './ChatSearchBar';
 export * from './ChatPalModelPickerSheet';
 export * from './ChatEmptyPlaceholder';
 export * from './ContentReportSheet';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1220,6 +1220,9 @@
     "generatingPreviewPending": "Generating preview…",
     "toolUsedChip": "used {{name}}",
     "toolErrorBlock": "{{name}} failed",
+    "searchMessages": "Search messages...",
+    "closeSearch": "Close search",
+    "noResults": "No results",
     "webSearch": {
       "searched": "Searched: {{query}}",
       "noResults": "No results",

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -6,6 +6,7 @@ import {runInAction} from 'mobx';
 import {
   Bubble,
   ChatView,
+  ChatSearchBar,
   ErrorSnackbar,
   ModelErrorReportSheet,
 } from '../../components';
@@ -24,7 +25,7 @@ import {
 } from '../../store';
 import {hasVideoCapability} from '../../utils/pal-capabilities';
 
-import {L10nContext} from '../../utils';
+import {L10nContext, SearchQueryContext} from '../../utils';
 import {resolveReasoningCapability} from '../../utils/reasoningCapability';
 import {MessageType} from '../../utils/types';
 import {ErrorState} from '../../utils/errors';
@@ -253,41 +254,58 @@ export const ChatScreen: React.FC = observer(() => {
     return <VideoPalScreen activePal={activePal} />;
   }
 
+  // Compute messages and search match count
+  // Search highlights matches in place (find-in-page); it never swaps the
+  // render list, so ChatView's message-derived state — empty-state, banners,
+  // suggested prompts — stays anchored to the real conversation.
+  const messages = chatSessionStore.currentSessionMessages;
+  const matchCount =
+    chatSessionStore.isSearchMode && chatSessionStore.searchQuery.trim()
+      ? chatSessionStore.searchMatchCount
+      : 0;
+
   // Otherwise, show the regular chat view
   return (
     <>
-      <ChatView
-        renderBubble={renderBubble}
-        messages={chatSessionStore.currentSessionMessages}
-        activePal={activePal}
-        onSendPress={handleSendPress}
-        onStopPress={handleStopPress}
-        onPalSettingsSelect={handleOpenPalSheet}
-        user={user}
-        isStopVisible={modelStore.inferencing}
-        isStreaming={modelStore.isStreaming}
-        sendButtonVisibilityMode="always"
-        showImageUpload={true}
-        isVisionEnabled={visionEnabled}
-        initialInputText={pendingMessage || undefined}
-        onInitialTextConsumed={clearPendingMessage}
-        inputProps={{
-          showThinkingToggle: thinkingSupported,
-          isThinkingEnabled: thinkingEnabled,
-          onThinkingToggle: handleThinkingToggle,
-          supportsEffort: reasoningCapability.supportsEffort,
-          effortValues: reasoningCapability.effortValues,
-          reasoningEffort,
-          onEffortCycle: handleEffortCycle,
-        }}
-        textInputProps={{
-          placeholder: !modelStore.engine
-            ? modelStore.isContextLoading
-              ? l10n.chat.loadingModel
-              : l10n.chat.modelNotLoaded
-            : l10n.chat.typeYourMessage,
-        }}
-      />
+      <SearchQueryContext.Provider value={chatSessionStore.searchQuery}>
+        <ChatView
+          renderBubble={renderBubble}
+          messages={messages}
+          customContent={
+            chatSessionStore.isSearchMode ? (
+              <ChatSearchBar matchCount={matchCount} />
+            ) : undefined
+          }
+          activePal={activePal}
+          onSendPress={handleSendPress}
+          onStopPress={handleStopPress}
+          onPalSettingsSelect={handleOpenPalSheet}
+          user={user}
+          isStopVisible={modelStore.inferencing}
+          isStreaming={modelStore.isStreaming}
+          sendButtonVisibilityMode="always"
+          showImageUpload={true}
+          isVisionEnabled={visionEnabled}
+          initialInputText={pendingMessage || undefined}
+          onInitialTextConsumed={clearPendingMessage}
+          inputProps={{
+            showThinkingToggle: thinkingSupported,
+            isThinkingEnabled: thinkingEnabled,
+            onThinkingToggle: handleThinkingToggle,
+            supportsEffort: reasoningCapability.supportsEffort,
+            effortValues: reasoningCapability.effortValues,
+            reasoningEffort,
+            onEffortCycle: handleEffortCycle,
+          }}
+          textInputProps={{
+            placeholder: !modelStore.engine
+              ? modelStore.isContextLoading
+                ? l10n.chat.loadingModel
+                : l10n.chat.modelNotLoaded
+              : l10n.chat.typeYourMessage,
+          }}
+        />
+      </SearchQueryContext.Provider>
       {uiStore.chatWarning && (
         <ErrorSnackbar
           error={uiStore.chatWarning}

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -113,6 +113,9 @@ class ChatSessionStore {
   // Selection mode state
   isSelectionMode: boolean = false;
   selectedSessionIds: Set<string> = new Set();
+  // Search mode state
+  isSearchMode: boolean = false;
+  searchQuery: string = '';
 
   // UX state for the active agent run. Driven by `agentStateReducer`
   // from `AgentEvent`s emitted by the runner. The only writer is
@@ -370,6 +373,9 @@ class ChatSessionStore {
       // Do not copy completion settings from session to global settings
       // Instead, preserve global settings as they are
       this.exitEditMode();
+      // Search is a per-session view; don't carry it into a new chat.
+      this.isSearchMode = false;
+      this.searchQuery = '';
       this.activeSessionId = null;
       this.lastCompletionResult = undefined;
       this.dismissedBannerVariants = new Set();
@@ -413,6 +419,9 @@ class ChatSessionStore {
 
     runInAction(() => {
       this.exitEditMode();
+      // Search is a per-session view; don't carry a stale query across sessions.
+      this.isSearchMode = false;
+      this.searchQuery = '';
       this.activeSessionId = sessionId;
       // Don't modify global settings when changing sessions
       this.newChatPalId = undefined;
@@ -617,6 +626,10 @@ class ChatSessionStore {
         this.newChatPalId = undefined;
         this.newChatThinkingOverride = undefined;
         this.newChatReasoningEffort = undefined;
+        // Search is a per-session view; don't carry a stale query into the new
+        // session (reachable one tap away via Duplicate → createNewSession).
+        this.isSearchMode = false;
+        this.searchQuery = '';
       });
     } catch (error) {
       console.error('Failed to create new session:', error);
@@ -1430,6 +1443,48 @@ class ChatSessionStore {
 
   clearDraft(sessionId: string) {
     this.sessionDrafts.delete(sessionId);
+  }
+
+  // Search mode actions
+  enterSearchMode() {
+    runInAction(() => {
+      // Leave edit mode first: while editing, currentSessionMessages is sliced
+      // to the messages after the edit point, so search would otherwise scan a
+      // truncated conversation.
+      this.exitEditMode();
+      this.isSearchMode = true;
+      this.searchQuery = '';
+    });
+  }
+
+  exitSearchMode() {
+    runInAction(() => {
+      this.isSearchMode = false;
+      this.searchQuery = '';
+    });
+  }
+
+  setSearchQuery(query: string) {
+    this.searchQuery = query;
+  }
+
+  /**
+   * Number of messages in the active session whose text matches the current
+   * query. Search highlights in place (find-in-page) rather than filtering the
+   * message list, so this is a count only — the render list is never swapped.
+   *
+   * Matches on `derivedText`, so assistant replies (`assistant_turn` rows,
+   * whose `text` column is empty by design) are searched via their step
+   * content, not skipped.
+   */
+  get searchMatchCount(): number {
+    if (!this.isSearchMode || !this.searchQuery.trim()) {
+      return 0;
+    }
+    const query = this.searchQuery.toLowerCase().trim();
+    return this.currentSessionMessages.filter(msg =>
+      derivedText(msg).toLowerCase().includes(query),
+    ).length;
   }
 
   async setActivePal(palId: string | undefined): Promise<void> {

--- a/src/store/__tests__/ChatSessionStore.test.ts
+++ b/src/store/__tests__/ChatSessionStore.test.ts
@@ -2669,4 +2669,162 @@ describe('chatSessionStore', () => {
       });
     });
   });
+
+  describe('Search mode', () => {
+    const setupSessionWithMessages = (messages: MessageType.Any[]) => {
+      const session = {
+        id: 'search-session',
+        title: 'Search Test Session',
+        date: new Date().toISOString(),
+        messages,
+        completionSettings: defaultCompletionSettings,
+        settingsSource: 'pal' as 'pal' | 'custom',
+      };
+      chatSessionStore.sessions = [session];
+      chatSessionStore.activeSessionId = session.id;
+    };
+
+    const userText = (id: string, text: string): MessageType.Text =>
+      ({
+        id,
+        type: 'text',
+        text,
+        author: {id: 'user1'},
+        createdAt: Date.now(),
+      }) as MessageType.Text;
+
+    // Assistant replies are assistant_turn rows: the content lives in
+    // steps[].content and the `text` column is empty by design.
+    const assistantTurn = (id: string, content: string): MessageType.Any =>
+      ({
+        id,
+        type: 'assistant_turn',
+        text: '',
+        steps: [{content}],
+        author: {id: 'assistant'},
+        createdAt: Date.now(),
+      }) as unknown as MessageType.Any;
+
+    beforeEach(() => {
+      chatSessionStore.exitEditMode();
+      chatSessionStore.exitSearchMode();
+    });
+
+    it('enters search mode with empty query', () => {
+      chatSessionStore.enterSearchMode();
+      expect(chatSessionStore.isSearchMode).toBe(true);
+      expect(chatSessionStore.searchQuery).toBe('');
+    });
+
+    it('exits search mode and clears query', () => {
+      chatSessionStore.enterSearchMode();
+      chatSessionStore.setSearchQuery('hello');
+      chatSessionStore.exitSearchMode();
+      expect(chatSessionStore.isSearchMode).toBe(false);
+      expect(chatSessionStore.searchQuery).toBe('');
+    });
+
+    it('sets search query', () => {
+      chatSessionStore.setSearchQuery('test query');
+      expect(chatSessionStore.searchQuery).toBe('test query');
+    });
+
+    it('leaves edit mode when search opens so the full conversation is searched', () => {
+      chatSessionStore.isEditMode = true;
+      chatSessionStore.editingMessageId = 'msg1';
+
+      chatSessionStore.enterSearchMode();
+
+      expect(chatSessionStore.isEditMode).toBe(false);
+      expect(chatSessionStore.editingMessageId).toBeNull();
+    });
+
+    describe('searchMatchCount', () => {
+      it('is 0 when not in search mode', () => {
+        setupSessionWithMessages([userText('msg1', 'Hello world')]);
+        chatSessionStore.isSearchMode = false;
+        expect(chatSessionStore.searchMatchCount).toBe(0);
+      });
+
+      it('is 0 when the query is only whitespace', () => {
+        setupSessionWithMessages([userText('msg1', 'Hello world')]);
+        chatSessionStore.enterSearchMode();
+        chatSessionStore.setSearchQuery('   ');
+        expect(chatSessionStore.searchMatchCount).toBe(0);
+      });
+
+      it('counts user messages that match, case-insensitively', () => {
+        setupSessionWithMessages([
+          userText('msg1', 'Hello world'),
+          userText('msg2', 'Goodbye world'),
+          userText('msg3', 'HELLO again'),
+        ]);
+        chatSessionStore.enterSearchMode();
+        chatSessionStore.setSearchQuery('hello');
+        expect(chatSessionStore.searchMatchCount).toBe(2);
+      });
+
+      // Guards the blocking bug: the old filter matched `msg.text`, which is
+      // always empty for assistant replies, so they never matched. Reverting
+      // searchMatchCount to `msg.type === 'text' && msg.text` turns this red.
+      it('counts assistant replies whose match lives in step content', () => {
+        setupSessionWithMessages([
+          userText('msg1', 'How do leaves make energy?'),
+          assistantTurn(
+            'msg2',
+            'Leaves use chlorophyll to turn sunlight into energy.',
+          ),
+        ]);
+        chatSessionStore.enterSearchMode();
+        chatSessionStore.setSearchQuery('energy');
+        expect(chatSessionStore.searchMatchCount).toBe(2);
+      });
+    });
+
+    describe('per-session reset', () => {
+      it('clears search state when a new session is created', async () => {
+        setupSessionWithMessages([userText('msg1', 'Hello world')]);
+        chatSessionStore.enterSearchMode();
+        chatSessionStore.setSearchQuery('hello');
+
+        (chatSessionRepository.createSession as jest.Mock).mockResolvedValue({
+          id: 'new-session',
+          title: 'New Session',
+          date: new Date().toISOString(),
+        });
+        (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValue({
+          messages: [],
+          completionSettings: {getSettings: () => defaultCompletionSettings},
+        });
+
+        await chatSessionStore.createNewSession('New Session');
+
+        expect(chatSessionStore.isSearchMode).toBe(false);
+        expect(chatSessionStore.searchQuery).toBe('');
+      });
+
+      it('clears search state when switching to another session', async () => {
+        setupSessionWithMessages([userText('msg1', 'Hello world')]);
+        chatSessionStore.sessions = [
+          ...chatSessionStore.sessions,
+          {
+            id: 'other-session',
+            title: 'Other',
+            date: new Date().toISOString(),
+            messages: [],
+            messagesLoaded: true,
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal' as 'pal' | 'custom',
+          },
+        ];
+        chatSessionStore.enterSearchMode();
+        chatSessionStore.setSearchQuery('hello');
+
+        await chatSessionStore.setActiveSession('other-session');
+
+        expect(chatSessionStore.isSearchMode).toBe(false);
+        expect(chatSessionStore.searchQuery).toBe('');
+      });
+    });
+  });
 });

--- a/src/theme/tokens/colors.ts
+++ b/src/theme/tokens/colors.ts
@@ -65,6 +65,11 @@ export const lightColors: TokenColors = {
   // Figma `Color/Secondary/Default` — the secondary surface used by
   // small DS buttons (back chevron, audio glyph) over the muted canvas.
   secondaryDefault: '#f3f2f2',
+  // Search highlight: a deep amber that clears ~3:1 against the light message
+  // background (a bright yellow would be near-invisible on near-white); black
+  // text keeps the highlighted term readable.
+  searchHighlight: '#C77700',
+  onSearchHighlight: '#000000',
   // MD3 extras
   surfaceDisabled: withOpacity('#fcfcfc', 0.12),
   onSurfaceDisabled: withOpacity('#333333', 0.38),
@@ -202,6 +207,10 @@ export const darkColors: TokenColors = {
   mutedLight: '#3a3937',
   // Figma `Color/Secondary/Default` — dark binding from canonical file.
   secondaryDefault: '#2a2928',
+  // Search highlight: a bright amber that pops against the dark message
+  // background (~7:1); black text stays readable on it.
+  searchHighlight: '#FFB300',
+  onSearchHighlight: '#000000',
   // MD3 extras
   surfaceDisabled: withOpacity('#333333', 0.12),
   onSurfaceDisabled: withOpacity('#e5e5e6', 0.38),

--- a/src/theme/tokens/types.ts
+++ b/src/theme/tokens/types.ts
@@ -43,6 +43,12 @@ export interface TokenColors {
   // Design-system `Color/Secondary/Default` — small DS button surface.
   secondaryDefault: string;
 
+  // In-conversation search highlight (find-in-page). Kept distinct from the
+  // container tokens so it can clear ~3:1 against the message background in
+  // both themes.
+  searchHighlight: string;
+  onSearchHighlight: string;
+
   // MD3 extras
   surfaceDisabled: string;
   onSurfaceDisabled: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,6 +35,7 @@ export const L10nContext = React.createContext<
   (typeof l10n)[keyof typeof l10n]
 >(l10n.en);
 export const UserContext = React.createContext<User | undefined>(undefined);
+export const SearchQueryContext = React.createContext<string>('');
 
 /** Returns size in bytes of the provided text */
 export const getTextSizeInBytes = (text: string) => new Blob([text]).size;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -290,6 +290,9 @@ export interface SemanticColors {
   mutedLight: string;
   // Figma `Color/Secondary/Default` — small DS button surface.
   secondaryDefault: string;
+  // In-conversation search highlight (find-in-page).
+  searchHighlight: string;
+  onSearchHighlight: string;
 
   // Interactive states
   stateLayerOpacity: number;


### PR DESCRIPTION
## Summary
- Adds in-conversation message search. Matches are highlighted **in place (find-in-page)** — the full conversation stays visible and a match count is shown, rather than filtering the message list.
- Search bar appears via a toolbar icon with auto-focus, a match-count / "No results" indicator, and a close button.
- Matching text is highlighted with `<mark>` tags via `SearchQueryContext` (avoids prop drilling through ChatView → Message → TextMessage → MarkdownView).

## Why find-in-page rather than filtering the list
`ChatView`'s `messages` prop is conversation truth — it drives the empty state, the context banners, and the suggested-prompts row (whose `onSelect` sends a message). Swapping it for a filtered list made a zero-result search render the new-chat state, as if the chat had been deleted. Highlighting in place never touches that prop, so all of those derivations stay anchored to the real conversation.

## Implementation details
- **ChatSessionStore**: `isSearchMode`, `searchQuery`, `enterSearchMode()` (also exits edit mode), `exitSearchMode()`, `setSearchQuery()`, and a `searchMatchCount` getter. Count derives from `derivedText`, so assistant replies (`assistant_turn` rows, whose `text` column is empty) are searched via their step content. Search state resets on session create, switch, and reset.
- **ChatSearchBar**: search input, match-count / no-results indicator, close button.
- **HeaderRight**: search icon toggle (visible when a session is active).
- **ChatScreen**: passes the unfiltered conversation and the search bar via `customContent`; wraps ChatView in `SearchQueryContext.Provider`.
- **MarkdownView**: consumes `SearchQueryContext` and wraps matches in `<mark>` after markdown→HTML. The highlighter decodes the basic HTML entities before matching and re-encodes after (so a query with `'`, `&`, `<`, `>` highlights and agrees with the count), skips code/pre regions, and no longer leaks on a self-closing `<code/>`.
- **MarkdownProvider**: registers the `mark` element model and styles it with dedicated `searchHighlight` / `onSearchHighlight` theme tokens that clear ~3:1 against the message background in both themes (the old `tertiaryContainer` was invisible in light mode).
- **Theme tokens**: `searchHighlight` / `onSearchHighlight` added to the token palette and `SemanticColors`.
- **l10n**: `chat.searchMessages`, `chat.noResults`, `chat.closeSearch` in en.json.

## Test plan
- [x] Store tests: enter/exit, query setting, `searchMatchCount` (user + **assistant_turn** fixtures, whitespace/not-in-mode gating), edit-mode exit on open, and search-state reset on create + session switch. Mutation-verified: reverting to the `msg.type === 'text'` filter turns the assistant-reply test red.
- [x] MarkdownView tests: entity-safe highlight (apostrophe), self-closing `<code/>`, code-block skip, and a render test asserting the `searchHighlight` token is applied (mutation-verified against `tertiaryContainer`).
- [x] ChatSearchBar component tests.
- [x] `tsc --noEmit` clean · `eslint` clean · `l10n:validate` valid.
- [x] Full suite: **269 suites / 4186 passed**, 2 skipped. No native changes.
- [ ] Manual device pass of the search bar (iOS/Android).

## Acceptance criteria (#603)
- ✅ **Search bar accessible from the chat view** — header search icon toggles the bar.
- ⚠️ **Message list filters to matching messages in real time** — satisfied as **find-in-page**: matches are highlighted in place with a live count, rather than filtering the list. This is a deliberate deviation from the AC's literal wording — filtering `ChatView`'s `messages` prop corrupts its conversation-truth derivations (empty state, banners, suggested-prompts), which was blocking bug #2. Flagging for explicit sign-off; happy to add prev/next jump or revisit if you'd prefer literal list-filtering.
- ✅ **Query term highlighted within matching messages** — via `<mark>` + dedicated theme tokens.
- ✅ **Clear/exit search restores the normal view** — `exitSearchMode`.
- ✅ **Pure JS, no new native dependencies** — no native changes in the diff.

## Deferred (non-blocking, follow-up)
Perf debounce / query-as-prop, the a11y set (BackHandler, live region, hitSlop, match-count wording), and minor polish (l10n dedup, `autoFocus` prop, `spellCheck`, StyleSheet→createStyles).

Closes #603

