### PR TITLE
feat(android): enable Adreno large buffer for A7X/A8X GPUs

### DIFF
--- a/android/app/src/main/java/com/pocketpalai/MainApplication.kt
+++ b/android/app/src/main/java/com/pocketpalai/MainApplication.kt
@@ -1,6 +1,7 @@
 package com.pocketpal
 
 import android.app.Application
+import android.system.Os
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
@@ -43,6 +44,12 @@ class MainApplication : Application(), ReactApplication {
 
   override fun onCreate() {
     super.onCreate()
+    // Enable Adreno large buffer support on Qualcomm A7X/A8X GPUs.
+    // The OpenCL backend in llama.rn self-gates on GPU family and the
+    // cl_qcom_large_buffer extension — this is a no-op on non-Adreno devices.
+    // Must be set before SoLoader.init so the native library picks it up.
+    // See: https://github.com/ggml-org/llama.cpp/pull/20997
+    Os.setenv("LM_GGML_OPENCL_ADRENO_USE_LARGE_BUFFER", "1", true)
     SoLoader.init(this, OpenSourceMergedSoMapping)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // If you opted-in for the New Architecture, we load the native entry point for this app.


### PR DESCRIPTION
## Summary

Sets `LM_GGML_OPENCL_ADRENO_USE_LARGE_BUFFER=1` before `SoLoader.init` in `MainApplication.kt` so llama.rn's OpenCL backend enables Qualcomm's `cl_qcom_large_buffer` extension on Adreno A7X/A8X GPUs.

This lifts the per-allocation `CL_DEVICE_MAX_MEM_ALLOC_SIZE` cap (~1 GB on most Qualcomm drivers), letting 7B+ models and long-context KV caches stay on GPU instead of failing allocation on flagship Snapdragon devices.

Closes #657

## Why

- Standard OpenCL caps a single buffer allocation at `CL_DEVICE_MAX_MEM_ALLOC_SIZE`. On Adreno drivers this is typically ~1 GB even on phones with 12–24 GB of RAM.
- Large model weights or long-context KV caches can exceed this cap → allocation fails → model fails to load or falls back to CPU.
- Upstream llama.cpp added the opt-in fix in [ggml-org/llama.cpp#20997](https://github.com/ggml-org/llama.cpp/pull/20997), synced into llama.rn at `b8547` (2026-03-27), present in our pinned `llama.rn@0.12.0-rc.9`.

## Scope

- **Android only.** iOS uses Metal — unaffected.
- **Non-Adreno Android devices: no-op.** The native layer in `ggml-opencl.cpp` gates on `gpu_family == ADRENO && cl_qcom_large_buffer available`. Mali / Xclipse / CPU-only paths never see the flag take effect.
- **Graceful fallback on older Adreno drivers** that lack the extension — native code clears the flag and logs it.
- No Kotlin-side device detection was added on purpose: native self-gating is authoritative, so a Kotlin-side check would be redundant and a second place to keep in sync.

## Test plan

- [x] Android release build (`./gradlew assembleRelease`) — BUILD SUCCESSFUL locally
- [x] Lint, TypeCheck, Jest (2011 tests) — all green, no regressions
- [ ] **Manual verification (requested from @BlindDeveloper or anyone with Adreno A7X/A8X hardware):**
  - On a Snapdragon 8 Gen 2/3 or 8 Elite device, install this build
  - Load a 7B+ GGUF (e.g. 8B Q4_K_M) or a smaller model with long context
  - Filter logcat: `adb logcat -s ggml-opencl`
  - Look for `lm_ggml_opencl: Adreno large buffer enabled`
  - If you see `Adreno large buffer requested but not supported by driver` instead, that is the expected graceful fallback on older A7X drivers — not a bug
- [ ] Non-Adreno Android (Mali / Xclipse / CPU-only): confirm no regression, no new log spam

No automated unit/E2E test added — the change is a pre-init env-var side-effect with no JS/TS surface, and we have no Adreno A7X/A8X hardware in the E2E pipeline. A Jest/Robolectric test asserting `Os.setenv` was called would test the Kotlin stdlib, not our behaviour.

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)