### PR TITLE
chore(deps): upgrade llama.rn to 0.12.0-rc.8

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.0-rc.5):
+  - llama-rn (0.12.0-rc.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -3655,7 +3655,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: d316bbee13fb9b89ba372a2e283de6f5fdb57e8d
+  llama-rn: 1786e2a130bdb5cc53dd681ac679020b48b814ce
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.12.0-rc.5",
+    "llama.rn": "0.12.0-rc.8",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,10 +6500,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.0-rc.5:
-  version "0.12.0-rc.5"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0-rc.5.tgz#6054fc4cd44ed86aafee22cdb6c3649588f8e029"
-  integrity sha512-92UDVtroH4hMWekgGyjxtAM4/K5NizO4kEPnhGOloXpuH67H5GWH3sZsT617afJwVwyvLTX8WtoY/M1Ke9wjNw==
+llama.rn@0.12.0-rc.8:
+  version "0.12.0-rc.8"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0-rc.8.tgz#4ddce5e367e096fd3786c7ea221738effc3f622d"
+  integrity sha512-IT7phq/jgj5JS6bKqmQSe0FBeOnClTd8Wgmn2fZSKImfiStqQdffwfhG2zT8SAxty4ChR44iO4eMymOfyw6wJA==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Bump `llama.rn` from `0.12.0-rc.5` to `0.12.0-rc.8`
- Regenerated `yarn.lock` and `ios/Podfile.lock` (new checksum `1786e2a1...`)
- Exactly 3 files changed — matches prior upgrade precedent (PR #664, commits `0614148`, `f91144d`)

## Verification
- `yarn typecheck`: PASS
- `yarn lint`: PASS (0 errors)
- iOS Release build (`yarn ios:build:e2e`): PASS (247.53s)
- Android Release build (`./gradlew assembleRelease`): PASS (11m 41s)
- E2E `quick-smoke` on iPhone 17 Pro sim (iOS 26.0): PASS — smollm2-135m at 119.81 tok/s, 103ms TTFT

Story: `workflows/stories/TASK-20260414-llama-rc8.md`

## Test plan
- [x] iOS Release builds
- [x] Android Release builds
- [x] E2E quick-smoke passes
- [ ] Manual smoke on physical device (optional)

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)