### PR TITLE
feat(ios): add memory entitlements for larger model loading

### DIFF
--- a/ios/PocketPal.xcodeproj/project.pbxproj
+++ b/ios/PocketPal.xcodeproj/project.pbxproj
@@ -511,6 +511,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = PocketPal/PocketPal.entitlements;
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 133;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = MYXGXY23Y6;
@@ -548,6 +549,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = PocketPal/PocketPal.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 133;
@@ -925,6 +927,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = PocketPal/PocketPal.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 133;

--- a/ios/PocketPal/PocketPal.entitlements
+++ b/ios/PocketPal/PocketPal.entitlements
@@ -22,5 +22,23 @@
 	-->
 	<key>com.apple.developer.siri</key>
 	<true/>
+
+	<!--
+		Increased Memory Limit: Required for loading large language models
+
+		This entitlement raises the per-process jetsam threshold, allowing the app
+		to use more memory before iOS terminates it.
+	-->
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+
+	<!--
+		Extended Virtual Addressing: Required for memory-mapping large model files
+
+		Allows the app to address a larger virtual memory range, enabling mmap of
+		large GGUF model files without running into virtual address limits.
+	-->
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `increased-memory-limit` and `extended-virtual-addressing` entitlements to raise the iOS jetsam threshold
- Wire up `CODE_SIGN_ENTITLEMENTS` in all Xcode build configurations (Debug, Release, Profiling)
- Gives ~1 GB more memory headroom on iPhone 13 Pro (6 GB RAM), allowing larger models to load reliably on first attempt

## Background
On memory-constrained devices (e.g. iPhone 13 Pro), loading a ~2 GB model would intermittently fail because iOS would jetsam-kill the app before background apps were evicted. All other iOS LLM apps (MLC-LLM, LLMFarm, MLX Swift) use these entitlements.

## Test plan
- [x] E2E memory profile on iPhone 13 Pro with qwen3-1.7b — PASS, no regression
- [x] `available_memory` increased from 3.12 GB → 4.20 GB at app launch (+1.08 GB headroom)
- [x] Peak memory unchanged (~2,151 MB vs 2,148 MB baseline)
- [x] Verified entitlements embedded in IPA via `codesign -d --entitlements`
- [ ] CI build succeeds (provisioning profiles already updated in match repo)