### PR TITLE
chore(deps): upgrade llama.rn to 0.12.0-rc.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.11.5):
+  - llama-rn (0.12.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3655,7 +3655,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: d571d2fcfbebd55eed17c8866c6a1172857cca33
+  llama-rn: 6690c7cca20d93b85a1325405102bc4735a0cf33
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.11.5",
+    "llama.rn": "0.12.0-rc.2",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,10 +6500,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.11.5:
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.11.5.tgz#ecaf80867bb53698d4e3b6abc3c6c42b010232b9"
-  integrity sha512-ON4ThybtiPnNEfJHbQcBk5zkm/YyFgjpGzykgEeqOLFZMTVaZqsSQyZ6TOTyvDfKrIQzukIKKglBtCyPLbbBsw==
+llama.rn@0.12.0-rc.2:
+  version "0.12.0-rc.2"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0-rc.2.tgz#8d43353b67ce913a0a8693f4917513092b4d15c2"
+  integrity sha512-h6/CV78qav1rgcz61v/rZpZ7kvQ9gMpM0GQdztX8l34gBVfpMquMgcNjtR1Ju5V2Ftjrcav2VUrEMv8b4axAjg==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Upgrade `llama.rn` from `0.11.5` to `0.12.0-rc.2`
- llama.cpp synced to b8547
- New additive features available: reasoning budget support, `force_pure_content`
- Fixes: antiprompt/sampling rewind, TTS vocoder, TranslateGemma

## Changes
- `package.json`: version bump
- `yarn.lock`: regenerated
- `ios/Podfile.lock`: regenerated via `pod install`

## Verification
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes (0 errors, 4 pre-existing warnings)
- [x] `yarn test` passes (135 suites, 1755 passed, 2 skipped)
- [x] `pod install` succeeds
- [x] iOS Release build succeeds
- [x] Android Release build succeeds

No API changes — all existing imports (`LlamaContext`, `initLlama`, `ContextParams`, `CompletionParams`, etc.) remain unchanged. New features are additive and not yet consumed.

Story: TASK-20260327-0958

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)