### PR TITLE
feat(pal): add combobox input type for dynamic parameter forms

### DIFF
--- a/src/components/DynamicParameters/DynamicComboboxField.tsx
+++ b/src/components/DynamicParameters/DynamicComboboxField.tsx
@@ -34,6 +34,7 @@ const ComboboxInput: React.FC<{
           opt.toLowerCase().includes(searchText.toLowerCase()),
         )
       : options;
+  const isMenuOpen = menuVisible && filteredOptions.length > 0;
 
   const resetSearch = () => {
     setIsSearching(false);
@@ -47,7 +48,7 @@ const ComboboxInput: React.FC<{
 
   return (
     <Menu
-      visible={menuVisible && filteredOptions.length > 0}
+      visible={isMenuOpen}
       onDismiss={closeMenu}
       anchorPosition="bottom"
       selectable
@@ -56,12 +57,18 @@ const ComboboxInput: React.FC<{
           testID={`dynamic-combobox-input-${parameter.key}`}
           value={displayValue}
           onChangeText={text => {
+            if (disabled) {
+              return;
+            }
             setSearchText(text);
             setIsSearching(true);
             onChange(text);
             setMenuVisible(true);
           }}
           onFocus={() => {
+            if (disabled) {
+              return;
+            }
             resetSearch();
             setMenuVisible(true);
           }}
@@ -72,8 +79,12 @@ const ComboboxInput: React.FC<{
           returnKeyType="default"
           right={
             <PaperTextInput.Icon
-              icon={menuVisible ? 'chevron-up' : 'chevron-down'}
+              icon={isMenuOpen ? 'chevron-up' : 'chevron-down'}
+              disabled={disabled}
               onPress={() => {
+                if (disabled) {
+                  return;
+                }
                 if (menuVisible) {
                   closeMenu();
                 } else {

--- a/src/components/DynamicParameters/DynamicComboboxField.tsx
+++ b/src/components/DynamicParameters/DynamicComboboxField.tsx
@@ -40,6 +40,7 @@ const ComboboxInput: React.FC<{
         setIsSearching(false);
         setSearchText('');
       }}
+      anchorPosition="bottom"
       selectable
       anchor={
         <TextInput

--- a/src/components/DynamicParameters/DynamicComboboxField.tsx
+++ b/src/components/DynamicParameters/DynamicComboboxField.tsx
@@ -1,0 +1,107 @@
+import React, {useState} from 'react';
+import {View} from 'react-native';
+import {Text} from 'react-native-paper';
+import {Controller, useFormContext} from 'react-hook-form';
+
+import type {ParameterDefinition} from '../../types/pal';
+import {useTheme} from '../../hooks';
+import {createStyles} from './styles';
+import {TextInput} from '../TextInput';
+import {Menu} from '../Menu';
+
+interface DynamicComboboxFieldProps {
+  parameter: ParameterDefinition;
+  disabled?: boolean;
+  error?: string;
+}
+
+const ComboboxInput: React.FC<{
+  parameter: ParameterDefinition;
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+  error?: string;
+}> = ({parameter, value, onChange, disabled, error}) => {
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const options = parameter.options || [];
+  const filteredOptions = value
+    ? options.filter(opt => opt.toLowerCase().includes(value.toLowerCase()))
+    : options;
+
+  return (
+    <Menu
+      visible={menuVisible && filteredOptions.length > 0}
+      onDismiss={() => setMenuVisible(false)}
+      selectable
+      anchor={
+        <TextInput
+          testID={`dynamic-combobox-input-${parameter.key}`}
+          value={value || ''}
+          onChangeText={text => {
+            onChange(text);
+            setMenuVisible(true);
+          }}
+          onFocus={() => setMenuVisible(true)}
+          error={!!error}
+          placeholder={parameter.placeholder}
+          helperText={error}
+          editable={!disabled}
+          returnKeyType="default"
+        />
+      }>
+      {filteredOptions.map(option => (
+        <Menu.Item
+          key={option}
+          label={option}
+          onPress={() => {
+            onChange(option);
+            setMenuVisible(false);
+          }}
+          selected={option === value}
+          testID={`dynamic-combobox-option-${parameter.key}-${option}`}
+        />
+      ))}
+    </Menu>
+  );
+};
+
+export const DynamicComboboxField: React.FC<DynamicComboboxFieldProps> = ({
+  parameter,
+  disabled = false,
+  error,
+}) => {
+  const theme = useTheme();
+  const styles = createStyles(theme);
+  const {control} = useFormContext();
+
+  return (
+    <View style={styles.field} testID={`dynamic-combobox-${parameter.key}`}>
+      <Text style={theme.fonts.titleMediumLight}>
+        {parameter.label}
+        {parameter.required && '*'}
+      </Text>
+      {parameter.description && (
+        <Text style={styles.sublabel}>{parameter.description}</Text>
+      )}
+      <Controller
+        control={control}
+        name={parameter.key}
+        rules={{
+          required: parameter.required
+            ? `${parameter.label} is required`
+            : false,
+        }}
+        render={({field: {onChange, value}}) => (
+          <ComboboxInput
+            parameter={parameter}
+            value={value || ''}
+            onChange={onChange}
+            disabled={disabled}
+            error={error}
+          />
+        )}
+      />
+    </View>
+  );
+};

--- a/src/components/DynamicParameters/DynamicComboboxField.tsx
+++ b/src/components/DynamicParameters/DynamicComboboxField.tsx
@@ -28,18 +28,27 @@ const ComboboxInput: React.FC<{
 
   const options = parameter.options || [];
   const displayValue = isSearching ? searchText : value || '';
-  const filteredOptions = isSearching && searchText
-    ? options.filter(opt => opt.toLowerCase().includes(searchText.toLowerCase()))
-    : options;
+  const filteredOptions =
+    isSearching && searchText
+      ? options.filter(opt =>
+          opt.toLowerCase().includes(searchText.toLowerCase()),
+        )
+      : options;
+
+  const resetSearch = () => {
+    setIsSearching(false);
+    setSearchText('');
+  };
+
+  const closeMenu = () => {
+    setMenuVisible(false);
+    resetSearch();
+  };
 
   return (
     <Menu
       visible={menuVisible && filteredOptions.length > 0}
-      onDismiss={() => {
-        setMenuVisible(false);
-        setIsSearching(false);
-        setSearchText('');
-      }}
+      onDismiss={closeMenu}
       anchorPosition="bottom"
       selectable
       anchor={
@@ -53,8 +62,7 @@ const ComboboxInput: React.FC<{
             setMenuVisible(true);
           }}
           onFocus={() => {
-            setIsSearching(false);
-            setSearchText('');
+            resetSearch();
             setMenuVisible(true);
           }}
           error={!!error}
@@ -67,12 +75,9 @@ const ComboboxInput: React.FC<{
               icon={menuVisible ? 'chevron-up' : 'chevron-down'}
               onPress={() => {
                 if (menuVisible) {
-                  setMenuVisible(false);
-                  setIsSearching(false);
-                  setSearchText('');
+                  closeMenu();
                 } else {
-                  setIsSearching(false);
-                  setSearchText('');
+                  resetSearch();
                   setMenuVisible(true);
                 }
               }}
@@ -86,9 +91,7 @@ const ComboboxInput: React.FC<{
           label={option}
           onPress={() => {
             onChange(option);
-            setMenuVisible(false);
-            setIsSearching(false);
-            setSearchText('');
+            closeMenu();
           }}
           selected={option === value}
           testID={`dynamic-combobox-option-${parameter.key}-${option}`}

--- a/src/components/DynamicParameters/DynamicComboboxField.tsx
+++ b/src/components/DynamicParameters/DynamicComboboxField.tsx
@@ -23,26 +23,39 @@ const ComboboxInput: React.FC<{
   error?: string;
 }> = ({parameter, value, onChange, disabled, error}) => {
   const [menuVisible, setMenuVisible] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
 
   const options = parameter.options || [];
-  const filteredOptions = value
-    ? options.filter(opt => opt.toLowerCase().includes(value.toLowerCase()))
+  const displayValue = isSearching ? searchText : value || '';
+  const filteredOptions = isSearching && searchText
+    ? options.filter(opt => opt.toLowerCase().includes(searchText.toLowerCase()))
     : options;
 
   return (
     <Menu
       visible={menuVisible && filteredOptions.length > 0}
-      onDismiss={() => setMenuVisible(false)}
+      onDismiss={() => {
+        setMenuVisible(false);
+        setIsSearching(false);
+        setSearchText('');
+      }}
       selectable
       anchor={
         <TextInput
           testID={`dynamic-combobox-input-${parameter.key}`}
-          value={value || ''}
+          value={displayValue}
           onChangeText={text => {
+            setSearchText(text);
+            setIsSearching(true);
             onChange(text);
             setMenuVisible(true);
           }}
-          onFocus={() => setMenuVisible(true)}
+          onFocus={() => {
+            setIsSearching(false);
+            setSearchText('');
+            setMenuVisible(true);
+          }}
           error={!!error}
           placeholder={parameter.placeholder}
           helperText={error}
@@ -51,7 +64,17 @@ const ComboboxInput: React.FC<{
           right={
             <PaperTextInput.Icon
               icon={menuVisible ? 'chevron-up' : 'chevron-down'}
-              onPress={() => setMenuVisible(v => !v)}
+              onPress={() => {
+                if (menuVisible) {
+                  setMenuVisible(false);
+                  setIsSearching(false);
+                  setSearchText('');
+                } else {
+                  setIsSearching(false);
+                  setSearchText('');
+                  setMenuVisible(true);
+                }
+              }}
             />
           }
         />
@@ -63,6 +86,8 @@ const ComboboxInput: React.FC<{
           onPress={() => {
             onChange(option);
             setMenuVisible(false);
+            setIsSearching(false);
+            setSearchText('');
           }}
           selected={option === value}
           testID={`dynamic-combobox-option-${parameter.key}-${option}`}

--- a/src/components/DynamicParameters/DynamicComboboxField.tsx
+++ b/src/components/DynamicParameters/DynamicComboboxField.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {View} from 'react-native';
-import {Text} from 'react-native-paper';
+import {Text, TextInput as PaperTextInput} from 'react-native-paper';
 import {Controller, useFormContext} from 'react-hook-form';
 
 import type {ParameterDefinition} from '../../types/pal';
@@ -48,6 +48,12 @@ const ComboboxInput: React.FC<{
           helperText={error}
           editable={!disabled}
           returnKeyType="default"
+          right={
+            <PaperTextInput.Icon
+              icon={menuVisible ? 'chevron-up' : 'chevron-down'}
+              onPress={() => setMenuVisible(v => !v)}
+            />
+          }
         />
       }>
       {filteredOptions.map(option => (

--- a/src/components/DynamicParameters/DynamicParameterForm.tsx
+++ b/src/components/DynamicParameters/DynamicParameterForm.tsx
@@ -8,6 +8,7 @@ import {createStyles} from './styles';
 import {DynamicTextField} from './DynamicTextField';
 import {DynamicOptionField} from './DynamicOptionField';
 import {DynamicDateTimeTagField} from './DynamicDateTimeTagField';
+import {DynamicComboboxField} from './DynamicComboboxField';
 
 interface DynamicParameterFormProps {
   schema: ParameterDefinition[];
@@ -37,6 +38,9 @@ export const DynamicParameterForm: React.FC<DynamicParameterFormProps> = ({
 
       case 'select':
         return <DynamicOptionField key={parameter.key} {...commonProps} />;
+
+      case 'combobox':
+        return <DynamicComboboxField key={parameter.key} {...commonProps} />;
 
       case 'datetime_tag':
         return <DynamicDateTimeTagField key={parameter.key} {...commonProps} />;

--- a/src/components/DynamicParameters/__tests__/DynamicComboboxField.test.tsx
+++ b/src/components/DynamicParameters/__tests__/DynamicComboboxField.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import {FormProvider, useForm} from 'react-hook-form';
+import {render, fireEvent} from '../../../../jest/test-utils';
+import {DynamicComboboxField} from '../DynamicComboboxField';
+import type {ParameterDefinition} from '../../../types/pal';
+
+// Wrapper component to provide form context
+const TestWrapper: React.FC<{
+  children: React.ReactNode;
+  defaultValues?: Record<string, any>;
+}> = ({children, defaultValues = {}}) => {
+  const methods = useForm({defaultValues});
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('DynamicComboboxField', () => {
+  const mockParameter: ParameterDefinition = {
+    key: 'testCombobox',
+    type: 'combobox',
+    label: 'Test Combobox',
+    required: false,
+    options: ['English', 'French', 'German', 'Spanish'],
+    placeholder: 'Type or select a language',
+    description: 'Choose or type a language',
+  };
+
+  it('should render with label and description', () => {
+    const {getByText} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={mockParameter} />
+      </TestWrapper>,
+    );
+
+    expect(getByText('Test Combobox')).toBeTruthy();
+    expect(getByText('Choose or type a language')).toBeTruthy();
+  });
+
+  it('should show required indicator when required', () => {
+    const requiredParameter = {...mockParameter, required: true};
+
+    const {getByText} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={requiredParameter} />
+      </TestWrapper>,
+    );
+
+    expect(getByText('Test Combobox*')).toBeTruthy();
+  });
+
+  it('should render input with placeholder', () => {
+    const {getByPlaceholderText} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={mockParameter} />
+      </TestWrapper>,
+    );
+
+    expect(getByPlaceholderText('Type or select a language')).toBeTruthy();
+  });
+
+  it('should handle text input changes (free text)', () => {
+    const {getByTestId} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={mockParameter} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+    fireEvent.changeText(input, 'Custom Language');
+
+    expect(input.props.value).toBe('Custom Language');
+  });
+
+  it('should filter options by typed text (case-insensitive)', () => {
+    const {getByTestId, queryByTestId} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={mockParameter} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+    fireEvent.changeText(input, 'en');
+
+    // "English" and "French" contain "en"
+    expect(
+      queryByTestId('dynamic-combobox-option-testCombobox-English'),
+    ).toBeTruthy();
+    expect(
+      queryByTestId('dynamic-combobox-option-testCombobox-French'),
+    ).toBeTruthy();
+    // "German" contains "en" too (GermaN? No — "German" has "an" not "en")
+    // Actually "German" does NOT contain "en". Let's check: G-e-r-m-a-n. No "en".
+    expect(
+      queryByTestId('dynamic-combobox-option-testCombobox-German'),
+    ).toBeNull();
+    // "Spanish" does not contain "en"
+    expect(
+      queryByTestId('dynamic-combobox-option-testCombobox-Spanish'),
+    ).toBeNull();
+  });
+
+  it('should select a menu option and update the input value', () => {
+    const {getByTestId} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={mockParameter} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+
+    // Focus to show menu
+    fireEvent(input, 'focus');
+
+    // Select an option
+    const option = getByTestId(
+      'dynamic-combobox-option-testCombobox-French',
+    );
+    fireEvent.press(option);
+
+    expect(input.props.value).toBe('French');
+  });
+
+  it('should show all options when input is empty and focused', () => {
+    const {getByTestId} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={mockParameter} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+    fireEvent(input, 'focus');
+
+    expect(
+      getByTestId('dynamic-combobox-option-testCombobox-English'),
+    ).toBeTruthy();
+    expect(
+      getByTestId('dynamic-combobox-option-testCombobox-French'),
+    ).toBeTruthy();
+    expect(
+      getByTestId('dynamic-combobox-option-testCombobox-German'),
+    ).toBeTruthy();
+    expect(
+      getByTestId('dynamic-combobox-option-testCombobox-Spanish'),
+    ).toBeTruthy();
+  });
+
+  it('should display error message when provided', () => {
+    const {getByText} = render(
+      <TestWrapper>
+        <DynamicComboboxField
+          parameter={mockParameter}
+          error="This field is required"
+        />
+      </TestWrapper>,
+    );
+
+    expect(getByText('This field is required')).toBeTruthy();
+  });
+
+  it('should be disabled when disabled prop is true', () => {
+    const {getByTestId} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={mockParameter} disabled={true} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+    expect(input.props.editable).toBe(false);
+  });
+
+  it('should use default value from form context', () => {
+    const {getByTestId} = render(
+      <TestWrapper defaultValues={{testCombobox: 'German'}}>
+        <DynamicComboboxField parameter={mockParameter} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+    expect(input.props.value).toBe('German');
+  });
+
+  it('should handle empty options array', () => {
+    const parameterWithoutOptions = {...mockParameter, options: []};
+
+    const {getByTestId} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={parameterWithoutOptions} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+    expect(input).toBeTruthy();
+  });
+
+  it('should handle undefined options', () => {
+    const parameterWithoutOptions = {...mockParameter, options: undefined};
+
+    const {getByTestId} = render(
+      <TestWrapper>
+        <DynamicComboboxField parameter={parameterWithoutOptions} />
+      </TestWrapper>,
+    );
+
+    const input = getByTestId('dynamic-combobox-input-testCombobox');
+    expect(input).toBeTruthy();
+  });
+});

--- a/src/components/DynamicParameters/__tests__/DynamicComboboxField.test.tsx
+++ b/src/components/DynamicParameters/__tests__/DynamicComboboxField.test.tsx
@@ -111,9 +111,7 @@ describe('DynamicComboboxField', () => {
     fireEvent(input, 'focus');
 
     // Select an option
-    const option = getByTestId(
-      'dynamic-combobox-option-testCombobox-French',
-    );
+    const option = getByTestId('dynamic-combobox-option-testCombobox-French');
     fireEvent.press(option);
 
     expect(input.props.value).toBe('French');

--- a/src/components/DynamicParameters/__tests__/DynamicParameterForm.test.tsx
+++ b/src/components/DynamicParameters/__tests__/DynamicParameterForm.test.tsx
@@ -99,6 +99,26 @@ describe('DynamicParameterForm', () => {
     expect(getByTestId('dynamic-option-testSelect')).toBeTruthy();
   });
 
+  it('should render combobox field for combobox type', () => {
+    const schema: ParameterDefinition[] = [
+      {
+        key: 'testCombobox',
+        type: 'combobox',
+        label: 'Test Combobox',
+        required: false,
+        options: ['Option A', 'Option B'],
+      },
+    ];
+
+    const {getByTestId} = render(
+      <TestWrapper>
+        <DynamicParameterForm schema={schema} />
+      </TestWrapper>,
+    );
+
+    expect(getByTestId('dynamic-combobox-testCombobox')).toBeTruthy();
+  });
+
   it('should render datetime field for datetime_tag type', () => {
     const schema: ParameterDefinition[] = [
       {

--- a/src/components/DynamicParameters/index.ts
+++ b/src/components/DynamicParameters/index.ts
@@ -1,4 +1,5 @@
 export {DynamicParameterForm} from './DynamicParameterForm';
 export {DynamicTextField} from './DynamicTextField';
 export {DynamicOptionField} from './DynamicOptionField';
+export {DynamicComboboxField} from './DynamicComboboxField';
 export {DynamicDateTimeTagField} from './DynamicDateTimeTagField';

--- a/src/types/pal.ts
+++ b/src/types/pal.ts
@@ -1,13 +1,13 @@
 import type {Model} from '../utils/types';
 
-export type ParameterType = 'text' | 'select' | 'datetime_tag';
+export type ParameterType = 'text' | 'select' | 'combobox' | 'datetime_tag';
 
 export interface ParameterDefinition {
   key: string;
   type: ParameterType;
   label: string;
   required: boolean;
-  options?: string[]; // for select
+  options?: string[]; // for select and combobox
   placeholder?: string;
   description?: string;
 }

--- a/src/utils/__tests__/palshub-template-parser.test.ts
+++ b/src/utils/__tests__/palshub-template-parser.test.ts
@@ -141,6 +141,41 @@ Remember to stay true to your character's nature.`;
       });
     });
 
+    it('should parse a combobox type with options from template schema', () => {
+      const template = `{{! json-schema-start
+{
+  "language": {
+    "label": "Language",
+    "type": "combobox",
+    "required": true,
+    "options": ["English", "French", "German", "Spanish"],
+    "placeholder": "Type or select a language",
+    "description": "Choose or type a language",
+    "default": "English"
+  }
+}
+json-schema-end }}
+
+Translate to {{language}}.`;
+
+      const result = parsePalsHubTemplate(template);
+
+      expect(result.cleanSystemPrompt).toBe('Translate to {{language}}.');
+      expect(result.parameterSchema).toHaveLength(1);
+      expect(result.parameterSchema[0]).toEqual({
+        key: 'language',
+        type: 'combobox',
+        label: 'Language',
+        required: true,
+        placeholder: 'Type or select a language',
+        description: 'Choose or type a language',
+        options: ['English', 'French', 'German', 'Spanish'],
+      });
+      expect(result.defaultParameters).toEqual({
+        language: 'English',
+      });
+    });
+
     it('should handle templates without JSON schema', () => {
       const template = 'You are {{name}}, a helpful assistant.';
       const result = parsePalsHubTemplate(template);

--- a/src/utils/palshub-template-parser.ts
+++ b/src/utils/palshub-template-parser.ts
@@ -103,6 +103,9 @@ function convertJsonSchemaToPocketPal(
       case 'select':
         pocketPalType = 'select';
         break;
+      case 'combobox':
+        pocketPalType = 'combobox';
+        break;
       case 'text':
       default:
         pocketPalType = 'text';
@@ -119,7 +122,10 @@ function convertJsonSchemaToPocketPal(
     };
 
     // Add options for select fields
-    if (pocketPalType === 'select' && Array.isArray(definition.options)) {
+    if (
+      (pocketPalType === 'select' || pocketPalType === 'combobox') &&
+      Array.isArray(definition.options)
+    ) {
       paramDef.options = definition.options;
     }
 
@@ -145,7 +151,8 @@ function extractDefaultParametersFromSchema(
     // Set appropriate default based on type
     switch (definition.type) {
       case 'select':
-        // For select, use schema default or empty string (single-select)
+      case 'combobox':
+        // For select/combobox, use schema default or empty string (single-select)
         defaults[key] =
           definition.default !== undefined ? definition.default : '';
         break;

--- a/src/utils/palshub-template-parser.ts
+++ b/src/utils/palshub-template-parser.ts
@@ -121,7 +121,7 @@ function convertJsonSchemaToPocketPal(
       description: definition.description,
     };
 
-    // Add options for select fields
+    // Add options for select and combobox fields
     if (
       (pocketPalType === 'select' || pocketPalType === 'combobox') &&
       Array.isArray(definition.options)


### PR DESCRIPTION
## Summary

- Adds a new `combobox` parameter type for Pal configuration forms — a searchable text input with a filterable dropdown of predefined options that also accepts free text
- Enables Pals like the Lingua translator to offer a searchable language selector where users can pick from suggestions or type a custom value
- Touches only JS/TS code (no native changes)

## Changes

- **`src/types/pal.ts`**: Added `'combobox'` to `ParameterType` union
- **`src/utils/palshub-template-parser.ts`**: Added `combobox` case in parser switch and options propagation
- **`src/components/DynamicParameters/DynamicComboboxField.tsx`**: New component with `ComboboxInput` inner component using `Menu` + `TextInput` from react-native-paper
- **`src/components/DynamicParameters/DynamicParameterForm.tsx`**: Added routing for `combobox` type
- **`src/components/DynamicParameters/index.ts`**: Added export

## Test plan

- [x] 11 unit tests for DynamicComboboxField (render, required, placeholder, free text, filtering, selection, focus, error, disabled, default value, empty options)
- [x] 1 routing test in DynamicParameterForm
- [x] 1 parser test in palshub-template-parser
- [x] Lint: 0 errors
- [x] TypeCheck: clean
- [x] All 45 related tests passing
- [x] Manual: create/modify a Pal with `"type": "combobox"` and verify filtering, selection, and free text entry
- [x] Manual: verify existing text and select fields still work

Linear: P-222

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)