### PR TITLE
chore(deps): upgrade llama.rn to 0.12.0-rc.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.0-rc.2):
+  - llama-rn (0.12.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3655,7 +3655,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 6690c7cca20d93b85a1325405102bc4735a0cf33
+  llama-rn: cf884b7fb6b5e5bdea0342cacaa265afc466e6a3
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.12.0-rc.2",
+    "llama.rn": "0.12.0-rc.3",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,10 +6500,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.0-rc.2:
-  version "0.12.0-rc.2"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0-rc.2.tgz#8d43353b67ce913a0a8693f4917513092b4d15c2"
-  integrity sha512-h6/CV78qav1rgcz61v/rZpZ7kvQ9gMpM0GQdztX8l34gBVfpMquMgcNjtR1Ju5V2Ftjrcav2VUrEMv8b4axAjg==
+llama.rn@0.12.0-rc.3:
+  version "0.12.0-rc.3"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0-rc.3.tgz#1c14bde6af7376a81763618e97b25ab283d92ed8"
+  integrity sha512-GnSuIScaWipzPUMA812uynYNl/F1U4CddCDwRu/CwAwY0fMDiGtXVc5NVbL0Q6Z6+Gp59c3/u/sOy2I6drKmpg==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

- Upgrades `llama.rn` from `0.12.0-rc.2` to `0.12.0-rc.3`
- Brings underlying llama.cpp from b8547 to b8641, which adds **Gemma 4 model support** (text and vision)
- GGUF quants already available from Unsloth on HuggingFace (E2B ~3.5-4.7GB, E4B ~5GB at Q4_K_M)

## Changes

Only 3 files changed (7 insertions, 7 deletions):
- `package.json` — version bump
- `yarn.lock` — resolved version update
- `ios/Podfile.lock` — pod checksum update

## Verification

| Check | Result |
|-------|--------|
| Lint | PASS (0 errors) |
| TypeCheck | PASS |
| Tests | PASS (135 suites, 1763/1763) |
| Pod Install | PASS |
| iOS Release Build | PASS |
| Android Release Build | PASS |

## Test plan

- [x] `yarn lint` passes
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (1763/1763)
- [x] `pod install` succeeds
- [x] iOS Release build succeeds
- [x] Android Release build succeeds
- [x] Manual: load a model and verify inference works
- [x] Manual: test Gemma 4 GGUF if available

Closes #661

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)