### PR TITLE
fix(release): increase Node heap size for iOS bundle step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,8 @@ jobs:
   build_ios:
     runs-on: macos-15 # macOS 15 with Xcode 16
     needs: build_android
+    env:
+      NODE_OPTIONS: '--max-old-space-size=8192'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Mirrors the CI fix (d6feb7d) on the release workflow: adds `NODE_OPTIONS: '--max-old-space-size=8192'` to the `build_ios` job in `.github/workflows/release.yml`.
- Without it, the Metro/Hermes "Bundle React Native code and images" PhaseScriptExecution step OOMs on the 4GB default Node heap, killing the TestFlight upload.

## Evidence
- Failed release run: [24673701509](https://github.com/a-ghorbani/pocketpal-ai/actions/runs/24673701509/job/72156304509) — `build_ios_app` died after 1105s at the bundle phase.
- Same symptom and fix as commit d6feb7d for `ci.yml`.

## Test plan
- [ ] Re-trigger the release workflow and confirm `build_ios` completes the bundle step and uploads to TestFlight.

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)