### PR TITLE
Fix completion settings inconsistencies with pal overrides

### DIFF
--- a/__mocks__/repositories/ChatSessionRepository.js
+++ b/__mocks__/repositories/ChatSessionRepository.js
@@ -57,6 +57,7 @@ class ChatSessionRepository {
     initialMessages = [],
     completionSettings = defaultCompletionSettings,
     activePalId,
+    settingsSource,
   ) {
     return {
       id: 'mock-session-id',
@@ -105,6 +106,10 @@ class ChatSessionRepository {
   }
 
   async setSessionActivePal(sessionId, palId) {
+    return; // Mock: do nothing
+  }
+
+  async setSessionSettingsSource(sessionId, settingsSource) {
     return; // Mock: do nothing
   }
 

--- a/e2e/pages/ChatPage.ts
+++ b/e2e/pages/ChatPage.ts
@@ -6,7 +6,12 @@
  */
 
 import {BasePage, ChainableElement} from './BasePage';
-import {Selectors, byText} from '../helpers/selectors';
+import {
+  Selectors,
+  byText,
+  byAccessibilityLabel,
+  byPartialText,
+} from '../helpers/selectors';
 import {Gestures} from '../helpers/gestures';
 
 declare const browser: WebdriverIO.Browser;
@@ -200,6 +205,72 @@ export class ChatPage extends BasePage {
     await input.clearValue();
     await input.setValue(value);
     await this.dismissKeyboard();
+  }
+
+  /**
+   * Get the temperature value displayed in the generation settings sheet.
+   * Must be called when the generation settings sheet is open.
+   */
+  async getTemperatureValue(): Promise<string> {
+    await Gestures.scrollInSheetToElement(
+      Selectors.generationSettings.temperatureInput,
+      3,
+    );
+    const input = browser.$(Selectors.generationSettings.temperatureInput);
+    await input.waitForDisplayed({timeout: 5000});
+    if ((browser as any).isAndroid) {
+      return (await input.getAttribute('text')) || '';
+    }
+    return (await input.getAttribute('value')) || '';
+  }
+
+  /**
+   * Close the generation settings sheet by tapping outside or using back gesture
+   */
+  async closeGenerationSettings(): Promise<void> {
+    // Swipe down to dismiss the bottom sheet
+    await Gestures.swipe({
+      startXPercent: 0.5,
+      startYPercent: 0.3,
+      endXPercent: 0.5,
+      endYPercent: 0.9,
+      duration: 300,
+    });
+    await browser.pause(500);
+  }
+
+  /**
+   * Open the pal/model picker sheet by tapping the pal selector button.
+   */
+  async openPalPicker(): Promise<void> {
+    const palBtn = browser.$(byAccessibilityLabel('Select Pal'));
+    await palBtn.waitForDisplayed({timeout: 5000});
+    await palBtn.click();
+    await browser.pause(500);
+  }
+
+  /**
+   * Select a pal by name from the pal picker sheet (must be open).
+   * Swipes left to reach the Pals tab since the picker defaults to Models.
+   */
+  async selectPal(palName: string): Promise<void> {
+    // The picker shows Models tab by default.
+    // Swipe right to reach the Pals tab (Pals is to the left of Models).
+    await Gestures.swipe({
+      startXPercent: 0.2,
+      startYPercent: 0.7,
+      endXPercent: 0.8,
+      endYPercent: 0.7,
+      duration: 300,
+    });
+    await browser.pause(500);
+
+    // Now find and tap the pal using partial text match
+    // (Pressable may combine child text labels into one accessibility element)
+    const palItem = browser.$(byPartialText(palName));
+    await palItem.waitForDisplayed({timeout: 5000});
+    await palItem.click();
+    await browser.pause(500);
   }
 
   /**

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -118,5 +118,17 @@ export default schemaMigrations({
         }),
       ],
     },
+    // Migration to version 6: Add settings_source column to chat_sessions
+    {
+      toVersion: 6,
+      steps: [
+        addColumns({
+          table: 'chat_sessions',
+          columns: [
+            {name: 'settings_source', type: 'string', isOptional: true},
+          ],
+        }),
+      ],
+    },
   ],
 });

--- a/src/database/models/ChatSession.ts
+++ b/src/database/models/ChatSession.ts
@@ -15,6 +15,7 @@ export default class ChatSession extends Model {
   @text('title') title!: string;
   @text('date') date!: string;
   @text('active_pal_id') activePalId?: string;
+  @text('settings_source') settingsSource?: string;
   @field('created_at') createdAt!: number;
   @field('updated_at') updatedAt!: number;
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -1,7 +1,7 @@
 import {appSchema, tableSchema} from '@nozbe/watermelondb';
 
 export default appSchema({
-  version: 5,
+  version: 6,
   tables: [
     tableSchema({
       name: 'chat_sessions',
@@ -9,6 +9,7 @@ export default appSchema({
         {name: 'title', type: 'string'},
         {name: 'date', type: 'string'},
         {name: 'active_pal_id', type: 'string', isOptional: true},
+        {name: 'settings_source', type: 'string', isOptional: true},
         {name: 'created_at', type: 'number'},
         {name: 'updated_at', type: 'number'},
       ],

--- a/src/repositories/ChatSessionRepository.ts
+++ b/src/repositories/ChatSessionRepository.ts
@@ -248,6 +248,7 @@ class ChatSessionRepository {
     initialMessages: MessageType.Any[] = [],
     completionSettings: CompletionParams = defaultCompletionSettings,
     activePalId?: string,
+    settingsSource?: 'pal' | 'custom',
   ): Promise<ChatSession> {
     let newSession: any;
 
@@ -260,6 +261,9 @@ class ChatSessionRepository {
           record.date = new Date().toISOString();
           if (activePalId) {
             record.activePalId = activePalId;
+          }
+          if (settingsSource) {
+            record.settingsSource = settingsSource;
           }
         });
 
@@ -609,6 +613,27 @@ class ChatSessionRepository {
     await database.write(async () => {
       await session.update((record: any) => {
         record.activePalId = palId || null;
+      });
+    });
+  }
+
+  // Set settings source for a session
+  async setSessionSettingsSource(
+    sessionId: string,
+    settingsSource: 'pal' | 'custom',
+  ): Promise<void> {
+    const session = await database.collections
+      .get('chat_sessions')
+      .find(sessionId)
+      .catch(() => null);
+
+    if (!session) {
+      return;
+    }
+
+    await database.write(async () => {
+      await session.update((record: any) => {
+        record.settingsSource = settingsSource;
       });
     });
   }

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -107,15 +107,21 @@ export const ChatScreen: React.FC = observer(() => {
 
   const thinkingSupported = modelStore.activeModel?.supportsThinking ?? false;
 
-  const thinkingEnabled = (() => {
-    const currentSession = chatSessionStore.sessions.find(
-      s => s.id === chatSessionStore.activeSessionId,
-    );
-    const settings =
-      currentSession?.completionSettings ??
-      chatSessionStore.newChatCompletionSettings;
-    return settings.enable_thinking ?? true;
-  })();
+  const [thinkingEnabled, setThinkingEnabled] = useState(true);
+  const activeSession = chatSessionStore.sessions.find(
+    s => s.id === chatSessionStore.activeSessionId,
+  );
+  React.useEffect(() => {
+    chatSessionStore.getCurrentCompletionSettings().then(settings => {
+      setThinkingEnabled(settings.enable_thinking ?? true);
+    });
+  }, [
+    chatSessionStore.activeSessionId,
+    activeSession?.settingsSource,
+    activeSession?.completionSettings,
+    chatSessionStore.newChatCompletionSettings,
+    activePalId,
+  ]);
 
   // Show loading bubble only during the thinking phase (inferencing but not streaming)
   const isThinking = modelStore.inferencing && !modelStore.isStreaming;
@@ -126,9 +132,11 @@ export const ChatScreen: React.FC = observer(() => {
     );
 
     if (currentSession) {
-      // Update session-specific settings
+      // Use resolved settings so pal overrides (temperature, etc.) are preserved
+      const resolvedSettings =
+        await chatSessionStore.getCurrentCompletionSettings();
       const updatedSettings = {
-        ...currentSession.completionSettings,
+        ...resolvedSettings,
         enable_thinking: enabled,
       };
       await chatSessionStore.updateSessionCompletionSettings(updatedSettings);

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -115,6 +115,7 @@ export const ChatScreen: React.FC = observer(() => {
     chatSessionStore.getCurrentCompletionSettings().then(settings => {
       setThinkingEnabled(settings.enable_thinking ?? true);
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     chatSessionStore.activeSessionId,
     activeSession?.settingsSource,

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -112,9 +112,15 @@ export const ChatScreen: React.FC = observer(() => {
     s => s.id === chatSessionStore.activeSessionId,
   );
   React.useEffect(() => {
+    let cancelled = false;
     chatSessionStore.getCurrentCompletionSettings().then(settings => {
-      setThinkingEnabled(settings.enable_thinking ?? true);
+      if (!cancelled) {
+        setThinkingEnabled(settings.enable_thinking ?? true);
+      }
     });
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     chatSessionStore.activeSessionId,

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -179,8 +179,7 @@ class ChatSessionStore {
           messages,
           completionSettings,
           activePalId: session.activePalId,
-          settingsSource:
-            (session.settingsSource as 'pal' | 'custom') || 'pal',
+          settingsSource: (session.settingsSource as 'pal' | 'custom') || 'pal',
           messagesLoaded: false, // Mark as not loaded for lazy loading
         });
       }

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -179,7 +179,8 @@ class ChatSessionStore {
           messages,
           completionSettings,
           activePalId: session.activePalId,
-          settingsSource: 'pal', // Default to pal settings for existing sessions
+          settingsSource:
+            (session.settingsSource as 'pal' | 'custom') || 'pal',
           messagesLoaded: false, // Mark as not loaded for lazy loading
         });
       }
@@ -343,8 +344,12 @@ class ChatSessionStore {
         });
       }
     } else {
-      // Always use the global settings for new sessions
-      const settings = {...this.newChatCompletionSettings};
+      // Resolve settings including pal overrides so the session snapshot
+      // matches what the model actually receives
+      const settings = await this.resolveCompletionSettings(
+        undefined,
+        this.newChatPalId,
+      );
       await this.createNewSession(NEW_SESSION_TITLE, [message], settings);
     }
   }
@@ -391,6 +396,7 @@ class ChatSessionStore {
         initialMessages,
         completionSettings,
         this.newChatPalId,
+        this.newChatSettingsSource,
       );
 
       // Get the full session data
@@ -584,6 +590,10 @@ class ChatSessionStore {
             this.activeSessionId,
             settings,
           );
+          await chatSessionRepository.setSessionSettingsSource(
+            this.activeSessionId,
+            'custom',
+          );
 
           // Update local state directly - no need to reload from database
           runInAction(() => {
@@ -601,6 +611,10 @@ class ChatSessionStore {
     if (this.activeSessionId) {
       const session = this.sessions.find(s => s.id === this.activeSessionId);
       if (session) {
+        await chatSessionRepository.setSessionSettingsSource(
+          this.activeSessionId,
+          source,
+        );
         runInAction(() => {
           session.settingsSource = source;
         });

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -343,11 +343,13 @@ class ChatSessionStore {
         });
       }
     } else {
-      // Resolve settings including pal overrides so the session snapshot
-      // matches what the model actually receives
+      // Resolve settings using the selected settings source so the
+      // session snapshot matches what the model actually receives
+      const palIdForSettings =
+        this.newChatSettingsSource === 'pal' ? this.newChatPalId : undefined;
       const settings = await this.resolveCompletionSettings(
         undefined,
-        this.newChatPalId,
+        palIdForSettings,
       );
       await this.createNewSession(NEW_SESSION_TITLE, [message], settings);
     }

--- a/src/store/__tests__/ChatSessionStore.test.ts
+++ b/src/store/__tests__/ChatSessionStore.test.ts
@@ -24,6 +24,7 @@ jest.spyOn(chatSessionRepository, 'updateSessionCompletionSettings');
 jest.spyOn(chatSessionRepository, 'getGlobalCompletionSettings');
 jest.spyOn(chatSessionRepository, 'saveGlobalCompletionSettings');
 jest.spyOn(chatSessionRepository, 'setSessionActivePal');
+jest.spyOn(chatSessionRepository, 'setSessionSettingsSource');
 
 describe('chatSessionStore', () => {
   const mockMessage = {
@@ -426,6 +427,7 @@ describe('chatSessionStore', () => {
         [mockMessage],
         defaultCompletionSettings,
         undefined,
+        'pal',
       );
       expect(chatSessionRepository.getSessionById).toHaveBeenCalledWith(
         mockNewSession.id,
@@ -489,6 +491,7 @@ describe('chatSessionStore', () => {
         [mockMessage],
         originalSession.completionSettings,
         undefined,
+        'pal',
       );
       expect(chatSessionStore.sessions.length).toBe(2);
       expect(chatSessionStore.sessions[1].completionSettings.temperature).toBe(
@@ -626,6 +629,7 @@ describe('chatSessionStore', () => {
         [mockMessage],
         originalSession.completionSettings,
         undefined,
+        'pal',
       );
       expect(chatSessionStore.sessions.length).toBe(2);
       expect(chatSessionStore.sessions[1].title).toBe(
@@ -759,12 +763,18 @@ describe('chatSessionStore', () => {
       (
         chatSessionRepository.updateSessionCompletionSettings as jest.Mock
       ).mockResolvedValue(undefined);
+      (
+        chatSessionRepository.setSessionSettingsSource as jest.Mock
+      ).mockResolvedValue(undefined);
 
       await chatSessionStore.updateSessionCompletionSettings(newSettings);
 
       expect(
         chatSessionRepository.updateSessionCompletionSettings,
       ).toHaveBeenCalledWith(session.id, newSettings);
+      expect(
+        chatSessionRepository.setSessionSettingsSource,
+      ).toHaveBeenCalledWith(session.id, 'custom');
       expect(chatSessionStore.sessions[0].completionSettings).toEqual(
         newSettings,
       );
@@ -847,6 +857,7 @@ describe('chatSessionStore', () => {
         [],
         customSettings,
         undefined,
+        'pal',
       );
       expect(chatSessionStore.sessions[0].completionSettings).toEqual(
         customSettings,


### PR DESCRIPTION
## Summary
- **Thinking toggle** now reads from resolved settings (including pal overrides) instead of raw session/global settings, so it correctly shows the effective `enable_thinking` state
- **Toggling thinking** preserves pal-specific settings (temperature, etc.) by spreading resolved settings instead of stored session defaults
- **New sessions** store resolved settings (with pal overrides) so the session snapshot matches what the model receives
- **`settingsSource`** (`'pal'`|`'custom'`) is now persisted to the database via a new column on `chat_sessions` (schema v5→v6), surviving app restarts

## Context
When a pal overrides completion settings (e.g. `enable_thinking: false`, `temperature: 0.9`), the resolution hierarchy (defaults → global → pal → session) was applied correctly at completion time but not reflected in the UI or session storage:

1. The thinking toggle read directly from session/global settings, ignoring pal overrides
2. Toggling thinking spread the raw session settings (which only had global defaults), losing pal overrides
3. New sessions stored global-only settings instead of resolved settings
4. `settingsSource` was in-memory only, reverting to `'pal'` on every app restart

## Test plan
- [x] Load a thinking-capable model (e.g. Qwen3-0.6B)
- [x] Toggle thinking on/off without a pal — verify it works
- [x] Create a pal with `enable_thinking: false` and custom temperature
- [x] Select the pal — verify thinking toggle shows OFF
- [x] Send a message — open generation settings — verify temperature matches pal's value
- [x] Toggle thinking ON — open generation settings — verify temperature is preserved
- [x] Kill and reopen app — navigate to same session — verify settings source is preserved
- [ ] Verify existing sessions without `settings_source` column default to `'pal'` (migration)

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)