### PR TITLE
chore(ci): retain iOS dSYM as release workflow artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,3 +240,24 @@ jobs:
           APP_STORE_CONNECT_USER_ID: ${{ secrets.APP_STORE_CONNECT_USER_ID }}
           GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}
         run: bundle exec fastlane release_ios_testflight
+
+      # Step 9: Extract iOS version info for dSYM artifact naming
+      - name: Extract iOS version info
+        id: version
+        if: always()
+        run: |
+          MARKETING_VERSION=$(cat .version | tr -d '[:space:]')
+          BUILD_NUMBER=$(grep -m1 'CURRENT_PROJECT_VERSION' ios/PocketPal.xcodeproj/project.pbxproj | awk -F'= ' '{print $2}' | tr -d ' ;')
+          echo "marketing_version=${MARKETING_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Extracted: v${MARKETING_VERSION} build ${BUILD_NUMBER}"
+
+      # Step 10: Retain dSYM as a workflow artifact for crash symbolication (FOU-86)
+      - name: Upload iOS dSYM
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-dsym-v${{ steps.version.outputs.marketing_version }}-build${{ steps.version.outputs.build_number }}
+          path: ios/build/PocketPal.app.dSYM.zip
+          retention-days: 90
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- Retain `PocketPal.app.dSYM.zip` as a 90-day workflow artifact after every iOS release build (normal release and `ios_only` dispatch paths), so future App Store / TestFlight crashes can be symbolicated locally without a crash-reporting SDK.
- Adds two steps to the `build_ios` job: "Extract iOS version info" (publishes marketing version + build number via `$GITHUB_OUTPUT`) and "Upload iOS dSYM" (`actions/upload-artifact@v4`, `retention-days: 90`, `if-no-files-found: warn`). Artifact is named like `ios-dsym-v1.14.0-build137`.
- Both new steps run with `if: always()` so the dSYM is retained even when TestFlight upload fails (a known flaky path). If gym itself fails, the file is absent and the step logs a warning and exits 0 — never converts a single failure into a double failure.

Linear: [FOU-86](https://linear.app/pocketpal/issue/FOU-86)
Unblocks: FOU-85 (symbolicatable CI-built dSYMs)

## What changed
- `.github/workflows/release.yml`: +21 lines, additive only, inside the `build_ios` job.
- No app source, no native config, no pods, no JS.

## Verification
- `actionlint .github/workflows/release.yml` — clean on new steps (pre-existing findings on unrelated lines are out of scope).
- `python3 -c "import yaml; yaml.safe_load(...)"` — parses; `build_ios` now has 11 steps; last two carry the expected `name`/`if`/`id`/`uses`/`with` fields.
- Extraction dry-run on the current ref: `.version` → `1.14.0`, `CURRENT_PROJECT_VERSION` (first of 6, all in lockstep) → `137`, so a release run would produce artifact `ios-dsym-v1.14.0-build137`.

## Test plan
- [ ] After merge, trigger the release workflow (normal or `ios_only`) and confirm the run summary's Artifacts section lists `ios-dsym-v<version>-build<number>`.
- [ ] Download the artifact and confirm it contains `PocketPal.app.dSYM.zip` (upload-artifact v4 re-zips inputs, so the download is a `.zip` of the `.zip` — expected).
- [ ] Confirm "Expires in 90 days" on the artifact metadata.
- [ ] (If a future TestFlight upload fails) confirm the dSYM artifact is still attached to that failed run.

🤖 Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)