### PR TITLE
feat(release): add ios_only dispatch input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,16 @@ on:
           - preminor
           - prepatch
           - prerelease
+      ios_only:
+        description: "iOS only: skip version bump + Android, build TestFlight from current ref"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   # Job 1: Version Bumping and Android Build
   build_android:
+    if: ${{ !inputs.ios_only }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'write' # Allows workflow to checkout repository code
@@ -147,6 +153,7 @@ jobs:
   build_ios:
     runs-on: macos-15 # macOS 15 with Xcode 16
     needs: build_android
+    if: ${{ always() && (needs.build_android.result == 'success' || needs.build_android.result == 'skipped') }}
     env:
       NODE_OPTIONS: '--max-old-space-size=8192'
 


### PR DESCRIPTION
## Summary
- Adds `ios_only` boolean input (default `false`) to the release `workflow_dispatch`.
- When set, `build_android` is skipped (no version bump, no tag, no Play Store upload, no GitHub Release).
- `build_ios` gets an `if:` guard so it runs whether `build_android` succeeded or was skipped — existing full-release flow is unchanged.

## Motivation
Release run 24673701509 shipped v1.14.0 to Play Store Alpha + cut the GitHub Release, but the iOS job OOMed at the bundle step. With this input we can re-run just iOS/TestFlight off the already-bumped `main` instead of doing a throwaway 1.14.1 bump.

## Test plan
- [ ] Dispatch the Release workflow with `ios_only = true` from `main`, confirm `build_android` is skipped and `build_ios` runs and uploads to TestFlight.
- [ ] Next regular release: dispatch without `ios_only`, confirm both jobs still run in sequence.

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)