### PR TITLE
Upgrade react-native-keyboard-controller to fix iOS startup crash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1926,7 +1926,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-keyboard-controller (1.19.1):
+  - react-native-keyboard-controller (1.21.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1944,7 +1944,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.19.1)
+    - react-native-keyboard-controller/common (= 1.21.4)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1955,7 +1955,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-keyboard-controller/common (1.19.1):
+  - react-native-keyboard-controller/common (1.21.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3694,7 +3694,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: a0f219f1de355c2da4e4a7ce9de5f91e2d9df5a9
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   react-native-image-picker: 6051cfd030121b880a58f1cc0e5e33e9887804e4
-  react-native-keyboard-controller: e4ff19011e66fa0b671c0887a664c007c8c3546d
+  react-native-keyboard-controller: 78f861c4dc73887b4cb7173a37e01f1634c9a58a
   react-native-render-html: 5afc4751f1a98621b3009432ef84c47019dcb2bd
   react-native-safe-area-context: ee1e8e2a7abf737a8d4d9d1a5686a7f2e7466236
   react-native-slider: 6201419b3e3f7c6b7cf2068e0c01274fa86a1da5

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-native-haptic-feedback": "^2.3.3",
     "react-native-image-picker": "^8.2.1",
     "react-native-image-viewing": "^0.2.2",
-    "react-native-keyboard-controller": "^1.19.1",
+    "react-native-keyboard-controller": "^1.21.3",
     "react-native-keychain": "^10.0.0",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-paper": "5.14.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,10 +7709,10 @@ react-native-is-edge-to-edge@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz#64e10851abd9d176cbf2b40562f751622bde3358"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
-react-native-keyboard-controller@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.19.1.tgz#2e0c3ad532f56eb6de4374feacbaffb20adc673d"
-  integrity sha512-+/jWtRfWQtq7Akr73x9y0iJJ4NPoENrBpNKDU/s65HeUH8VAzXz+Fq7kFSObJx5UVelRN/d8njTK/tMrs4a/hA==
+react-native-keyboard-controller@^1.21.3:
+  version "1.21.4"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.21.4.tgz#9ea9687c4b1a7e9856d796abd867449713a83da5"
+  integrity sha512-j1bS2ZKo+ahexnhTYJ+GxXWeMHUylY7AM0h3i0y+XgxcCHW05DpJJQcSvMCmDtMrMhRUtalLZRDCGvuh/aUPZQ==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 


### PR DESCRIPTION
## Summary

- Upgrades `react-native-keyboard-controller` from 1.19.1 to ^1.21.3 (resolved to 1.21.4)
- Fixes iOS startup crash (SIGABRT) on iPhone 16 Pro Max / iOS 18.4 caused by two bugs in v1.19.1's `preload()` method:
  - Preload tracking view crash (fixed upstream in v1.19.2, PR #1170)
  - `ensureLayout` NSException (fixed upstream in v1.19.3, PR #1174)
- No source code changes — dependency-only update (3 files: `package.json`, `yarn.lock`, `ios/Podfile.lock`)

## Verification

| Check | Result |
|-------|--------|
| TypeCheck | PASS |
| Tests | PASS (135 suites, 1765 passed) |
| Pod Install | PASS |
| iOS Release Build | PASS |
| Android Release Build | PASS |

## Test plan

- [x] iOS Release build succeeds
- [x] Android Release build succeeds
- [x] All 1765 existing tests pass
- [x] Manual: launch app on iOS simulator — no crash on startup
- [x] Manual: verify keyboard behavior in chat view and dialogs
- [x] Manual: ask TestFlight tester to re-test on iPhone 16 Pro Max / iOS 18.4

Linear: P-223

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)