### PR TITLE
fix(android): correct display density on external displays

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode|density"
         android:launchMode="singleTask"
         android:windowSoftInputMode="adjustResize"
         android:exported="true">

--- a/android/app/src/main/java/com/pocketpalai/MainActivity.kt
+++ b/android/app/src/main/java/com/pocketpalai/MainActivity.kt
@@ -4,7 +4,9 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
-import androidx.core.view.WindowCompat   // for edge-to-edge pre API 35 
+import com.facebook.react.uimanager.DisplayMetricsHolder
+import androidx.core.view.WindowCompat   // for edge-to-edge pre API 35
+import android.content.res.Configuration
 import android.os.Bundle
 
 class MainActivity : ReactActivity() {
@@ -24,13 +26,46 @@ class MainActivity : ReactActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
       // Prevent react-native-screens from restoring fragments after process death
-      // This fixes the "Screen fragments should never be restored" crash 
-      // See: https://github.com/software-mansion/react-native-screens/issues/17 
+      // This fixes the "Screen fragments should never be restored" crash
+      // See: https://github.com/software-mansion/react-native-screens/issues/17
       // and https://github.com/software-mansion/react-native-screens?tab=readme-ov-file#android
       super.onCreate(null)
+
+      fixExternalDisplayDensity()
 
       WindowCompat.enableEdgeToEdge(window)  // enable E2E pre-Android 15
     // Optional: fully transparent nav bar (can reduce contrast on 3-button nav)
     // window.isNavigationBarContrastEnforced = false
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+      super.onConfigurationChanged(newConfig)
+      fixExternalDisplayDensity()
+  }
+
+  /**
+   * Fix display density for external displays (Samsung DeX, Pixel Desktop Mode).
+   *
+   * RN's DisplayMetricsHolder.initDisplayMetrics() sets screenDisplayMetrics via
+   * wm.defaultDisplay.getRealMetrics(), which always reads from the phone display
+   * (e.g. 420dpi). PixelUtil uses screenDisplayMetrics for all dp-to-px conversions,
+   * causing everything to render ~4x too large on a lower-density external monitor.
+   *
+   * windowDisplayMetrics (from Application context) has the correct density, so we
+   * copy it over. This runs in onCreate and onConfigurationChanged because RN
+   * re-initializes metrics on orientation/resize changes.
+   */
+  private fun fixExternalDisplayDensity() {
+      try {
+          val screenMetrics = DisplayMetricsHolder.getScreenDisplayMetrics()
+          val windowMetrics = DisplayMetricsHolder.getWindowDisplayMetrics()
+          if (screenMetrics.densityDpi != windowMetrics.densityDpi) {
+              screenMetrics.densityDpi = windowMetrics.densityDpi
+              screenMetrics.density = windowMetrics.density
+              screenMetrics.scaledDensity = windowMetrics.scaledDensity
+          }
+      } catch (_: Exception) {
+          // DisplayMetricsHolder not yet initialized — normal on phone display
+      }
   }
 }


### PR DESCRIPTION
## Summary
- Fix oversized UI rendering on Samsung DeX and Pixel Desktop Mode
- RN's `DisplayMetricsHolder` reads `screenDisplayMetrics` from `wm.defaultDisplay` which always returns the phone's density (e.g. 420dpi), but `PixelUtil` uses it for all dp-to-px conversions — causing ~4x scaling on external monitors (e.g. 111dpi)
- Copies correct density from `windowDisplayMetrics` to `screenDisplayMetrics` in `onCreate` and `onConfigurationChanged`
- No impact on phone-only usage (fix is a no-op when both metrics match)

## Test plan
- [x] Tested on Pixel 9 with Desktop Mode (external 1920x1080 monitor at 111dpi)
- [x] Verified initial render is correct
- [x] Verified window resize keeps correct density
- [x] Verify no regression on phone-only usage
- [ ] Test on Samsung DeX if possible