### PR TITLE
[Feat]: AssistantTurn rendering — one footer per turn, dot-row indicator, tool fallbacks

### DIFF
--- a/__mocks__/stores/chatSessionStore.ts
+++ b/__mocks__/stores/chatSessionStore.ts
@@ -63,6 +63,8 @@ export const mockChatSessionStore = {
   enterEditMode: jest.fn(),
   removeMessagesFromId: jest.fn(),
   setIsGenerating: jest.fn(),
+  setIsStopping: jest.fn(),
+  isStopping: false,
   duplicateSession: jest.fn().mockResolvedValue(undefined),
   setNewChatCompletionSettings: jest.fn().mockResolvedValue(undefined),
   resetNewChatCompletionSettings: jest.fn().mockResolvedValue(undefined),

--- a/__mocks__/stores/chatSessionStore.ts
+++ b/__mocks__/stores/chatSessionStore.ts
@@ -98,11 +98,10 @@ export const mockChatSessionStore = {
   agentUiState: {
     status: 'idle' as
       | 'idle'
-      | 'preparing'
+      | 'prefill'
       | 'streaming_text'
       | 'generating_tool_call'
       | 'executing_tool'
-      | 'streaming_followup'
       | 'done'
       | 'failed',
     pendingTalentNames: [] as string[],
@@ -111,6 +110,7 @@ export const mockChatSessionStore = {
   setAgentUiState: jest.fn(),
   pushAgentStep: jest.fn().mockResolvedValue(undefined),
   updateActiveStepStreaming: jest.fn(),
+  appendToolCall: jest.fn().mockResolvedValue(undefined),
   appendToolOutcome: jest.fn().mockResolvedValue(undefined),
   finalizeActiveStep: jest.fn().mockResolvedValue(undefined),
 };

--- a/src/components/AssistantTurnFooter/AssistantTurnFooter.tsx
+++ b/src/components/AssistantTurnFooter/AssistantTurnFooter.tsx
@@ -1,0 +1,109 @@
+import React, {useContext} from 'react';
+import {TouchableOpacity, View} from 'react-native';
+
+import {Text} from 'react-native-paper';
+import Clipboard from '@react-native-clipboard/clipboard';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+
+import {useTheme} from '../../hooks';
+
+import {styles} from './styles';
+
+import {L10nContext} from '../../utils';
+import {derivedText} from '../../utils/chat';
+import {MessageType} from '../../utils/types';
+import {t} from '../../locales';
+
+const hapticOptions = {
+  enableVibrateFallback: true,
+  ignoreAndroidSystemSettings: false,
+};
+
+interface AssistantTurnFooterProps {
+  message: MessageType.Any;
+}
+
+/**
+ * Turn-level chrome (timing + copy) rendered ONCE per assistant row,
+ * below all step blocks. Per WHAT §4b / I1, the footer's two slots
+ * render independently:
+ *
+ *   - `metadata.timings` present → render the timing line
+ *   - `metadata.copyable` true   → render the copy button
+ *
+ * Each is gated only by field presence, not by run status (D1: "show
+ * what we have"). On a turn aborted mid-stream with partial content,
+ * `copyable` is true but `timings` is absent — the footer renders the
+ * copy button alone (Scenario H).
+ *
+ * Per D9, this component is the universal owner of timing+copy chrome
+ * for ALL assistant rows (legacy Text rows AND AssistantTurn rows).
+ * Bubble (the shape primitive) no longer renders chrome.
+ *
+ * Sender-name handling stays where it is today — TextMessage renders
+ * the author name above its text via `showName`. This component only
+ * owns the below-bubble chrome.
+ */
+export const AssistantTurnFooter: React.FC<AssistantTurnFooterProps> = ({
+  message,
+}) => {
+  const theme = useTheme();
+  const l10n = useContext(L10nContext);
+  const {copyable, timings} = message.metadata || {};
+
+  if (!timings && !copyable) {
+    return null;
+  }
+
+  const componentStyles = styles({theme});
+
+  // Build timing string from whichever parts are available. Each part
+  // is independent; missing parts are omitted from the joined string.
+  const timingParts: string[] = [];
+  if (timings?.predicted_per_token_ms != null) {
+    timingParts.push(
+      t(l10n.components.bubble.msPerToken, {
+        value: timings.predicted_per_token_ms.toFixed(),
+      }),
+    );
+  }
+  if (timings?.predicted_per_second != null) {
+    timingParts.push(
+      t(l10n.components.bubble.tokensPerSec, {
+        value: timings.predicted_per_second.toFixed(2),
+      }),
+    );
+  }
+  if (timings?.time_to_first_token_ms != null) {
+    timingParts.push(
+      t(l10n.components.bubble.ttft, {
+        value: timings.time_to_first_token_ms,
+      }),
+    );
+  }
+  const fullTimingsString = timingParts.join(', ');
+
+  const copyToClipboard = () => {
+    if (message.type !== 'text' && message.type !== 'assistant_turn') {
+      return;
+    }
+    ReactNativeHapticFeedback.trigger('impactLight', hapticOptions);
+    Clipboard.setString(derivedText(message).trim());
+  };
+
+  return (
+    <View style={componentStyles.container} testID="assistant-turn-footer">
+      {copyable && (
+        <TouchableOpacity onPress={copyToClipboard} testID="footer-copy">
+          <Icon name="content-copy" style={componentStyles.icon} />
+        </TouchableOpacity>
+      )}
+      {timings && fullTimingsString ? (
+        <Text style={componentStyles.timing} testID="footer-timing">
+          {fullTimingsString}
+        </Text>
+      ) : null}
+    </View>
+  );
+};

--- a/src/components/AssistantTurnFooter/__tests__/AssistantTurnFooter.test.tsx
+++ b/src/components/AssistantTurnFooter/__tests__/AssistantTurnFooter.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+
+import {render, fireEvent} from '../../../../jest/test-utils';
+
+import {AssistantTurnFooter} from '../AssistantTurnFooter';
+
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => {
+  const {Text: PaperText} = require('react-native-paper');
+  return props => <PaperText>{props.name}</PaperText>;
+});
+
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  setString: jest.fn(),
+}));
+
+const baseTurn = (overrides: Partial<any> = {}): any => ({
+  author: {id: 'assistant'},
+  createdAt: 0,
+  id: 'turn-1',
+  type: 'assistant_turn',
+  steps: [{content: 'Hello'}],
+  metadata: {},
+  ...overrides,
+});
+
+describe('AssistantTurnFooter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when neither timings nor copyable are set', () => {
+    const message = baseTurn({metadata: {}});
+    const {queryByTestId} = render(<AssistantTurnFooter message={message} />);
+    expect(queryByTestId('assistant-turn-footer')).toBeNull();
+  });
+
+  it('renders timing line when timings present (no copy button if not copyable)', () => {
+    const message = baseTurn({
+      metadata: {
+        timings: {predicted_per_token_ms: 10, predicted_per_second: 100},
+      },
+    });
+    const {getByText, queryByText, queryByTestId} = render(
+      <AssistantTurnFooter message={message} />,
+    );
+    expect(queryByTestId('assistant-turn-footer')).toBeTruthy();
+    expect(getByText('10ms/token, 100.00 tokens/sec')).toBeTruthy();
+    expect(queryByText('content-copy')).toBeNull();
+  });
+
+  it('renders copy button when copyable, even if timings absent (Scenario H abort path)', () => {
+    const message = baseTurn({
+      metadata: {copyable: true, interrupted: true},
+    });
+    const {getByText, queryByTestId} = render(
+      <AssistantTurnFooter message={message} />,
+    );
+    expect(queryByTestId('assistant-turn-footer')).toBeTruthy();
+    expect(getByText('content-copy')).toBeTruthy();
+    expect(queryByTestId('footer-timing')).toBeNull();
+  });
+
+  it('renders both timing and copy when both fields present', () => {
+    const message = baseTurn({
+      metadata: {
+        copyable: true,
+        timings: {predicted_per_token_ms: 32, predicted_per_second: 30},
+      },
+    });
+    const {getByText} = render(<AssistantTurnFooter message={message} />);
+    expect(getByText('32ms/token, 30.00 tokens/sec')).toBeTruthy();
+    expect(getByText('content-copy')).toBeTruthy();
+  });
+
+  it('copy button copies derived text via Clipboard.setString', () => {
+    const message = baseTurn({
+      steps: [
+        {content: 'Sure, here it is.'},
+        {content: 'Hope this helps.'},
+      ],
+      metadata: {
+        copyable: true,
+        timings: {predicted_per_second: 50},
+      },
+    });
+    const {getByText} = render(<AssistantTurnFooter message={message} />);
+    fireEvent.press(getByText('content-copy'));
+    expect(
+      require('@react-native-clipboard/clipboard').setString,
+    ).toHaveBeenCalledWith('Sure, here it is.\n\nHope this helps.');
+  });
+
+  it('copy button is a no-op for unsupported message types', () => {
+    const message = {
+      author: {id: 'assistant'},
+      createdAt: 0,
+      id: 'img-1',
+      type: 'image' as const,
+      uri: 'file://foo.png',
+      width: 10,
+      height: 10,
+      size: 100,
+      name: 'foo.png',
+      metadata: {copyable: true},
+    } as any;
+    const {getByText} = render(<AssistantTurnFooter message={message} />);
+    fireEvent.press(getByText('content-copy'));
+    expect(
+      require('@react-native-clipboard/clipboard').setString,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('renders TTFT-only timing string when only ttft is present', () => {
+    const message = baseTurn({
+      metadata: {
+        timings: {time_to_first_token_ms: 150},
+      },
+    });
+    const {getByText} = render(<AssistantTurnFooter message={message} />);
+    expect(getByText('150ms TTFT')).toBeTruthy();
+  });
+
+  it('does not render the timing Text when timings are empty (no parts to show)', () => {
+    const message = baseTurn({
+      metadata: {
+        copyable: true,
+        timings: {},
+      },
+    });
+    const {getByText, queryByTestId} = render(
+      <AssistantTurnFooter message={message} />,
+    );
+    expect(queryByTestId('footer-timing')).toBeNull();
+    expect(getByText('content-copy')).toBeTruthy();
+  });
+});

--- a/src/components/AssistantTurnFooter/__tests__/AssistantTurnFooter.test.tsx
+++ b/src/components/AssistantTurnFooter/__tests__/AssistantTurnFooter.test.tsx
@@ -74,10 +74,7 @@ describe('AssistantTurnFooter', () => {
 
   it('copy button copies derived text via Clipboard.setString', () => {
     const message = baseTurn({
-      steps: [
-        {content: 'Sure, here it is.'},
-        {content: 'Hope this helps.'},
-      ],
+      steps: [{content: 'Sure, here it is.'}, {content: 'Hope this helps.'}],
       metadata: {
         copyable: true,
         timings: {predicted_per_second: 50},

--- a/src/components/AssistantTurnFooter/index.ts
+++ b/src/components/AssistantTurnFooter/index.ts
@@ -1,0 +1,1 @@
+export * from './AssistantTurnFooter';

--- a/src/components/AssistantTurnFooter/styles.ts
+++ b/src/components/AssistantTurnFooter/styles.ts
@@ -1,0 +1,23 @@
+import {StyleSheet} from 'react-native';
+
+import {Theme} from '../../utils/types';
+
+export const styles = ({theme}: {theme: Theme}) =>
+  StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingBottom: 12,
+      marginTop: -8,
+      marginLeft: 20,
+    },
+    timing: {
+      color: theme.colors.textSecondary,
+      fontSize: 10,
+    },
+    icon: {
+      marginRight: 5,
+      color: theme.colors.textSecondary,
+      fontSize: 16,
+    },
+  });

--- a/src/components/AssistantTurnFooter/styles.ts
+++ b/src/components/AssistantTurnFooter/styles.ts
@@ -8,8 +8,6 @@ export const styles = ({theme}: {theme: Theme}) =>
       flexDirection: 'row',
       alignItems: 'center',
       paddingBottom: 12,
-      marginTop: -8,
-      marginLeft: 20,
     },
     timing: {
       color: theme.colors.textSecondary,

--- a/src/components/Bubble/Bubble.tsx
+++ b/src/components/Bubble/Bubble.tsx
@@ -1,26 +1,22 @@
 import type {ReactNode} from 'react';
 import React, {useContext} from 'react';
-import {View, TouchableOpacity, Animated} from 'react-native';
-
-import {Text} from 'react-native-paper';
-import Clipboard from '@react-native-clipboard/clipboard';
-import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import {Animated} from 'react-native';
 
 import {useTheme} from '../../hooks';
 
 import {styles} from './styles';
 
-import {UserContext, L10nContext} from '../../utils';
-import {derivedText} from '../../utils/chat';
+import {UserContext} from '../../utils';
 import {MessageType} from '../../utils/types';
-import {t} from '../../locales';
 
-const hapticOptions = {
-  enableVibrateFallback: true,
-  ignoreAndroidSystemSettings: false,
-};
-
+/**
+ * Pure shape primitive (border, background, scale animation). Per D9
+ * (WHAT §4d) Bubble no longer renders chrome — timing, copy, and any
+ * future turn-level slots are owned by `AssistantTurnFooter` rendered
+ * adjacent to the Bubble by `Message`. This collapses the
+ * "chrome-in-Bubble" pattern that produced the duplicate-footer bug
+ * for multi-step AssistantTurns.
+ */
 export const Bubble = ({
   child,
   message,
@@ -35,73 +31,20 @@ export const Bubble = ({
 }) => {
   const theme = useTheme();
   const user = useContext(UserContext);
-  const l10n = useContext(L10nContext);
   const currentUserIsAuthor = user?.id === message.author.id;
-  const {copyable, timings} = message.metadata || {};
 
-  // Build timing string from whichever parts are available
-  const timingParts: string[] = [];
-  if (timings?.predicted_per_token_ms != null) {
-    timingParts.push(
-      t(l10n.components.bubble.msPerToken, {
-        value: timings.predicted_per_token_ms.toFixed(),
-      }),
-    );
-  }
-  if (timings?.predicted_per_second != null) {
-    timingParts.push(
-      t(l10n.components.bubble.tokensPerSec, {
-        value: timings.predicted_per_second.toFixed(2),
-      }),
-    );
-  }
-  if (timings?.time_to_first_token_ms != null) {
-    timingParts.push(
-      t(l10n.components.bubble.ttft, {
-        value: timings.time_to_first_token_ms,
-      }),
-    );
-  }
-  const fullTimingsString = timingParts.join(', ');
-
-  const {contentContainer, dateHeaderContainer, dateHeader, iconContainer} =
-    styles({
-      currentUserIsAuthor,
-      message,
-      roundBorder: true,
-      theme,
-    });
-
-  const copyToClipboard = () => {
-    if (message.type !== 'text' && message.type !== 'assistant_turn') {
-      return;
-    }
-    ReactNativeHapticFeedback.trigger('impactLight', hapticOptions);
-    Clipboard.setString(derivedText(message).trim());
-  };
+  const {contentContainer} = styles({
+    currentUserIsAuthor,
+    message,
+    roundBorder: true,
+    theme,
+  });
 
   return (
     <Animated.View
       testID={currentUserIsAuthor ? 'user-message' : 'ai-message'}
-      style={[
-        contentContainer,
-        {
-          transform: [{scale}],
-        },
-      ]}>
+      style={[contentContainer, {transform: [{scale}]}]}>
       {child}
-      {timings && (
-        <View style={dateHeaderContainer} testID="message-timing">
-          {copyable && (
-            <TouchableOpacity onPress={copyToClipboard}>
-              <Icon name="content-copy" style={iconContainer} />
-            </TouchableOpacity>
-          )}
-          {fullTimingsString ? (
-            <Text style={dateHeader}>{fullTimingsString}</Text>
-          ) : null}
-        </View>
-      )}
     </Animated.View>
   );
 };

--- a/src/components/Bubble/__tests__/Bubble.test.tsx
+++ b/src/components/Bubble/__tests__/Bubble.test.tsx
@@ -2,18 +2,9 @@ import React from 'react';
 
 import {Text} from 'react-native-paper';
 
-import {render, fireEvent} from '../../../../jest/test-utils';
+import {render} from '../../../../jest/test-utils';
 
 import {Bubble} from '../Bubble';
-
-jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => {
-  const {Text: PaperText} = require('react-native-paper');
-  return props => <PaperText>{props.name}</PaperText>;
-});
-
-jest.mock('@react-native-clipboard/clipboard', () => ({
-  setString: jest.fn(),
-}));
 
 describe('Bubble', () => {
   let mockMessage;
@@ -26,13 +17,7 @@ describe('Bubble', () => {
       id: 'uuidv4',
       text: 'Hello, world!',
       type: 'text',
-      metadata: {
-        copyable: true,
-        timings: {
-          predicted_per_token_ms: 10,
-          predicted_per_second: 100,
-        },
-      },
+      metadata: {},
     };
   });
 
@@ -46,28 +31,18 @@ describe('Bubble', () => {
     );
   };
 
-  it('renders correctly with all props', () => {
-    const {getByText, getByTestId} = renderBubble(mockMessage);
+  // Bubble is a pure shape primitive after D9 — chrome moved to
+  // AssistantTurnFooter. Tests assert shape behaviour only.
+
+  it('renders the child content', () => {
+    const {getByTestId} = renderBubble(mockMessage);
     expect(getByTestId('child')).toBeTruthy();
-    expect(getByText('10ms/token, 100.00 tokens/sec')).toBeTruthy();
-    expect(getByText('content-copy')).toBeTruthy();
   });
 
-  it('does not render copy icon when message is not copyable', () => {
-    const nonCopyableMessage = {
-      ...mockMessage,
-      metadata: {...mockMessage.metadata, copyable: false},
-    };
-    const {queryByText} = renderBubble(nonCopyableMessage);
-    expect(queryByText('content-copy')).toBeNull();
-  });
-
-  it('calls Clipboard.setString when copy icon is pressed', () => {
-    const {getByText} = renderBubble(mockMessage);
-    fireEvent.press(getByText('content-copy'));
-    expect(
-      require('@react-native-clipboard/clipboard').setString,
-    ).toHaveBeenCalledWith('Hello, world!');
+  it('renders an ai-message testID for non-current-user authors', () => {
+    const aiMessage = {...mockMessage, author: {id: 'assistant'}};
+    const {getByTestId} = renderBubble(aiMessage);
+    expect(getByTestId('ai-message')).toBeTruthy();
   });
 
   it('does not crash when message.metadata is undefined', () => {
@@ -76,203 +51,17 @@ describe('Bubble', () => {
     expect(getByText('Child content')).toBeTruthy();
   });
 
-  it('displays time to first token when available', () => {
-    const messageWithTimeToFirstToken = {
+  it('does NOT render timing or copy chrome (chrome lives in AssistantTurnFooter now)', () => {
+    const messageWithTimings = {
       ...mockMessage,
       metadata: {
         copyable: true,
-        timings: {
-          predicted_per_token_ms: 10,
-          predicted_per_second: 100,
-          time_to_first_token_ms: 250,
-        },
+        timings: {predicted_per_token_ms: 10, predicted_per_second: 100},
       },
     };
-
-    const {getByText} = renderBubble(messageWithTimeToFirstToken);
-
-    expect(getByText('10ms/token, 100.00 tokens/sec, 250ms TTFT')).toBeTruthy();
-  });
-
-  it('does not display time to first token when null', () => {
-    const messageWithNullTimeToFirstToken = {
-      ...mockMessage,
-      metadata: {
-        copyable: true,
-        timings: {
-          predicted_per_token_ms: 10,
-          predicted_per_second: 100,
-          time_to_first_token_ms: null,
-        },
-      },
-    };
-
-    const {getByText} = renderBubble(messageWithNullTimeToFirstToken);
-
-    // Should show timing without TTFT
-    expect(getByText('10ms/token, 100.00 tokens/sec')).toBeTruthy();
-  });
-
-  it('does not display time to first token when undefined', () => {
-    const messageWithoutTimeToFirstToken = {
-      ...mockMessage,
-      metadata: {
-        copyable: true,
-        timings: {
-          predicted_per_token_ms: 10,
-          predicted_per_second: 100,
-          // time_to_first_token_ms is undefined
-        },
-      },
-    };
-
-    const {getByText} = renderBubble(messageWithoutTimeToFirstToken);
-
-    // Should show timing without TTFT
-    expect(getByText('10ms/token, 100.00 tokens/sec')).toBeTruthy();
-  });
-
-  it('shows only TTFT when server timings are not available', () => {
-    const messageWithTtftOnly = {
-      ...mockMessage,
-      metadata: {
-        copyable: true,
-        timings: {
-          time_to_first_token_ms: 150,
-        },
-      },
-    };
-
-    const {getByText} = renderBubble(messageWithTtftOnly);
-
-    expect(getByText('150ms TTFT')).toBeTruthy();
-  });
-
-  it('hides footer when timings not yet set (streaming in progress)', () => {
-    const messageWithCopyableOnly = {
-      ...mockMessage,
-      metadata: {
-        copyable: true,
-      },
-    };
-
-    const {queryByTestId} = renderBubble(messageWithCopyableOnly);
-
-    // Footer is gated on timings, not copyable — prevents showing
-    // an awkward copy icon before streaming has started/finished
+    const {queryByText, queryByTestId} = renderBubble(messageWithTimings);
     expect(queryByTestId('message-timing')).toBeNull();
-  });
-
-  it('shows copy button when timings exist but have no server values', () => {
-    const messageWithEmptyTimings = {
-      ...mockMessage,
-      metadata: {
-        copyable: true,
-        timings: {},
-      },
-    };
-
-    const {getByText, queryByTestId} = renderBubble(messageWithEmptyTimings);
-
-    // Footer shows because timings object exists (set after completion)
-    expect(queryByTestId('message-timing')).toBeTruthy();
-    expect(getByText('content-copy')).toBeTruthy();
-  });
-
-  it('hides footer when metadata is empty', () => {
-    const messageWithNoFooter = {
-      ...mockMessage,
-      metadata: {},
-    };
-
-    const {queryByTestId} = renderBubble(messageWithNoFooter);
-
-    expect(queryByTestId('message-timing')).toBeNull();
-  });
-
-  // ---------- Story Test Requirements (Renderer) #9 ----------
-
-  describe('AssistantTurn copy via derivedText', () => {
-    it('copies joined step.content for a multi-step AssistantTurn', () => {
-      const turnMessage = {
-        author: {id: 'assistant'},
-        createdAt: 0,
-        id: 'turn-1',
-        type: 'assistant_turn',
-        steps: [
-          {content: 'Let me calculate that'},
-          {
-            toolCalls: [
-              {id: 'c0', function: {name: 'calculate', arguments: '{}'}},
-            ],
-            toolOutcomes: [
-              {
-                callId: 'c0',
-                toolName: 'calculate',
-                result: {type: 'text', summary: '42'},
-                responseContent: '42',
-              },
-            ],
-          },
-          {content: 'The answer is 42'},
-        ],
-        metadata: {
-          copyable: true,
-          timings: {
-            predicted_per_token_ms: 10,
-            predicted_per_second: 100,
-          },
-        },
-      };
-      const {getByText} = renderBubble(turnMessage);
-      fireEvent.press(getByText('content-copy'));
-      expect(
-        require('@react-native-clipboard/clipboard').setString,
-      ).toHaveBeenCalledWith('Let me calculate that\n\nThe answer is 42');
-    });
-
-    it('copies single step.content for a single-step AssistantTurn', () => {
-      const turnMessage = {
-        author: {id: 'assistant'},
-        createdAt: 0,
-        id: 'turn-2',
-        type: 'assistant_turn',
-        steps: [{content: 'Hello there'}],
-        metadata: {
-          copyable: true,
-          timings: {predicted_per_second: 50},
-        },
-      };
-      const {getByText} = renderBubble(turnMessage);
-      fireEvent.press(getByText('content-copy'));
-      expect(
-        require('@react-native-clipboard/clipboard').setString,
-      ).toHaveBeenCalledWith('Hello there');
-    });
-
-    it('does not crash for tool-only AssistantTurn (derivedText returns "")', () => {
-      const turnMessage = {
-        author: {id: 'assistant'},
-        createdAt: 0,
-        id: 'turn-3',
-        type: 'assistant_turn',
-        steps: [
-          {
-            toolCalls: [
-              {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
-            ],
-          },
-        ],
-        metadata: {
-          copyable: true,
-          timings: {},
-        },
-      };
-      const {getByText} = renderBubble(turnMessage);
-      fireEvent.press(getByText('content-copy'));
-      expect(
-        require('@react-native-clipboard/clipboard').setString,
-      ).toHaveBeenCalledWith('');
-    });
+    expect(queryByText('content-copy')).toBeNull();
+    expect(queryByText('10ms/token, 100.00 tokens/sec')).toBeNull();
   });
 });

--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -716,11 +716,10 @@ export const ChatView = observer(
     const newestMessageId = messages.length > 0 ? messages[0].id : null;
     const agentStatus = chatSessionStore.agentUiState.status;
     const isAgentActive =
-      agentStatus === 'preparing' ||
+      agentStatus === 'prefill' ||
       agentStatus === 'streaming_text' ||
       agentStatus === 'generating_tool_call' ||
-      agentStatus === 'executing_tool' ||
-      agentStatus === 'streaming_followup';
+      agentStatus === 'executing_tool';
     const activeRunPendingTalentNames =
       chatSessionStore.agentUiState.pendingTalentNames;
     const isGeneratingToolCall = agentStatus === 'generating_tool_call';

--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -57,7 +57,7 @@ import {
   ChatInputAdditionalProps,
   ChatInputTopLevelProps,
   Menu,
-  LoadingBubble,
+  PendingIndicator,
   ChatPalModelPickerSheet,
   ChatHeader,
   ChatEmptyPlaceholder,
@@ -128,10 +128,13 @@ export interface ChatProps extends ChatTopLevelProps {
    * When true, indicates that there are no more pages to load and
    * pagination will not be triggered. */
   isLastPage?: boolean;
-  /** Indicates if the AI is currently streaming tokens */
+  /** Indicates if the AI is currently streaming tokens. Used by the
+   * FlatList's `maintainVisibleContentPosition` to keep the latest
+   * tokens in view while the stream lands. The legacy `isThinking`
+   * prop has been retired — pending UX is now derived inside
+   * ChatView from `chatSessionStore.agentUiState.status` (WHAT §4d
+   * / D4 / I4). */
   isStreaming?: boolean;
-  /** Indicates if the AI is currently thinking (processing but not yet streaming) */
-  isThinking?: boolean;
   messages: MessageType.Any[];
   /** Used for pagination (infinite scroll). Called when user scrolls
    * to the very end of the list (minus `onEndReachedThreshold`).
@@ -176,7 +179,6 @@ export const ChatView = observer(
     isLastPage,
     isStopVisible,
     isStreaming = false,
-    isThinking = false,
     messages,
     onEndReached,
     onMessageLongPress: externalOnMessageLongPress,
@@ -720,6 +722,15 @@ export const ChatView = observer(
       agentStatus === 'streaming_text' ||
       agentStatus === 'generating_tool_call' ||
       agentStatus === 'executing_tool';
+    // PendingIndicator visibility (WHAT §3 table, §7 derivation,
+    // I4). The indicator covers every dead zone: prefill (initial
+    // and follow-up), generating_tool_call, executing_tool. Hidden
+    // in streaming_text and done so it doesn't compete with the
+    // visible token stream / final footer.
+    const isPending =
+      agentStatus === 'prefill' ||
+      agentStatus === 'generating_tool_call' ||
+      agentStatus === 'executing_tool';
     const activeRunPendingTalentNames =
       chatSessionStore.agentUiState.pendingTalentNames;
     const isGeneratingToolCall = agentStatus === 'generating_tool_call';
@@ -860,15 +871,19 @@ export const ChatView = observer(
       };
     });
 
-    // Render header (loading bubble and keyboard spacer)
+    // Render header (pending indicator + keyboard spacer). The
+    // FlatList is `inverted={true}`, so the ListHeaderComponent
+    // renders at the bottom of the visible list — i.e. BELOW the
+    // latest turn, satisfying I4 ("PendingIndicator lives below the
+    // latest turn during dead zones, never inside one").
     const renderListHeaderComponent = React.useCallback(
       () => (
         <>
-          {isThinking && <LoadingBubble />}
+          {isPending && <PendingIndicator />}
           {chatMessages.length > 0 && <Reanimated.View style={headerStyle} />}
         </>
       ),
-      [isThinking, chatMessages.length, headerStyle],
+      [isPending, chatMessages.length, headerStyle],
     );
 
     // Render complete chat list with scroll-to-bottom button

--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -180,6 +180,7 @@ const PendingIndicatorView: React.FC = observer(() => (
   <PendingIndicator
     pendingTalentNames={chatSessionStore.agentUiState.pendingTalentNames}
     pendingToolTokens={chatSessionStore.agentUiState.pendingToolTokens}
+    isStopping={chatSessionStore.isStopping}
   />
 ));
 
@@ -747,7 +748,12 @@ export const ChatView = observer(
     const isPending =
       agentStatus === 'prefill' ||
       agentStatus === 'generating_tool_call' ||
-      agentStatus === 'executing_tool';
+      agentStatus === 'executing_tool' ||
+      // Keep the indicator visible during the user-initiated stop
+      // window so they see the "Stopping…" feedback even if status
+      // had been `streaming_text` (no indicator) at the moment of the
+      // tap. Cleared together with `isStopping` once the runner exits.
+      chatSessionStore.isStopping;
     const activeRunPendingTalentNames =
       chatSessionStore.agentUiState.pendingTalentNames;
     const isGeneratingToolCall = agentStatus === 'generating_tool_call';

--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -166,6 +166,23 @@ export interface ChatProps extends ChatTopLevelProps {
   user: User;
 }
 
+/**
+ * Thin observer wrapper around PendingIndicator so the per-token
+ * count + label updates only re-render this small subtree (and not
+ * the entire FlatList header), keeping the dot animations alive and
+ * the elapsed-seconds timer ticking. Without this isolation, MobX
+ * re-renders ChatView on each token, the `renderListHeaderComponent`
+ * useCallback would change reference (because it'd carry the count in
+ * its deps), and FlatList would unmount + remount the header every
+ * ~50ms — killing both Animated.loop and setInterval.
+ */
+const PendingIndicatorView: React.FC = observer(() => (
+  <PendingIndicator
+    pendingTalentNames={chatSessionStore.agentUiState.pendingTalentNames}
+    pendingToolTokens={chatSessionStore.agentUiState.pendingToolTokens}
+  />
+));
+
 /** Entry component, represents the complete chat */
 export const ChatView = observer(
   ({
@@ -879,7 +896,7 @@ export const ChatView = observer(
     const renderListHeaderComponent = React.useCallback(
       () => (
         <>
-          {isPending && <PendingIndicator />}
+          {isPending && <PendingIndicatorView />}
           {chatMessages.length > 0 && <Reanimated.View style={headerStyle} />}
         </>
       ),

--- a/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
+++ b/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
@@ -250,3 +250,64 @@ describe('ChatView — Copy menu item label is present in l10n', () => {
     expect(l10n.en.components.chatView.menuItems.copy).toBeTruthy();
   });
 });
+
+// ---------- Canonical scenario H + I ----------
+
+describe('ChatView — Scenario H (abort with partial content)', () => {
+  it('H — interrupted turn with copyable but no timings: AssistantTurnFooter shows copy alone, no timing', () => {
+    const turn: MessageType.AssistantTurn = {
+      id: 't1',
+      type: 'assistant_turn',
+      author,
+      createdAt: 1,
+      steps: [{content: 'I was about to say...', partial: true}],
+      metadata: {interrupted: true, copyable: true},
+    };
+    const {getByTestId, queryByTestId} = render(
+      <ChatView messages={[turn]} onSendPress={jest.fn()} user={user} />,
+      {withNavigation: true, withBottomSheetProvider: true},
+    );
+    expect(getByTestId('assistant-turn-footer')).toBeTruthy();
+    // Copy renders (copyable=true).
+    expect(getByTestId('footer-copy')).toBeTruthy();
+    // No timing line — `metadata.timings` is absent (D1 / Scenario H).
+    expect(queryByTestId('footer-timing')).toBeNull();
+  });
+});
+
+describe('ChatView — Scenario I (dead-zone phase walk via PendingIndicator)', () => {
+  // The PendingIndicator (D4 / I4) is owned by ChatView and gated on
+  // `chatSessionStore.agentUiState.status`. The §3 table says it
+  // appears in every status EXCEPT streaming_text and done. Drive
+  // the status across that table and assert testID presence /
+  // absence per phase.
+  const phases: Array<{label: string; status: any; visible: boolean}> = [
+    {label: 'idle (no run)', status: 'idle', visible: false},
+    {label: 'phase 2 / 7: prefill', status: 'prefill', visible: true},
+    {label: 'phase 3 / 8: streaming_text', status: 'streaming_text', visible: false},
+    {label: 'phase 4: generating_tool_call', status: 'generating_tool_call', visible: true},
+    {label: 'phase 5: executing_tool', status: 'executing_tool', visible: true},
+    {label: 'phase 9: done', status: 'done', visible: false},
+    {label: 'failed', status: 'failed', visible: false},
+  ];
+
+  it.each(phases)('$label → indicator visible=$visible', ({status, visible}) => {
+    runInAction(() => {
+      chatSessionStore.agentUiState = {
+        status,
+        pendingTalentNames: [],
+        hitMaxTurns: false,
+      };
+    });
+    const turn = makeAssistantTurn([{content: 'hi'}], 't1', 1);
+    const {queryByTestId} = render(
+      <ChatView messages={[turn]} onSendPress={jest.fn()} user={user} />,
+      {withNavigation: true, withBottomSheetProvider: true},
+    );
+    if (visible) {
+      expect(queryByTestId('pending-indicator')).toBeTruthy();
+    } else {
+      expect(queryByTestId('pending-indicator')).toBeNull();
+    }
+  });
+});

--- a/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
+++ b/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
@@ -284,30 +284,41 @@ describe('ChatView — Scenario I (dead-zone phase walk via PendingIndicator)', 
   const phases: Array<{label: string; status: any; visible: boolean}> = [
     {label: 'idle (no run)', status: 'idle', visible: false},
     {label: 'phase 2 / 7: prefill', status: 'prefill', visible: true},
-    {label: 'phase 3 / 8: streaming_text', status: 'streaming_text', visible: false},
-    {label: 'phase 4: generating_tool_call', status: 'generating_tool_call', visible: true},
+    {
+      label: 'phase 3 / 8: streaming_text',
+      status: 'streaming_text',
+      visible: false,
+    },
+    {
+      label: 'phase 4: generating_tool_call',
+      status: 'generating_tool_call',
+      visible: true,
+    },
     {label: 'phase 5: executing_tool', status: 'executing_tool', visible: true},
     {label: 'phase 9: done', status: 'done', visible: false},
     {label: 'failed', status: 'failed', visible: false},
   ];
 
-  it.each(phases)('$label → indicator visible=$visible', ({status, visible}) => {
-    runInAction(() => {
-      chatSessionStore.agentUiState = {
-        status,
-        pendingTalentNames: [],
-        hitMaxTurns: false,
-      };
-    });
-    const turn = makeAssistantTurn([{content: 'hi'}], 't1', 1);
-    const {queryByTestId} = render(
-      <ChatView messages={[turn]} onSendPress={jest.fn()} user={user} />,
-      {withNavigation: true, withBottomSheetProvider: true},
-    );
-    if (visible) {
-      expect(queryByTestId('pending-indicator')).toBeTruthy();
-    } else {
-      expect(queryByTestId('pending-indicator')).toBeNull();
-    }
-  });
+  it.each(phases)(
+    '$label → indicator visible=$visible',
+    ({status, visible}) => {
+      runInAction(() => {
+        chatSessionStore.agentUiState = {
+          status,
+          pendingTalentNames: [],
+          hitMaxTurns: false,
+        };
+      });
+      const turn = makeAssistantTurn([{content: 'hi'}], 't1', 1);
+      const {queryByTestId} = render(
+        <ChatView messages={[turn]} onSendPress={jest.fn()} user={user} />,
+        {withNavigation: true, withBottomSheetProvider: true},
+      );
+      if (visible) {
+        expect(queryByTestId('pending-indicator')).toBeTruthy();
+      } else {
+        expect(queryByTestId('pending-indicator')).toBeNull();
+      }
+    },
+  );
 });

--- a/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
+++ b/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
@@ -321,4 +321,49 @@ describe('ChatView — Scenario I (dead-zone phase walk via PendingIndicator)', 
       }
     },
   );
+
+  it('PendingIndicator no-flicker: streaming_text → re-render after rapid token bursts keeps indicator hidden', () => {
+    // Wiring test. The reducer-level test (agentStateReducer.test.ts
+    // PendingIndicator no-flicker invariant) proves the predicate
+    // stays stable; this test proves ChatView wires the predicate
+    // to the indicator correctly. We simulate the user-perceived
+    // worst case: status starts in streaming_text (we already
+    // crossed prefill → streaming_text on the first token), then
+    // re-renders happen on every subsequent token. The indicator
+    // must stay hidden across all re-renders.
+    runInAction(() => {
+      chatSessionStore.agentUiState = {
+        status: 'streaming_text',
+        pendingTalentNames: [],
+        hitMaxTurns: false,
+      };
+    });
+    const turn = makeAssistantTurn([{content: 'h'}], 't1', 1);
+    const {queryByTestId, rerender} = render(
+      <ChatView messages={[turn]} onSendPress={jest.fn()} user={user} />,
+      {withNavigation: true, withBottomSheetProvider: true},
+    );
+    expect(queryByTestId('pending-indicator')).toBeNull();
+
+    // 10 simulated re-renders, each representing a token landing.
+    // The status remains streaming_text the whole time (no flips
+    // back to prefill — that's the reducer-level guarantee). Each
+    // re-render passes a new turn message reference (content
+    // grows), forcing React to re-evaluate the header component.
+    let content = 'h';
+    for (let i = 0; i < 10; i++) {
+      content += 'x';
+      const updatedTurn = makeAssistantTurn([{content}], 't1', 1);
+      rerender(
+        <ChatView
+          messages={[updatedTurn]}
+          onSendPress={jest.fn()}
+          user={user}
+        />,
+      );
+      // Indicator MUST remain hidden across every frame — no
+      // flicker is observable.
+      expect(queryByTestId('pending-indicator')).toBeNull();
+    }
+  });
 });

--- a/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
+++ b/src/components/ChatView/__tests__/ChatView.assistantTurn.test.tsx
@@ -50,6 +50,7 @@ beforeEach(() => {
     chatSessionStore.agentUiState = {
       status: 'idle',
       pendingTalentNames: [],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
   });
@@ -306,6 +307,7 @@ describe('ChatView — Scenario I (dead-zone phase walk via PendingIndicator)', 
         chatSessionStore.agentUiState = {
           status,
           pendingTalentNames: [],
+          pendingToolTokens: 0,
           hitMaxTurns: false,
         };
       });
@@ -335,6 +337,7 @@ describe('ChatView — Scenario I (dead-zone phase walk via PendingIndicator)', 
       chatSessionStore.agentUiState = {
         status: 'streaming_text',
         pendingTalentNames: [],
+        pendingToolTokens: 0,
         hitMaxTurns: false,
       };
     });

--- a/src/components/HtmlPreviewBubble/HtmlPreviewBubble.tsx
+++ b/src/components/HtmlPreviewBubble/HtmlPreviewBubble.tsx
@@ -128,7 +128,9 @@ export const HtmlPreviewBubble: React.FC<HtmlPreviewBubbleProps> = ({
             onPress={() => setShowCode(s => !s)}
             accessibilityRole="button"
             accessibilityLabel={
-              showCode ? l10n.htmlPreview.showPreview : l10n.htmlPreview.showCode
+              showCode
+                ? l10n.htmlPreview.showPreview
+                : l10n.htmlPreview.showCode
             }
             testID="html-preview-toggle-code"
             hitSlop={8}
@@ -142,7 +144,10 @@ export const HtmlPreviewBubble: React.FC<HtmlPreviewBubbleProps> = ({
           <Pressable
             onPress={() => setFullscreen(true)}
             accessibilityRole="button"
-            accessibilityLabel={l10n.htmlPreview.openFullscreen.replace('{{title}}', displayTitle)}
+            accessibilityLabel={l10n.htmlPreview.openFullscreen.replace(
+              '{{title}}',
+              displayTitle,
+            )}
             testID="html-preview-bubble-collapsed"
             hitSlop={8}
             style={styles.headerButton}>
@@ -200,7 +205,9 @@ export const HtmlPreviewBubble: React.FC<HtmlPreviewBubbleProps> = ({
                 onPress={() => setShowCode(s => !s)}
                 accessibilityRole="button"
                 accessibilityLabel={
-                  showCode ? l10n.htmlPreview.showPreview : l10n.htmlPreview.showCode
+                  showCode
+                    ? l10n.htmlPreview.showPreview
+                    : l10n.htmlPreview.showCode
                 }
                 testID="html-preview-modal-toggle-code"
                 hitSlop={8}

--- a/src/components/HtmlPreviewBubble/styles.ts
+++ b/src/components/HtmlPreviewBubble/styles.ts
@@ -9,6 +9,16 @@ export const createStyles = (colors: {
 }) =>
   StyleSheet.create({
     container: {
+      // alignSelf: 'stretch' makes the bubble fill the cross-axis of its
+      // parent (horizontal width in the default column-flex chat row).
+      // Without it, the auto-width parent + percentage-width WebView
+      // (`collapsedWebView: { width: '100%' }`) hits the classic flexbox
+      // "0% of nothing" race: on first layout pass the container shrink-
+      // wraps to intrinsic content, the WebView's 100% resolves to that
+      // small value, and only a later layout pass (e.g., when the model
+      // emits a follow-up text bubble below) gives container a definite
+      // width that lets WebView re-measure.
+      alignSelf: 'stretch',
       marginVertical: 8,
       marginHorizontal: 12,
       borderRadius: 12,

--- a/src/components/MarkdownView/MarkdownView.tsx
+++ b/src/components/MarkdownView/MarkdownView.tsx
@@ -7,7 +7,6 @@ import CodeHighlighter from 'react-native-code-highlighter';
 import {atomOneDark} from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
 import {useTheme} from '../../hooks';
-import {ThinkingBubble} from '../ThinkingBubble';
 import {CodeBlockHeader} from '../CodeBlockHeader';
 
 import {createTagsStyles, createStyles} from './styles';
@@ -20,8 +19,6 @@ interface MarkdownViewProps {
   maxMessageWidth: number;
   //isComplete: boolean; // indicating if message is complete
   selectable?: boolean;
-  /** Optional reasoning/thinking content */
-  reasoningContent?: string;
 }
 
 // Helper function to check if content is empty
@@ -101,26 +98,12 @@ const CodeRenderer = ({TDefaultRenderer, ...props}: any) => {
 };
 
 export const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
-  ({markdownText, maxMessageWidth, selectable = false, reasoningContent}) => {
+  ({markdownText, maxMessageWidth, selectable = false}) => {
     const _maxWidth = maxMessageWidth;
 
     const theme = useTheme();
     const styles = createStyles(theme);
     const tagsStyles = useMemo(() => createTagsStyles(theme), [theme]);
-
-    // Create separate tag styles for reasoning content with thinking bubble styling
-    const reasoningTagsStyles = useMemo(
-      () => ({
-        ...tagsStyles,
-        body: {
-          ...tagsStyles.body,
-          color: theme.colors.thinkingBubbleText,
-          fontSize: 14,
-          lineHeight: 20,
-        },
-      }),
-      [tagsStyles, theme],
-    );
 
     const renderers = useMemo(
       () => ({
@@ -147,36 +130,10 @@ export const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
     );
     const source = useMemo(() => ({html: htmlContent}), [htmlContent]);
 
-    // Render reasoning content as markdown if present
-    const reasoningHtmlContent = useMemo(
-      () => (reasoningContent ? (marked(reasoningContent) as string) : null),
-      [reasoningContent],
-    );
-    const reasoningSource = useMemo(
-      () => (reasoningHtmlContent ? {html: reasoningHtmlContent} : null),
-      [reasoningHtmlContent],
-    );
-
     return (
       <View
         testID="markdown-content"
         style={[styles.markdownContainer, {maxWidth: _maxWidth}]}>
-        {/* Render reasoning/thinking content first if present */}
-        {reasoningSource && !isEmptyContent(reasoningContent || '') && (
-          <ThinkingBubble>
-            <RenderHtml
-              contentWidth={contentWidth}
-              source={reasoningSource}
-              tagsStyles={reasoningTagsStyles}
-              defaultTextProps={defaultTextProps}
-              systemFonts={systemFonts}
-              renderers={renderers}
-              customHTMLElementModels={tableHTMLElementModels}
-            />
-          </ThinkingBubble>
-        )}
-
-        {/* Render main content only if it's not empty */}
         {!isEmptyContent(markdownText) && (
           <RenderHtml
             contentWidth={contentWidth}
@@ -195,6 +152,5 @@ export const MarkdownView: React.FC<MarkdownViewProps> = React.memo(
     prevProps.markdownText === nextProps.markdownText &&
     //prevProps.isComplete === nextProps.isComplete &&
     prevProps.maxMessageWidth === nextProps.maxMessageWidth &&
-    prevProps.selectable === nextProps.selectable &&
-    prevProps.reasoningContent === nextProps.reasoningContent,
+    prevProps.selectable === nextProps.selectable,
 );

--- a/src/components/MarkdownView/styles.ts
+++ b/src/components/MarkdownView/styles.ts
@@ -74,23 +74,4 @@ export const createStyles = (theme: Theme) =>
       borderRadius: 6,
       marginTop: 4,
     },
-    thinkContainer: {
-      backgroundColor: theme.colors.surfaceContainerHigh,
-      borderRadius: 8,
-      padding: 12,
-      marginVertical: 8,
-      borderLeftWidth: 4,
-      borderLeftColor: theme.colors.primary,
-      opacity: 0.8,
-    },
-    thinkText: {
-      color: theme.colors.primary,
-      fontWeight: 'bold',
-      marginRight: 8,
-    },
-    thinkTextContainer: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      marginBottom: 4,
-    },
   });

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {Pressable, StyleSheet, Text, View, Animated} from 'react-native';
 
 import {oneOf} from '@flyerhq/react-native-link-preview';
+import {observer} from 'mobx-react';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 
 import {useTheme} from '../../hooks';
@@ -108,8 +109,20 @@ export interface MessageProps extends MessageTopLevelProps {
 
 /** Base component for all message types in the chat. Renders bubbles around
  * messages and status. Sets maximum width for a message for
- * a nice look on larger screens. */
-export const Message = React.memo(
+ * a nice look on larger screens.
+ *
+ * Wrapped with `observer` (mobx-react) — without it, per-token mutations of
+ * `step.content` via `chatSessionStore.applyStreamingUpdate` (which replaces
+ * `turn.steps[lastIdx]` with a new object) would NOT trigger this component
+ * to re-render. The AssistantTurn message reference itself is stable across
+ * streaming, so a plain `React.memo` would skip every per-token update and
+ * the chat would only refresh when an unrelated state transition (status
+ * flip, keyboard event, scroll) happened to re-render the parent.
+ *
+ * `observer` already provides memo-equivalent shallow-prop comparison, so it
+ * cleanly replaces `React.memo` here. See `chat-flow.md` §2 for the
+ * single-writer streaming path this hooks into. */
+export const Message = observer(
   ({
     enableAnimation,
     // isActiveRun / activeRunPendingTalentNames / isGeneratingToolCall

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -112,9 +112,11 @@ export interface MessageProps extends MessageTopLevelProps {
 export const Message = React.memo(
   ({
     enableAnimation,
-    isActiveRun,
-    activeRunPendingTalentNames,
-    isGeneratingToolCall,
+    // isActiveRun / activeRunPendingTalentNames / isGeneratingToolCall
+    // are kept on MessageTopLevelProps for ChatView's existing prop
+    // API but are no longer consumed here — pending UX is owned by
+    // ChatView's PendingIndicator (D4 / I4) and TalentSurface
+    // dispatches off persisted step data alone (WHAT §4a).
     message,
     messageWidth,
     onMessagePress,
@@ -261,13 +263,10 @@ export const Message = React.memo(
     const renderAssistantTurn = () => {
       const turn = message as MessageType.DerivedAssistantTurn;
       const steps = turn.steps ?? [];
-      const lastIdx = steps.length - 1;
       const blocks: React.ReactNode[] = [];
       let isFirstBlock = true;
 
       steps.forEach((step, stepIdx) => {
-        const stepIsActive = isActiveRun && stepIdx === lastIdx;
-
         // Text/reasoning bubble — only when there's something to show.
         // The bubble wraps a TextMessage(step) so per-step content
         // routes through the same markdown / link-preview machinery.
@@ -313,28 +312,17 @@ export const Message = React.memo(
         }
 
         // Talent surface — outside the bubble, with its own visual
-        // container (e.g. HtmlPreviewBubble). Renders nothing if the
-        // step has no toolCalls and we're not actively generating one.
-        const showTalentSurface =
-          (step.toolCalls && step.toolCalls.length > 0) ||
-          (stepIsActive &&
-            ((activeRunPendingTalentNames?.length ?? 0) > 0 ||
-              isGeneratingToolCall));
-        if (showTalentSurface) {
+        // container (e.g. HtmlPreviewBubble). Renders one block per
+        // call in step.toolCalls (in array order). Per WHAT §4a, the
+        // ChatView-owned PendingIndicator covers the in-flight window
+        // before tool outcomes land — there is no per-call pending UI
+        // here.
+        if (step.toolCalls && step.toolCalls.length > 0) {
           blocks.push(
             <View
               key={`step-${stepIdx}-talent`}
               style={!isFirstBlock ? turnBlockStyles.blockSpacer : undefined}>
-              <TalentSurface
-                step={step}
-                isActiveRun={stepIsActive}
-                pendingTalentNames={
-                  stepIsActive ? activeRunPendingTalentNames : undefined
-                }
-                isGeneratingToolCall={
-                  stepIsActive ? isGeneratingToolCall : false
-                }
-              />
+              <TalentSurface step={step} />
             </View>,
           );
           isFirstBlock = false;

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -14,6 +14,7 @@ import {
   StatusIcon,
   FileMessage,
   ImageMessage,
+  ReasoningBlock,
   TalentSurface,
   TextMessage,
   TextMessageTopLevelProps,
@@ -28,7 +29,12 @@ import {excludeDerivedMessageProps, UserContext} from '../../utils';
 // HtmlPreview-after-text-bubble layout. The first block in a turn uses
 // no extra top margin so single-step no-tool turns render identically
 // to the legacy Text bubble snapshot.
-const ASSISTANT_TURN_BLOCK_GAP = 8;
+// Tightened from 8 → 4 (Idea F). With the auto-collapsed text-only
+// reasoning row and the smaller tool chip, an 8px gap between every
+// inner block bloated short turns ("what time is it now?" had visible
+// dead space between every annotation). 4px keeps the visual rhythm
+// without the airiness.
+const ASSISTANT_TURN_BLOCK_GAP = 4;
 const turnBlockStyles = StyleSheet.create({
   blockSpacer: {marginTop: ASSISTANT_TURN_BLOCK_GAP},
 });
@@ -277,24 +283,30 @@ export const Message = observer(
       const turn = message as MessageType.DerivedAssistantTurn;
       const steps = turn.steps ?? [];
       const blocks: React.ReactNode[] = [];
+      // `isFirstBlock` drives the inter-block spacer (no top margin on
+      // the first block). `nameShown` tracks whether the author header
+      // has already been rendered — reasoning blocks never render the
+      // header (they're metadata, not chat posts), so the showName
+      // slot passes through to the first content/talent block.
       let isFirstBlock = true;
+      let nameShown = false;
 
-      // Helper: wrap one TextMessage child in the contentContainer +
-      // optional renderBubble + turn-block spacer. `isReasoningBlock`
-      // selects the testID so tests / E2E can target the two blocks
-      // independently.
+      // Wraps a single TextMessage step fragment in the chat-bubble
+      // shell (contentContainer / renderBubble) plus the turn-block
+      // spacer. Used for content blocks only — reasoning has its own
+      // wrapper via `wrapReasoningBlock` because it's not a bubble.
       const wrapTextBlock = (
         keySuffix: string,
         stepFragment: (typeof steps)[number],
-        isReasoningBlock: boolean,
       ) => {
+        const showNameForBlock = showName && !nameShown;
         const child = (
           <TextMessage
             enableAnimation={enableAnimation}
             message={turn}
             messageWidth={messageWidth}
             onPreviewDataFetched={onPreviewDataFetched}
-            showName={showName && isFirstBlock}
+            showName={showNameForBlock}
             usePreviewData={usePreviewData}
             step={stepFragment}
           />
@@ -306,11 +318,7 @@ export const Message = observer(
               contentContainer,
               !isFirstBlock && turnBlockStyles.blockSpacer,
             ]}
-            testID={
-              isReasoningBlock
-                ? 'ContentContainer-reasoning'
-                : 'ContentContainer'
-            }>
+            testID="ContentContainer">
             {child}
           </View>,
         )({
@@ -319,6 +327,9 @@ export const Message = observer(
           nextMessageInGroup: roundBorder,
           scale: scaleAnim,
         });
+        if (showNameForBlock) {
+          nameShown = true;
+        }
         return (
           <View
             key={keySuffix}
@@ -328,13 +339,36 @@ export const Message = observer(
         );
       };
 
+      // Reasoning is metadata, not a chat bubble — it skips the
+      // contentContainer / renderBubble shell entirely, so the
+      // collapsed text-only row (and partial card) sit directly on
+      // the chat surface with no bubble background or insets fighting
+      // them. The author header is intentionally not shown here:
+      // it belongs to the first true content block.
+      const wrapReasoningBlock = (
+        keySuffix: string,
+        text: string,
+        autoCollapse: boolean,
+      ) => (
+        <View
+          key={keySuffix}
+          style={!isFirstBlock ? turnBlockStyles.blockSpacer : undefined}
+          testID="ContentContainer-reasoning">
+          <ReasoningBlock
+            text={text}
+            maxWidth={messageWidth}
+            autoCollapse={autoCollapse}
+          />
+        </View>
+      );
+
       steps.forEach((step, stepIdx) => {
         // Per WHAT §4a / D3: reasoning and content render as SEPARATE
         // blocks, reasoning first (matches model emission order). Each
         // block is skipped when its source field is empty so a step
         // with content-only or reasoning-only renders exactly one
-        // bubble (no phantom layout). Spacing between blocks is
-        // handled by `turnBlockStyles.blockSpacer`.
+        // block (no phantom layout). Spacing between blocks is handled
+        // by `turnBlockStyles.blockSpacer`.
         const hasReasoning =
           step.reasoningContent !== undefined &&
           step.reasoningContent.length > 0;
@@ -342,24 +376,24 @@ export const Message = observer(
           step.content !== undefined && step.content.length > 0;
 
         if (hasReasoning) {
-          // Reasoning-only fragment: drop content so MarkdownView
-          // renders only the ThinkingBubble. No type cast needed —
-          // step is already AgentStep-shaped.
-          const reasoningOnly = {...step, content: undefined};
+          // Auto-collapse the reasoning bubble once content has begun
+          // streaming OR the step has finalized. Streaming reasoning
+          // alone (before content starts) keeps the bubble in PARTIAL
+          // so the user sees thoughts live; once the model has moved
+          // on to content, the bubble shrinks to its text-only form.
+          const autoCollapseReasoning = hasContent || step.partial === false;
           blocks.push(
-            wrapTextBlock(`step-${stepIdx}-reasoning`, reasoningOnly, true),
+            wrapReasoningBlock(
+              `step-${stepIdx}-reasoning`,
+              step.reasoningContent as string,
+              autoCollapseReasoning,
+            ),
           );
           isFirstBlock = false;
         }
 
         if (hasContent) {
-          // Content-only fragment: drop reasoningContent so the
-          // content block renders without the (already-emitted)
-          // ThinkingBubble.
-          const contentOnly = {...step, reasoningContent: undefined};
-          blocks.push(
-            wrapTextBlock(`step-${stepIdx}-text`, contentOnly, false),
-          );
+          blocks.push(wrapTextBlock(`step-${stepIdx}-text`, step));
           isFirstBlock = false;
         }
 

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -266,47 +266,94 @@ export const Message = React.memo(
       const blocks: React.ReactNode[] = [];
       let isFirstBlock = true;
 
+      // Helper: wrap one TextMessage child in the contentContainer +
+      // optional renderBubble + turn-block spacer. `isReasoningBlock`
+      // selects the testID so tests / E2E can target the two blocks
+      // independently.
+      const wrapTextBlock = (
+        keySuffix: string,
+        stepFragment: typeof steps[number],
+        isReasoningBlock: boolean,
+      ) => {
+        const child = (
+          <TextMessage
+            enableAnimation={enableAnimation}
+            message={turn}
+            messageWidth={messageWidth}
+            onPreviewDataFetched={onPreviewDataFetched}
+            showName={showName && isFirstBlock}
+            usePreviewData={usePreviewData}
+            step={stepFragment}
+          />
+        );
+        const wrapped = oneOf(
+          renderBubble,
+          <View
+            style={[
+              contentContainer,
+              !isFirstBlock && turnBlockStyles.blockSpacer,
+            ]}
+            testID={
+              isReasoningBlock
+                ? 'ContentContainer-reasoning'
+                : 'ContentContainer'
+            }>
+            {child}
+          </View>,
+        )({
+          child,
+          message: excludeDerivedMessageProps(message),
+          nextMessageInGroup: roundBorder,
+          scale: scaleAnim,
+        });
+        return (
+          <View
+            key={keySuffix}
+            style={!isFirstBlock ? turnBlockStyles.blockSpacer : undefined}>
+            {wrapped}
+          </View>
+        );
+      };
+
       steps.forEach((step, stepIdx) => {
-        // Text/reasoning bubble — only when there's something to show.
-        // The bubble wraps a TextMessage(step) so per-step content
-        // routes through the same markdown / link-preview machinery.
-        if (
-          (step.content && step.content.length > 0) ||
-          (step.reasoningContent && step.reasoningContent.length > 0)
-        ) {
-          const child = (
-            <TextMessage
-              enableAnimation={enableAnimation}
-              message={turn}
-              messageWidth={messageWidth}
-              onPreviewDataFetched={onPreviewDataFetched}
-              showName={showName && isFirstBlock}
-              usePreviewData={usePreviewData}
-              step={step}
-            />
-          );
-          const wrapped = oneOf(
-            renderBubble,
-            <View
-              style={[
-                contentContainer,
-                !isFirstBlock && turnBlockStyles.blockSpacer,
-              ]}
-              testID="ContentContainer">
-              {child}
-            </View>,
-          )({
-            child,
-            message: excludeDerivedMessageProps(message),
-            nextMessageInGroup: roundBorder,
-            scale: scaleAnim,
-          });
+        // Per WHAT §4a / D3: reasoning and content render as SEPARATE
+        // blocks, reasoning first (matches model emission order). Each
+        // block is skipped when its source field is empty so a step
+        // with content-only or reasoning-only renders exactly one
+        // bubble (no phantom layout). Spacing between blocks is
+        // handled by `turnBlockStyles.blockSpacer`.
+        const hasReasoning =
+          step.reasoningContent !== undefined &&
+          step.reasoningContent.length > 0;
+        const hasContent =
+          step.content !== undefined && step.content.length > 0;
+
+        if (hasReasoning) {
+          // Reasoning-only fragment: drop content so MarkdownView
+          // renders only the ThinkingBubble. No type cast needed —
+          // step is already AgentStep-shaped.
+          const reasoningOnly = {...step, content: undefined};
           blocks.push(
-            <View
-              key={`step-${stepIdx}-text`}
-              style={!isFirstBlock ? turnBlockStyles.blockSpacer : undefined}>
-              {wrapped}
-            </View>,
+            wrapTextBlock(
+              `step-${stepIdx}-reasoning`,
+              reasoningOnly,
+              true,
+            ),
+          );
+          isFirstBlock = false;
+        }
+
+        if (hasContent) {
+          // Content-only fragment: drop reasoningContent so the
+          // content block renders without the (already-emitted)
+          // ThinkingBubble.
+          const contentOnly = {...step, reasoningContent: undefined};
+          blocks.push(
+            wrapTextBlock(
+              `step-${stepIdx}-text`,
+              contentOnly,
+              false,
+            ),
           );
           isFirstBlock = false;
         }

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -8,6 +8,7 @@ import {useTheme} from '../../hooks';
 
 import styles from './styles';
 import {
+  AssistantTurnFooter,
   Avatar,
   StatusIcon,
   FileMessage,
@@ -347,11 +348,31 @@ export const Message = React.memo(
     // The single Pressable + Avatar + StatusIcon wrapping is preserved
     // so long-press routing stays turn-level (selectedMessage holds the
     // turn id) and avatar shows once per turn.
+    //
+    // Per WHAT §4b / D9 / I1: ONE AssistantTurnFooter per assistant
+    // row, attached HERE in the outer JSX (not inside renderMessage())
+    // so:
+    //   - AssistantTurn rows render N step blocks then one footer
+    //     (regardless of step count — fixes the duplicate-footer bug
+    //     by construction).
+    //   - Legacy assistant Text rows still get exactly one footer
+    //     (chrome moves out of Bubble, into here).
+    //   - User-authored Text rows render no footer (no behaviour
+    //     change for the user side).
+    const showAssistantFooter =
+      !currentUserIsAuthor &&
+      (message.type === 'assistant_turn' || message.type === 'text');
     const innerContent =
       message.type === 'assistant_turn' ? (
-        <View>{renderAssistantTurn()}</View>
+        <View>
+          {renderAssistantTurn()}
+          {showAssistantFooter && <AssistantTurnFooter message={message} />}
+        </View>
       ) : (
-        renderBubbleContainer()
+        <>
+          {renderBubbleContainer()}
+          {showAssistantFooter && <AssistantTurnFooter message={message} />}
+        </>
       );
 
     return (

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -272,7 +272,7 @@ export const Message = React.memo(
       // independently.
       const wrapTextBlock = (
         keySuffix: string,
-        stepFragment: typeof steps[number],
+        stepFragment: (typeof steps)[number],
         isReasoningBlock: boolean,
       ) => {
         const child = (
@@ -334,11 +334,7 @@ export const Message = React.memo(
           // step is already AgentStep-shaped.
           const reasoningOnly = {...step, content: undefined};
           blocks.push(
-            wrapTextBlock(
-              `step-${stepIdx}-reasoning`,
-              reasoningOnly,
-              true,
-            ),
+            wrapTextBlock(`step-${stepIdx}-reasoning`, reasoningOnly, true),
           );
           isFirstBlock = false;
         }
@@ -349,11 +345,7 @@ export const Message = React.memo(
           // ThinkingBubble.
           const contentOnly = {...step, reasoningContent: undefined};
           blocks.push(
-            wrapTextBlock(
-              `step-${stepIdx}-text`,
-              contentOnly,
-              false,
-            ),
+            wrapTextBlock(`step-${stepIdx}-text`, contentOnly, false),
           );
           isFirstBlock = false;
         }

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -436,9 +436,18 @@ export const Message = observer(
     const showAssistantFooter =
       !currentUserIsAuthor &&
       (message.type === 'assistant_turn' || message.type === 'text');
+    // Assistant-turn rows render no chat-bubble background, and their
+    // child blocks (text, reasoning, tool chip, html preview, footer)
+    // each size to their own content. The HtmlPreviewBubble's WebView
+    // in particular has no intrinsic width — without an explicit width
+    // here the wrapper collapses to whatever non-html sibling is
+    // widest (or to nothing when an html-only step is mid-stream).
+    // Forcing `width: messageWidth` gives the WebView a budget to
+    // stretch into; text-only siblings still wrap to their natural
+    // width via MarkdownView's own `maxWidth` cap.
     const innerContent =
       message.type === 'assistant_turn' ? (
-        <View>
+        <View style={{width: messageWidth}}>
           {renderAssistantTurn()}
           {showAssistantFooter && <AssistantTurnFooter message={message} />}
         </View>

--- a/src/components/Message/__tests__/Message.assistantTurn.test.tsx
+++ b/src/components/Message/__tests__/Message.assistantTurn.test.tsx
@@ -357,15 +357,12 @@ describe('Message — AssistantTurn renderer', () => {
 
   describe('canonical scenarios', () => {
     it('A — text only: single TextMessage block, no TalentSurface, ONE footer', () => {
-      const message = makeDerivedTurn(
-        [{content: 'Hi! How can I help?'}],
-        {
-          metadata: {
-            timings: {predicted_per_token_ms: 32, predicted_per_second: 30},
-            copyable: true,
-          },
+      const message = makeDerivedTurn([{content: 'Hi! How can I help?'}], {
+        metadata: {
+          timings: {predicted_per_token_ms: 32, predicted_per_second: 30},
+          copyable: true,
         },
-      );
+      });
       const {getAllByTestId, queryByTestId} = render(
         <Message
           message={message}

--- a/src/components/Message/__tests__/Message.assistantTurn.test.tsx
+++ b/src/components/Message/__tests__/Message.assistantTurn.test.tsx
@@ -260,10 +260,11 @@ describe('Message — AssistantTurn renderer', () => {
     // already implicit; we just confirm the renderer threads `step` only.)
   });
 
-  it('#4 active run with empty pendingTalentNames + isGeneratingToolCall=true → renders generic pending UI', () => {
-    // Active run shape: a single step with toolCalls already parsed
-    // OR an empty step that still exists. Here we use the empty-step
-    // case where the renderer is told to show the generic pending UI.
+  it('#4 active run with empty step (no toolCalls) → no TalentSurface (PendingIndicator covers UX, owned by ChatView)', () => {
+    // Per WHAT §4a / D4 / I4: pending UX is no longer rendered inline
+    // by TalentSurface. The ChatView-owned PendingIndicator covers
+    // dead zones; TalentSurface renders only when step.toolCalls is
+    // populated.
     const message = makeDerivedTurn([{content: '', partial: true}]);
     render(
       <Message
@@ -279,16 +280,11 @@ describe('Message — AssistantTurn renderer', () => {
         isGeneratingToolCall
       />,
     );
-    // Talent block fires when the active step is generating a tool call
-    // even before tool_calls land — generic pending copy is shown by
-    // TalentSurface.
-    expect(mockTalentSurfaceCalls).toHaveLength(1);
-    expect(mockTalentSurfaceCalls[0].isActiveRun).toBe(true);
-    expect(mockTalentSurfaceCalls[0].isGeneratingToolCall).toBe(true);
-    expect(mockTalentSurfaceCalls[0].pendingTalentNames).toEqual([]);
+    // No TalentSurface rendered because step.toolCalls is empty.
+    expect(mockTalentSurfaceCalls).toHaveLength(0);
   });
 
-  it('#5 active run with pendingTalentNames=["calculate"] → talent surface receives the names', () => {
+  it('#5 active run with pendingTalentNames=["calculate"] → no TalentSurface until toolCalls land (PendingIndicator covers UX)', () => {
     const message = makeDerivedTurn([{content: '', partial: true}]);
     render(
       <Message
@@ -304,8 +300,10 @@ describe('Message — AssistantTurn renderer', () => {
         isGeneratingToolCall
       />,
     );
-    expect(mockTalentSurfaceCalls).toHaveLength(1);
-    expect(mockTalentSurfaceCalls[0].pendingTalentNames).toEqual(['calculate']);
+    // pendingTalentNames are no longer threaded into TalentSurface;
+    // ChatView's PendingIndicator handles the lead-up. The renderer
+    // emits no TalentSurface until step.toolCalls is populated.
+    expect(mockTalentSurfaceCalls).toHaveLength(0);
   });
 
   it('#7 reasoning-only step still renders a TextMessage block (so the per-step reasoningContent surfaces)', () => {

--- a/src/components/Message/__tests__/Message.assistantTurn.test.tsx
+++ b/src/components/Message/__tests__/Message.assistantTurn.test.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import {Text} from 'react-native';
 
-import {fireEvent, render} from '../../../../jest/test-utils';
+import {observable, runInAction} from 'mobx';
+
+import {act, fireEvent, render} from '../../../../jest/test-utils';
 import {defaultDerivedMessageProps} from '../../../../jest/fixtures';
 
 import {Message} from '../Message';
@@ -88,6 +90,57 @@ beforeEach(() => {
 
 describe('Message — AssistantTurn renderer', () => {
   // ---------- Story Test Requirements (Renderer) #1, #2, #10, #11, #12, #13 ----------
+
+  it('#0 streaming reactivity: in-place mutation of step.content re-renders Message (regression: would fail if `observer` were dropped)', () => {
+    // Mirrors the production streaming path: `applyStreamingUpdate` in
+    // ChatSessionStore replaces `turn.steps[lastIdx]` with a new spread
+    // object inside `runInAction`. The AssistantTurn message reference
+    // itself is stable across streaming. If Message used plain
+    // React.memo (no observer), this kind of inner mutation wouldn't
+    // trigger a re-render and the chat would freeze between status
+    // transitions until some unrelated event (keyboard, scroll) shook
+    // the tree. Wrapping Message with `observer` from mobx-react keeps
+    // the reads of `step.content` tracked so this works correctly.
+    const observableTurn = observable.object<MessageType.DerivedAssistantTurn>(
+      makeDerivedTurn([{content: 'Hel'}]),
+      {},
+      {deep: true},
+    );
+    render(
+      <Message
+        message={observableTurn}
+        messageWidth={440}
+        onMessagePress={jest.fn()}
+        roundBorder
+        showAvatar
+        showName
+        showStatus
+      />,
+    );
+    expect(mockTextMessageCalls).toHaveLength(1);
+    expect(mockTextMessageCalls[0].step?.content).toBe('Hel');
+
+    // Mutate the step in place — same shape as ChatSessionStore's
+    // `turn.steps[lastIdx] = {...last, ...partial}`. Wrapped in `act`
+    // so React flushes the observer-triggered re-render before we
+    // inspect mock calls.
+    act(() => {
+      runInAction(() => {
+        observableTurn.steps[0] = {
+          ...observableTurn.steps[0],
+          content: 'Hello',
+        };
+      });
+    });
+
+    // observer must have caught the read of `step.content` inside
+    // Message → TextMessage during the first render. The mutation
+    // schedules a re-render synchronously; React flushes it before
+    // the next assertion.
+    const latestCall = mockTextMessageCalls[mockTextMessageCalls.length - 1];
+    expect(latestCall.step?.content).toBe('Hello');
+    expect(mockTextMessageCalls.length).toBeGreaterThan(1);
+  });
 
   it('#1 single-step no-tool turn renders one TextMessage block + no talent block', () => {
     const message = makeDerivedTurn([{content: 'Hello!'}]);

--- a/src/components/Message/__tests__/Message.assistantTurn.test.tsx
+++ b/src/components/Message/__tests__/Message.assistantTurn.test.tsx
@@ -22,7 +22,9 @@ jest.mock('@react-native-clipboard/clipboard', () => ({
 
 // Stub TextMessage so renderer tests focus on per-block layout, not
 // internal markdown machinery. The stub records the step prop it was
-// rendered with so we can assert "right step → right block".
+// rendered with so we can assert "right step → right block". After
+// the reasoning split (see ReasoningBlock), TextMessage only renders
+// content blocks — reasoning is asserted via mockReasoningBlockCalls.
 let mockTextMessageCalls: Array<{step?: AgentStep; messageId: string}> = [];
 jest.mock('../../TextMessage/TextMessage', () => {
   return {
@@ -30,6 +32,22 @@ jest.mock('../../TextMessage/TextMessage', () => {
       mockTextMessageCalls.push({
         step: props.step,
         messageId: props.message?.id,
+      });
+      return <></>;
+    }),
+  };
+});
+
+// Stub ReasoningBlock so tests can assert reasoning rendering without
+// pulling in marked/RenderHtml. The stub records the text it was
+// rendered with — that's the only contract Message owes the block.
+let mockReasoningBlockCalls: Array<{text: string; autoCollapse?: boolean}> = [];
+jest.mock('../../ReasoningBlock/ReasoningBlock', () => {
+  return {
+    ReasoningBlock: jest.fn((props: any) => {
+      mockReasoningBlockCalls.push({
+        text: props.text,
+        autoCollapse: props.autoCollapse,
       });
       return <></>;
     }),
@@ -86,6 +104,7 @@ function makeDerivedTurn(
 beforeEach(() => {
   mockTextMessageCalls = [];
   mockTalentSurfaceCalls = [];
+  mockReasoningBlockCalls = [];
 });
 
 describe('Message — AssistantTurn renderer', () => {
@@ -370,7 +389,7 @@ describe('Message — AssistantTurn renderer', () => {
     expect(mockTalentSurfaceCalls).toHaveLength(0);
   });
 
-  it('#7 reasoning-only step still renders a TextMessage block (so the per-step reasoningContent surfaces)', () => {
+  it('#7 reasoning-only step renders a ReasoningBlock (no TextMessage, since content is empty)', () => {
     const message = makeDerivedTurn([
       {content: '', reasoningContent: 'thinking…'},
     ]);
@@ -385,8 +404,9 @@ describe('Message — AssistantTurn renderer', () => {
         showStatus
       />,
     );
-    expect(mockTextMessageCalls).toHaveLength(1);
-    expect(mockTextMessageCalls[0].step?.reasoningContent).toBe('thinking…');
+    expect(mockReasoningBlockCalls).toHaveLength(1);
+    expect(mockReasoningBlockCalls[0].text).toBe('thinking…');
+    expect(mockTextMessageCalls).toHaveLength(0);
   });
 
   it('renders empty content when AssistantTurn has zero steps', () => {
@@ -631,15 +651,13 @@ describe('Message — AssistantTurn renderer', () => {
           showStatus
         />,
       );
-      // Two TextMessage invocations: one for reasoning-only, one for
-      // content-only. Order: reasoning first, then content (D3).
-      expect(mockTextMessageCalls).toHaveLength(2);
-      expect(mockTextMessageCalls[0].step?.reasoningContent).toBe(
-        'Let me think…',
-      );
-      expect(mockTextMessageCalls[0].step?.content).toBeUndefined();
-      expect(mockTextMessageCalls[1].step?.content).toBe('The answer is 42.');
-      expect(mockTextMessageCalls[1].step?.reasoningContent).toBeUndefined();
+      // One ReasoningBlock for reasoning + one TextMessage for content.
+      // Order: reasoning first, then content (D3). Reasoning is no
+      // longer routed through TextMessage — see ReasoningBlock.
+      expect(mockReasoningBlockCalls).toHaveLength(1);
+      expect(mockReasoningBlockCalls[0].text).toBe('Let me think…');
+      expect(mockTextMessageCalls).toHaveLength(1);
+      expect(mockTextMessageCalls[0].step?.content).toBe('The answer is 42.');
       expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
     });
 

--- a/src/components/Message/__tests__/Message.assistantTurn.test.tsx
+++ b/src/components/Message/__tests__/Message.assistantTurn.test.tsx
@@ -7,6 +7,17 @@ import {defaultDerivedMessageProps} from '../../../../jest/fixtures';
 import {Message} from '../Message';
 import {MessageType, AgentStep} from '../../../utils/types';
 
+// Replace the icon component used by AssistantTurnFooter so tests
+// can render it without pulling in native icon assets.
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => {
+  const {Text: PaperText} = require('react-native-paper');
+  return props => <PaperText>{props.name}</PaperText>;
+});
+
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  setString: jest.fn(),
+}));
+
 // Stub TextMessage so renderer tests focus on per-block layout, not
 // internal markdown machinery. The stub records the step prop it was
 // rendered with so we can assert "right step → right block".
@@ -340,5 +351,346 @@ describe('Message — AssistantTurn renderer', () => {
     );
     expect(mockTextMessageCalls).toHaveLength(0);
     expect(mockTalentSurfaceCalls).toHaveLength(0);
+  });
+
+  // ---------- Canonical scenarios from WHAT §6 ----------
+
+  describe('canonical scenarios', () => {
+    it('A — text only: single TextMessage block, no TalentSurface, ONE footer', () => {
+      const message = makeDerivedTurn(
+        [{content: 'Hi! How can I help?'}],
+        {
+          metadata: {
+            timings: {predicted_per_token_ms: 32, predicted_per_second: 30},
+            copyable: true,
+          },
+        },
+      );
+      const {getAllByTestId, queryByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      expect(mockTextMessageCalls).toHaveLength(1);
+      expect(queryByTestId('talent-surface')).toBeNull();
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
+    it('B — datetime tool (no UI registered): TextMessage + TalentSurface (chip path) + TextMessage + ONE footer', () => {
+      const message = makeDerivedTurn(
+        [
+          {
+            content: 'Let me check.',
+            toolCalls: [
+              {id: 'c0', function: {name: 'datetime', arguments: '{}'}},
+            ],
+            toolOutcomes: [
+              {
+                callId: 'c0',
+                toolName: 'datetime',
+                result: {type: 'text', summary: '8:28 AM'},
+                responseContent: '8:28 AM',
+              },
+            ],
+          },
+          {content: "It's 8:28 AM."},
+        ],
+        {
+          metadata: {
+            timings: {predicted_per_second: 30},
+            copyable: true,
+          },
+        },
+      );
+      const {getAllByTestId, queryAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      // Two text blocks (preamble + follow-up)
+      expect(mockTextMessageCalls).toHaveLength(2);
+      // One TalentSurface invocation for the tool call
+      expect(queryAllByTestId('talent-surface')).toHaveLength(1);
+      expect(mockTalentSurfaceCalls[0].step?.toolCalls?.[0].function.name).toBe(
+        'datetime',
+      );
+      // ONE footer (regression guard for duplicate-footer bug — I1)
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
+    it('C — render_html with preamble and follow-up: 2 text blocks + 1 talent block + ONE footer', () => {
+      const message = makeDerivedTurn(
+        [
+          {
+            content: "Sure, here's a preview.",
+            toolCalls: [
+              {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+            ],
+            toolOutcomes: [
+              {
+                callId: 'c0',
+                toolName: 'render_html',
+                result: {
+                  type: 'html',
+                  html: '<p>preview</p>',
+                  summary: 'preview',
+                },
+                responseContent: 'preview',
+              },
+            ],
+          },
+          {content: 'Hope this looks right.'},
+        ],
+        {metadata: {timings: {predicted_per_second: 30}, copyable: true}},
+      );
+      const {getAllByTestId, queryAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      expect(mockTextMessageCalls).toHaveLength(2);
+      expect(queryAllByTestId('talent-surface')).toHaveLength(1);
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
+    it('D — render_html with no preamble: HtmlPreview block + TextMessage + ONE footer (no empty leading bubble)', () => {
+      const message = makeDerivedTurn(
+        [
+          {
+            content: '',
+            toolCalls: [
+              {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+            ],
+            toolOutcomes: [
+              {
+                callId: 'c0',
+                toolName: 'render_html',
+                result: {
+                  type: 'html',
+                  html: '<p>x</p>',
+                  summary: 'x',
+                },
+                responseContent: 'x',
+              },
+            ],
+          },
+          {content: 'There you go.'},
+        ],
+        {metadata: {timings: {predicted_per_second: 30}, copyable: true}},
+      );
+      const {getAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      // No empty leading TextMessage — the per-step skip rule §4a
+      // collapses zero-block steps. Step 0's content is empty, so
+      // only the talent block fires; step 1 supplies the only
+      // TextMessage.
+      expect(mockTextMessageCalls).toHaveLength(1);
+      expect(mockTextMessageCalls[0].step?.content).toBe('There you go.');
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
+    it('E — tool failed: TextMessage(preamble) + TalentSurface (error path) + TextMessage(apology) + ONE footer', () => {
+      const message = makeDerivedTurn(
+        [
+          {
+            content: 'Trying...',
+            toolCalls: [
+              {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+            ],
+            toolOutcomes: [
+              {
+                callId: 'c0',
+                toolName: 'render_html',
+                result: {
+                  type: 'error',
+                  summary: 'failed',
+                  errorMessage: 'invalid markup',
+                },
+                responseContent: 'failed',
+              },
+            ],
+          },
+          {content: "Sorry, couldn't do that."},
+        ],
+        {metadata: {timings: {predicted_per_second: 30}, copyable: true}},
+      );
+      const {getAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      expect(mockTextMessageCalls).toHaveLength(2);
+      expect(mockTalentSurfaceCalls).toHaveLength(1);
+      expect(
+        mockTalentSurfaceCalls[0].step?.toolOutcomes?.[0].result.type,
+      ).toBe('error');
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
+    it('F — reasoning + content: separate reasoning block + content block + ONE footer (D3)', () => {
+      const message = makeDerivedTurn(
+        [
+          {
+            reasoningContent: 'Let me think…',
+            content: 'The answer is 42.',
+          },
+        ],
+        {metadata: {timings: {predicted_per_second: 30}, copyable: true}},
+      );
+      const {getAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      // Two TextMessage invocations: one for reasoning-only, one for
+      // content-only. Order: reasoning first, then content (D3).
+      expect(mockTextMessageCalls).toHaveLength(2);
+      expect(mockTextMessageCalls[0].step?.reasoningContent).toBe(
+        'Let me think…',
+      );
+      expect(mockTextMessageCalls[0].step?.content).toBeUndefined();
+      expect(mockTextMessageCalls[1].step?.content).toBe('The answer is 42.');
+      expect(mockTextMessageCalls[1].step?.reasoningContent).toBeUndefined();
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
+    it('G — multi-tool in one step: 1 preamble TextMessage + 1 TalentSurface (with both calls) + ONE footer', () => {
+      const message = makeDerivedTurn(
+        [
+          {
+            content: 'Here are two:',
+            toolCalls: [
+              {
+                id: 'c1',
+                function: {name: 'render_html', arguments: '{}'},
+              },
+              {
+                id: 'c2',
+                function: {name: 'render_html', arguments: '{}'},
+              },
+            ],
+            toolOutcomes: [
+              {
+                callId: 'c1',
+                toolName: 'render_html',
+                result: {
+                  type: 'html',
+                  html: '<p>1</p>',
+                  summary: '1',
+                },
+                responseContent: '1',
+              },
+              {
+                callId: 'c2',
+                toolName: 'render_html',
+                result: {
+                  type: 'html',
+                  html: '<p>2</p>',
+                  summary: '2',
+                },
+                responseContent: '2',
+              },
+            ],
+          },
+        ],
+        {metadata: {timings: {predicted_per_second: 30}, copyable: true}},
+      );
+      const {getAllByTestId, queryAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      expect(mockTextMessageCalls).toHaveLength(1);
+      // Single TalentSurface invocation per step; the surface itself
+      // renders both calls in array order (verified by
+      // TalentSurface.test.tsx — block order matches array order
+      // [I2]).
+      expect(queryAllByTestId('talent-surface')).toHaveLength(1);
+      const calls = mockTalentSurfaceCalls[0].step?.toolCalls;
+      expect(calls?.[0].id).toBe('c1');
+      expect(calls?.[1].id).toBe('c2');
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
+    it('I1 multi-step turn renders exactly ONE AssistantTurnFooter (regression guard)', () => {
+      const message = makeDerivedTurn(
+        [
+          {content: 'A'},
+          {
+            toolCalls: [
+              {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+            ],
+            toolOutcomes: [
+              {
+                callId: 'c0',
+                toolName: 'render_html',
+                result: {type: 'html', html: '<p>x</p>', summary: 'x'},
+                responseContent: 'x',
+              },
+            ],
+          },
+          {content: 'B'},
+          {content: 'C'},
+        ],
+        {metadata: {timings: {predicted_per_second: 30}, copyable: true}},
+      );
+      const {getAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
   });
 });

--- a/src/components/Message/__tests__/Message.assistantTurn.test.tsx
+++ b/src/components/Message/__tests__/Message.assistantTurn.test.tsx
@@ -654,6 +654,79 @@ describe('Message — AssistantTurn renderer', () => {
       expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
     });
 
+    it('multi-tool partial completion (WHAT §9e): step₀ has two calls, first ok + second error → both rendered in array order via TalentSurface, ONE footer', () => {
+      // WHAT §9e: one talent block (A) followed by one error block
+      // (B), in array order (I2). Both surface simultaneously after
+      // step_finished — verified here at the Message-renderer level
+      // by asserting TalentSurface receives both calls + outcomes
+      // in the right order. The per-block dispatch (talent UI vs
+      // error block) is verified by TalentSurface.test.tsx:#3,#5.
+      const message = makeDerivedTurn(
+        [
+          {
+            content: 'Trying both tools:',
+            toolCalls: [
+              {
+                id: 'c1',
+                function: {name: 'render_html', arguments: '{}'},
+              },
+              {
+                id: 'c2',
+                function: {name: 'render_html', arguments: '{}'},
+              },
+            ],
+            toolOutcomes: [
+              {
+                callId: 'c1',
+                toolName: 'render_html',
+                result: {type: 'html', html: '<p>ok</p>', summary: 'ok'},
+                responseContent: 'ok',
+              },
+              {
+                callId: 'c2',
+                toolName: 'render_html',
+                result: {
+                  type: 'error',
+                  summary: 'failed',
+                  errorMessage: 'invalid markup',
+                },
+                responseContent: 'failed',
+              },
+            ],
+          },
+          {content: 'One worked, one did not.'},
+        ],
+        {metadata: {timings: {predicted_per_second: 30}, copyable: true}},
+      );
+      const {getAllByTestId, queryAllByTestId} = render(
+        <Message
+          message={message}
+          messageWidth={440}
+          onMessagePress={jest.fn()}
+          roundBorder
+          showAvatar
+          showName
+          showStatus
+        />,
+      );
+      // Two text blocks (preamble + apology), one TalentSurface for
+      // step₀.
+      expect(mockTextMessageCalls).toHaveLength(2);
+      expect(queryAllByTestId('talent-surface')).toHaveLength(1);
+      // Both calls reach TalentSurface in array order (I2). The
+      // surface-level dispatch is tested in TalentSurface.test.tsx
+      // — here we verify the renderer doesn't drop calls or
+      // shuffle order.
+      const calls = mockTalentSurfaceCalls[0].step?.toolCalls;
+      const outcomes = mockTalentSurfaceCalls[0].step?.toolOutcomes;
+      expect(calls?.[0].id).toBe('c1');
+      expect(calls?.[1].id).toBe('c2');
+      expect(outcomes?.[0].result.type).toBe('html');
+      expect(outcomes?.[1].result.type).toBe('error');
+      // ONE footer (I1).
+      expect(getAllByTestId('assistant-turn-footer')).toHaveLength(1);
+    });
+
     it('I1 multi-step turn renders exactly ONE AssistantTurnFooter (regression guard)', () => {
       const message = makeDerivedTurn(
         [

--- a/src/components/PalsSheets/__tests__/PalSheet.test.tsx
+++ b/src/components/PalsSheets/__tests__/PalSheet.test.tsx
@@ -710,18 +710,10 @@ describe('PalSheet', () => {
 
       // Toggle calculate and datetime talents on
       await act(async () => {
-        fireEvent(
-          getByTestId('talent-switch-calculate'),
-          'valueChange',
-          true,
-        );
+        fireEvent(getByTestId('talent-switch-calculate'), 'valueChange', true);
       });
       await act(async () => {
-        fireEvent(
-          getByTestId('talent-switch-datetime'),
-          'valueChange',
-          true,
-        );
+        fireEvent(getByTestId('talent-switch-datetime'), 'valueChange', true);
       });
 
       // Submit the form
@@ -778,11 +770,7 @@ describe('PalSheet', () => {
 
       // Toggle calculate off
       await act(async () => {
-        fireEvent(
-          getByTestId('talent-switch-calculate'),
-          'valueChange',
-          false,
-        );
+        fireEvent(getByTestId('talent-switch-calculate'), 'valueChange', false);
       });
 
       // Submit the form

--- a/src/components/PendingIndicator/PendingIndicator.tsx
+++ b/src/components/PendingIndicator/PendingIndicator.tsx
@@ -1,0 +1,67 @@
+import React, {useEffect, useRef} from 'react';
+import {Animated, View} from 'react-native';
+
+import {useTheme} from '../../hooks';
+
+import {styles} from './styles';
+
+import {Theme} from '../../utils/types';
+
+interface DotProps {
+  delay: number;
+  theme: Theme;
+}
+
+const Dot: React.FC<DotProps> = ({delay, theme}) => {
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const animation = Animated.sequence([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 500,
+        delay,
+        useNativeDriver: true,
+      }),
+      Animated.timing(opacity, {
+        toValue: 0.3,
+        duration: 500,
+        useNativeDriver: true,
+      }),
+    ]);
+    Animated.loop(animation).start();
+  }, [opacity, delay]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.dot,
+        {
+          backgroundColor: theme.colors.onSurfaceVariant,
+          opacity,
+        },
+      ]}
+    />
+  );
+};
+
+/**
+ * Subtle dot-row indicator owned by ChatView (WHAT §4d, D4, I4).
+ * Replaces the louder LoadingBubble: same three-dot motion at lower
+ * visual weight (smaller dots, no card background, low-prominence
+ * theme colour), positioned below the latest turn so it covers
+ * every dead zone in Scenario I phases 2, 4, 5, 7. Visibility
+ * gating lives at ChatView (Step 11) — this component is a pure
+ * decoration with no awareness of agent state.
+ */
+export const PendingIndicator: React.FC = () => {
+  const theme = useTheme();
+
+  return (
+    <View style={styles.container} testID="pending-indicator">
+      <Dot delay={0} theme={theme} />
+      <Dot delay={200} theme={theme} />
+      <Dot delay={400} theme={theme} />
+    </View>
+  );
+};

--- a/src/components/PendingIndicator/PendingIndicator.tsx
+++ b/src/components/PendingIndicator/PendingIndicator.tsx
@@ -136,15 +136,13 @@ export const PendingIndicator: React.FC<PendingIndicatorProps> = ({
     const parts: string[] = [label];
     if (pendingToolTokens >= MIN_TOKENS) {
       parts.push(
-        t(l10n.components.pendingIndicator.tokens, {
+        t(l10n.components.toolMetrics.tokens, {
           count: pendingToolTokens.toLocaleString(),
         }),
       );
     }
     if (elapsedSec >= 1) {
-      parts.push(
-        t(l10n.components.pendingIndicator.elapsed, {seconds: elapsedSec}),
-      );
+      parts.push(t(l10n.components.toolMetrics.elapsed, {seconds: elapsedSec}));
     }
     suffix = parts.join(' · ');
   }

--- a/src/components/PendingIndicator/PendingIndicator.tsx
+++ b/src/components/PendingIndicator/PendingIndicator.tsx
@@ -79,6 +79,15 @@ interface PendingIndicatorProps {
    * generation. Surfaced once it crosses {@link MIN_TOKENS}.
    */
   pendingToolTokens?: number;
+  /**
+   * True between the user pressing Stop and the runner actually
+   * exiting (native llama.rn finishing its in-flight `llama_decode`
+   * chunk). When true, the indicator overrides any tool-call label /
+   * count / elapsed suffix with a single "Stopping…" message — the
+   * user-facing signal that "your stop was received, native is
+   * winding down at its next chunk boundary."
+   */
+  isStopping?: boolean;
 }
 
 /**
@@ -102,6 +111,7 @@ interface PendingIndicatorProps {
 export const PendingIndicator: React.FC<PendingIndicatorProps> = ({
   pendingTalentNames,
   pendingToolTokens = 0,
+  isStopping = false,
 }) => {
   const theme = useTheme();
   const l10n = useContext(L10nContext);
@@ -126,9 +136,16 @@ export const PendingIndicator: React.FC<PendingIndicatorProps> = ({
     return () => clearInterval(interval);
   }, [inToolCallMode]);
 
-  // Build the label suffix: "Building page · 120 tokens · 4s"
+  // Build the label suffix.
+  // - In `stopping` mode we override everything with "Stopping…" so
+  //   the user knows their tap registered while we wait for native
+  //   to wind down at the next chunk boundary.
+  // - Otherwise it reads "Building page · 120 tokens · 4s" once the
+  //   thresholds are crossed (see MIN_TOKENS / elapsed >= 1).
   let suffix: string | null = null;
-  if (inToolCallMode) {
+  if (isStopping) {
+    suffix = l10n.components.pendingIndicator.stopping;
+  } else if (inToolCallMode) {
     const labelKey = firstTalent ? TALENT_LABEL_KEYS[firstTalent] : undefined;
     const label = labelKey
       ? l10n.components.pendingIndicator[labelKey]

--- a/src/components/PendingIndicator/PendingIndicator.tsx
+++ b/src/components/PendingIndicator/PendingIndicator.tsx
@@ -1,11 +1,33 @@
-import React, {useEffect, useRef} from 'react';
-import {Animated, View} from 'react-native';
+import React, {useContext, useEffect, useRef, useState} from 'react';
+import {Animated, Text, View} from 'react-native';
 
 import {useTheme} from '../../hooks';
+import {L10nContext} from '../../utils';
+import {t} from '../../locales';
 
-import {styles} from './styles';
+import {styles, createCountStyle} from './styles';
 
 import {Theme} from '../../utils/types';
+
+// Suppress the count for trivial in-progress calls so simple talents
+// don't trade a dot-row for "1 tokens" the moment they start. The
+// threshold is small enough that the user sees the count appear
+// within the first few tokens of any non-trivial tool call.
+const MIN_TOKENS = 10;
+
+// Map talent name → l10n key under `components.pendingIndicator`.
+// Keeping the mapping local to the renderer avoids leaking React-
+// context-bound l10n into the service layer. New talents that want
+// a label add an entry here; otherwise they fall back to the
+// generic "Preparing tool".
+const TALENT_LABEL_KEYS: Record<
+  string,
+  'buildingPage' | 'calculating' | 'lookingUpTime'
+> = {
+  render_html: 'buildingPage',
+  calculate: 'calculating',
+  datetime: 'lookingUpTime',
+};
 
 interface DotProps {
   delay: number;
@@ -45,23 +67,98 @@ const Dot: React.FC<DotProps> = ({delay, theme}) => {
   );
 };
 
+interface PendingIndicatorProps {
+  /**
+   * Names of tool calls the model is currently generating. The first
+   * name (if any) drives the friendly label ("Building page", etc.).
+   * Empty / undefined → no label, plain dot-row.
+   */
+  pendingTalentNames?: string[];
+  /**
+   * Number of token events received during the current tool-call
+   * generation. Surfaced once it crosses {@link MIN_TOKENS}.
+   */
+  pendingToolTokens?: number;
+}
+
 /**
  * Subtle dot-row indicator owned by ChatView (WHAT §4d, D4, I4).
  * Replaces the louder LoadingBubble: same three-dot motion at lower
  * visual weight (smaller dots, no card background, low-prominence
  * theme colour), positioned below the latest turn so it covers
- * every dead zone in Scenario I phases 2, 4, 5, 7. Visibility
- * gating lives at ChatView (Step 11) — this component is a pure
- * decoration with no awareness of agent state.
+ * every dead zone in Scenario I phases 2, 4, 5, 7.
+ *
+ * For long tool calls (e.g. `render_html` building a complex page)
+ * the bare dots aren't enough to tell the user it's still working.
+ * When `pendingTalentNames` is non-empty, the indicator additionally
+ * renders:
+ *   1. A friendly label per talent (e.g. "Building page").
+ *   2. The token count once it crosses the threshold.
+ *   3. Elapsed seconds once at least one second has passed.
+ *
+ * Visibility gating (whether the indicator renders at all) lives at
+ * ChatView (Step 11) — this component is a pure decoration.
  */
-export const PendingIndicator: React.FC = () => {
+export const PendingIndicator: React.FC<PendingIndicatorProps> = ({
+  pendingTalentNames,
+  pendingToolTokens = 0,
+}) => {
   const theme = useTheme();
+  const l10n = useContext(L10nContext);
+  const countStyle = createCountStyle(theme).count;
+
+  const firstTalent = pendingTalentNames?.[0];
+  const inToolCallMode = !!firstTalent;
+
+  // Elapsed seconds tracker. Starts when we enter tool-call mode,
+  // resets when we leave. Uses a 1-second interval — coarse enough
+  // not to thrash the UI, fine enough to reassure "still going".
+  const [elapsedSec, setElapsedSec] = useState(0);
+  useEffect(() => {
+    if (!inToolCallMode) {
+      setElapsedSec(0);
+      return;
+    }
+    const startedAt = Date.now();
+    const interval = setInterval(() => {
+      setElapsedSec(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [inToolCallMode]);
+
+  // Build the label suffix: "Building page · 120 tokens · 4s"
+  let suffix: string | null = null;
+  if (inToolCallMode) {
+    const labelKey = firstTalent ? TALENT_LABEL_KEYS[firstTalent] : undefined;
+    const label = labelKey
+      ? l10n.components.pendingIndicator[labelKey]
+      : l10n.components.pendingIndicator.preparingTool;
+    const parts: string[] = [label];
+    if (pendingToolTokens >= MIN_TOKENS) {
+      parts.push(
+        t(l10n.components.pendingIndicator.tokens, {
+          count: pendingToolTokens.toLocaleString(),
+        }),
+      );
+    }
+    if (elapsedSec >= 1) {
+      parts.push(
+        t(l10n.components.pendingIndicator.elapsed, {seconds: elapsedSec}),
+      );
+    }
+    suffix = parts.join(' · ');
+  }
 
   return (
     <View style={styles.container} testID="pending-indicator">
       <Dot delay={0} theme={theme} />
       <Dot delay={200} theme={theme} />
       <Dot delay={400} theme={theme} />
+      {suffix !== null && (
+        <Text style={countStyle} testID="pending-indicator-suffix">
+          {suffix}
+        </Text>
+      )}
     </View>
   );
 };

--- a/src/components/PendingIndicator/__tests__/PendingIndicator.test.tsx
+++ b/src/components/PendingIndicator/__tests__/PendingIndicator.test.tsx
@@ -80,6 +80,27 @@ describe('PendingIndicator', () => {
     );
   });
 
+  it('overrides everything with "Stopping…" when isStopping is true', () => {
+    // The user has tapped Stop and we're waiting for native llama.rn
+    // to finish its current llama_decode chunk. Even if a tool-call
+    // was in flight (label, token count, elapsed) the indicator must
+    // surface ONLY the stopping signal so the user knows their tap
+    // landed and the silent gap isn't a hung UI.
+    const {getByTestId} = render(
+      <PendingIndicator
+        pendingTalentNames={['render_html']}
+        pendingToolTokens={150}
+        isStopping
+      />,
+    );
+    const suffix = getByTestId('pending-indicator-suffix');
+    expect(suffix.props.children).toBe(
+      l10n.en.components.pendingIndicator.stopping,
+    );
+    // No leftover token count or elapsed text from the previous mode.
+    expect(suffix.props.children).not.toMatch(/tokens/);
+  });
+
   it('appends elapsed seconds after one second has passed', () => {
     jest.useFakeTimers();
     const {getByTestId, rerender} = render(

--- a/src/components/PendingIndicator/__tests__/PendingIndicator.test.tsx
+++ b/src/components/PendingIndicator/__tests__/PendingIndicator.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import {render} from '../../../../jest/test-utils';
+
+import {PendingIndicator} from '../PendingIndicator';
+
+describe('PendingIndicator', () => {
+  it('renders the dot-row container with the documented testID', () => {
+    const {getByTestId} = render(<PendingIndicator />);
+    expect(getByTestId('pending-indicator')).toBeTruthy();
+  });
+});

--- a/src/components/PendingIndicator/__tests__/PendingIndicator.test.tsx
+++ b/src/components/PendingIndicator/__tests__/PendingIndicator.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import {render} from '../../../../jest/test-utils';
+import {render, act} from '../../../../jest/test-utils';
+import {l10n} from '../../../locales';
 
 import {PendingIndicator} from '../PendingIndicator';
 
@@ -8,5 +9,101 @@ describe('PendingIndicator', () => {
   it('renders the dot-row container with the documented testID', () => {
     const {getByTestId} = render(<PendingIndicator />);
     expect(getByTestId('pending-indicator')).toBeTruthy();
+  });
+
+  it('renders no suffix when no tool call is in progress', () => {
+    const {queryByTestId} = render(<PendingIndicator />);
+    expect(queryByTestId('pending-indicator-suffix')).toBeNull();
+  });
+
+  it('shows the friendly label as soon as a tool call starts (no token threshold for label)', () => {
+    const {getByTestId} = render(
+      <PendingIndicator
+        pendingTalentNames={['render_html']}
+        pendingToolTokens={0}
+      />,
+    );
+    const suffix = getByTestId('pending-indicator-suffix');
+    expect(suffix.props.children).toBe(
+      l10n.en.components.pendingIndicator.buildingPage,
+    );
+  });
+
+  it('hides the token count below threshold but keeps the label', () => {
+    const {getByTestId} = render(
+      <PendingIndicator
+        pendingTalentNames={['render_html']}
+        pendingToolTokens={3}
+      />,
+    );
+    const suffix = getByTestId('pending-indicator-suffix');
+    expect(suffix.props.children).not.toMatch(/tokens/);
+    expect(suffix.props.children).toMatch(/Building page/);
+  });
+
+  it('shows label + token count once the count crosses the threshold', () => {
+    const {getByTestId} = render(
+      <PendingIndicator
+        pendingTalentNames={['render_html']}
+        pendingToolTokens={120}
+      />,
+    );
+    expect(getByTestId('pending-indicator-suffix').props.children).toBe(
+      `${l10n.en.components.pendingIndicator.buildingPage} · 120 tokens`,
+    );
+  });
+
+  it('uses the per-talent label for calculate', () => {
+    const {getByTestId} = render(
+      <PendingIndicator pendingTalentNames={['calculate']} />,
+    );
+    expect(getByTestId('pending-indicator-suffix').props.children).toBe(
+      l10n.en.components.pendingIndicator.calculating,
+    );
+  });
+
+  it('uses the per-talent label for datetime', () => {
+    const {getByTestId} = render(
+      <PendingIndicator pendingTalentNames={['datetime']} />,
+    );
+    expect(getByTestId('pending-indicator-suffix').props.children).toBe(
+      l10n.en.components.pendingIndicator.lookingUpTime,
+    );
+  });
+
+  it('falls back to the generic label for unknown talents', () => {
+    const {getByTestId} = render(
+      <PendingIndicator pendingTalentNames={['mystery_tool']} />,
+    );
+    expect(getByTestId('pending-indicator-suffix').props.children).toBe(
+      l10n.en.components.pendingIndicator.preparingTool,
+    );
+  });
+
+  it('appends elapsed seconds after one second has passed', () => {
+    jest.useFakeTimers();
+    const {getByTestId, rerender} = render(
+      <PendingIndicator
+        pendingTalentNames={['render_html']}
+        pendingToolTokens={120}
+      />,
+    );
+    // Initial render: no elapsed segment yet.
+    expect(getByTestId('pending-indicator-suffix').props.children).not.toMatch(
+      /\ds$/,
+    );
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+    rerender(
+      <PendingIndicator
+        pendingTalentNames={['render_html']}
+        pendingToolTokens={120}
+      />,
+    );
+    expect(getByTestId('pending-indicator-suffix').props.children).toMatch(
+      /· 2s$/,
+    );
+    jest.useRealTimers();
   });
 });

--- a/src/components/PendingIndicator/index.ts
+++ b/src/components/PendingIndicator/index.ts
@@ -1,0 +1,1 @@
+export * from './PendingIndicator';

--- a/src/components/PendingIndicator/styles.ts
+++ b/src/components/PendingIndicator/styles.ts
@@ -4,7 +4,12 @@ export const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignSelf: 'flex-start',
-    paddingVertical: 6,
+    paddingTop: 6,
+    // Extra paddingBottom keeps the dot-row from sitting flush against
+    // the chat input — when the keyboard is closed, the FlatList's
+    // header spacer collapses to height: 0 and the indicator is
+    // otherwise the very last visible row above the input.
+    paddingBottom: 16,
     paddingHorizontal: 12,
     gap: 4,
   },

--- a/src/components/PendingIndicator/styles.ts
+++ b/src/components/PendingIndicator/styles.ts
@@ -1,8 +1,11 @@
 import {StyleSheet} from 'react-native';
 
+import {Theme} from '../../utils/types';
+
 export const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
+    alignItems: 'center',
     alignSelf: 'flex-start',
     paddingTop: 6,
     // Extra paddingBottom keeps the dot-row from sitting flush against
@@ -19,3 +22,13 @@ export const styles = StyleSheet.create({
     borderRadius: 2,
   },
 });
+
+export const createCountStyle = (theme: Theme) =>
+  StyleSheet.create({
+    count: {
+      marginLeft: 4,
+      fontSize: 11,
+      color: theme.colors.onSurfaceVariant,
+      opacity: 0.75,
+    },
+  });

--- a/src/components/PendingIndicator/styles.ts
+++ b/src/components/PendingIndicator/styles.ts
@@ -1,0 +1,16 @@
+import {StyleSheet} from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignSelf: 'flex-start',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    gap: 4,
+  },
+  dot: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+  },
+});

--- a/src/components/ReasoningBlock/ReasoningBlock.tsx
+++ b/src/components/ReasoningBlock/ReasoningBlock.tsx
@@ -1,0 +1,83 @@
+import React, {useMemo} from 'react';
+
+import {marked} from 'marked';
+import RenderHtml, {defaultSystemFonts} from 'react-native-render-html';
+
+import {useTheme} from '../../hooks';
+import {ThinkingBubble} from '../ThinkingBubble';
+
+import {createTagsStyles} from '../MarkdownView/styles';
+import {
+  tableRenderers,
+  tableHTMLElementModels,
+} from '../MarkdownView/TableRenderers';
+
+interface ReasoningBlockProps {
+  text: string;
+  maxWidth: number;
+  /**
+   * When true, the inner ThinkingBubble auto-collapses to its compact
+   * text-only row. The user's manual toggle still wins for the bubble's
+   * lifetime — see ThinkingBubble's `userToggledRef`.
+   */
+  autoCollapse?: boolean;
+}
+
+const isEmpty = (s: string) => !s || s.trim() === '';
+
+export const ReasoningBlock: React.FC<ReasoningBlockProps> = React.memo(
+  ({text, maxWidth, autoCollapse}) => {
+    const theme = useTheme();
+
+    const tagsStyles = useMemo(() => createTagsStyles(theme), [theme]);
+
+    // Reasoning uses the same base markdown styling as content but
+    // overrides body color/size to match the thinking-bubble palette.
+    const reasoningTagsStyles = useMemo(
+      () => ({
+        ...tagsStyles,
+        body: {
+          ...tagsStyles.body,
+          color: theme.colors.thinkingBubbleText,
+          fontSize: 14,
+          lineHeight: 20,
+        },
+      }),
+      [tagsStyles, theme],
+    );
+
+    const renderers = useMemo(() => ({...tableRenderers}), []);
+
+    const defaultTextProps = useMemo(
+      () => ({selectable: false, userSelect: 'none' as const}),
+      [],
+    );
+
+    const systemFonts = useMemo(() => defaultSystemFonts, []);
+
+    const htmlContent = useMemo(() => marked(text) as string, [text]);
+    const source = useMemo(() => ({html: htmlContent}), [htmlContent]);
+
+    if (isEmpty(text)) {
+      return null;
+    }
+
+    return (
+      <ThinkingBubble autoCollapse={autoCollapse}>
+        <RenderHtml
+          contentWidth={maxWidth}
+          source={source}
+          tagsStyles={reasoningTagsStyles}
+          defaultTextProps={defaultTextProps}
+          systemFonts={systemFonts}
+          renderers={renderers}
+          customHTMLElementModels={tableHTMLElementModels}
+        />
+      </ThinkingBubble>
+    );
+  },
+  (prev, next) =>
+    prev.text === next.text &&
+    prev.maxWidth === next.maxWidth &&
+    prev.autoCollapse === next.autoCollapse,
+);

--- a/src/components/ReasoningBlock/index.ts
+++ b/src/components/ReasoningBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './ReasoningBlock';

--- a/src/components/TalentSurface/TalentSurface.tsx
+++ b/src/components/TalentSurface/TalentSurface.tsx
@@ -1,133 +1,91 @@
-import React, {useContext} from 'react';
-import {Text, View} from 'react-native';
+import React from 'react';
 
 import {talentUIRegistry} from '../../services/talents/TalentUIRegistry';
-import {L10nContext} from '../../utils';
 import {AgentStep} from '../../utils/types';
 
-import {styles} from './styles';
+import {ToolErrorBlock} from '../ToolErrorBlock';
+import {ToolUsedChip} from '../ToolUsedChip';
 
 interface TalentSurfaceProps {
   /**
-   * Persisted step data from an `AssistantTurn` row. When present, the
-   * component renders one block per tool call: a registered TalentUI's
-   * `renderResult` if the matching outcome exists, else `renderPending`
-   * if this step is part of the active run, else nothing.
+   * Persisted step data from an `AssistantTurn` row. The component
+   * iterates `step.toolCalls` in array order (per WHAT §4a / I2) and
+   * for each call dispatches to one of:
+   *
+   *   1. <ToolErrorBlock />  — outcome.result.type === 'error'
+   *   2. talent UI           — outcome exists, non-error, and the
+   *                            TalentUIRegistry has a renderResult
+   *                            for the call's name
+   *   3. <ToolUsedChip />    — outcome exists, non-error, and there
+   *                            is no registered TalentUI (D8)
+   *   4. (none)              — outcome doesn't exist yet; the
+   *                            ChatView-owned PendingIndicator (D4 /
+   *                            I4) covers feedback during the
+   *                            in-flight window. No inline pending
+   *                            UI is rendered here — that would
+   *                            duplicate the indicator's role.
+   *
+   * The id-match (`outcome.callId === call.id`) is safe by
+   * construction after WHAT §5 cleanup #1: the runner attaches the
+   * same normalized id to both `step_finished` (consumed by
+   * `appendToolCall`) and the per-call `tool_call_finished`
+   * (consumed by `appendToolOutcome`).
    */
   step?: AgentStep;
-  /**
-   * True if this step belongs to the active run. Computed once at the
-   * ChatView level (single source of truth) — see Active-vs-persisted
-   * predicate in the story.
-   */
-  isActiveRun?: boolean;
-  /**
-   * Active-run pending talent names. Populated by the reducer from
-   * parsed tool_calls. When the active step has no `toolCalls` yet but
-   * the runner has flagged talents as pending (early streaming), this
-   * is what drives the per-talent skeleton.
-   */
-  pendingTalentNames?: string[];
-  /**
-   * True if the active run is currently in `generating_tool_call`
-   * status. Used as a final fallback for the generic "preparing tool"
-   * copy when neither outcomes nor pendingTalentNames are populated.
-   */
-  isGeneratingToolCall?: boolean;
 }
 
-/**
- * Pure rendering component that delegates talent output to registered
- * TalentUI renderers via {@link talentUIRegistry}. Reads `step.toolCalls`
- * / `step.toolOutcomes` for persisted (and in-flight) steps and falls
- * back to active-run hints (`pendingTalentNames`, `isGeneratingToolCall`)
- * when the step itself doesn't carry tool data yet.
- *
- * The legacy metadata-bag readers (metadata.talentCalls, talentResults,
- * pendingTalentNames) are intentionally absent — PR-705 never shipped
- * so no production user data carries those fields.
- */
-export const TalentSurface: React.FC<TalentSurfaceProps> = ({
-  step,
-  isActiveRun = false,
-  pendingTalentNames,
-  isGeneratingToolCall = false,
-}) => {
-  const l10n = useContext(L10nContext);
+export const TalentSurface: React.FC<TalentSurfaceProps> = ({step}) => {
+  const calls = step?.toolCalls;
+  if (!calls || calls.length === 0) {
+    return null;
+  }
 
-  // Result phase: iterate the step's tool calls.
-  if (step?.toolCalls && step.toolCalls.length > 0) {
-    const outcomes = step.toolOutcomes ?? [];
-    const rendered: React.ReactNode[] = [];
+  const outcomes = step?.toolOutcomes ?? [];
+  const rendered: React.ReactNode[] = [];
 
-    for (const tc of step.toolCalls) {
-      const name = tc.function?.name ?? '';
-      const ui = talentUIRegistry.get(name);
-      if (!ui) {
+  for (const call of calls) {
+    const name = call.function?.name ?? '';
+    const outcome = outcomes.find(o => o.callId === call.id);
+
+    // 4. No outcome yet — pending indicator (ChatView) handles UX.
+    if (!outcome) {
+      continue;
+    }
+
+    // 1. Error outcome — subtle inline error block.
+    if (outcome.result.type === 'error') {
+      rendered.push(
+        <React.Fragment key={call.id}>
+          <ToolErrorBlock
+            toolName={name}
+            errorMessage={outcome.result.errorMessage}
+          />
+        </React.Fragment>,
+      );
+      continue;
+    }
+
+    // 2. Registered talent UI for this tool name — render its result.
+    const ui = talentUIRegistry.get(name);
+    if (ui?.renderResult) {
+      const node = ui.renderResult(outcome.result);
+      if (node != null) {
+        rendered.push(<React.Fragment key={call.id}>{node}</React.Fragment>);
         continue;
       }
-
-      const outcome = outcomes.find(o => o.callId === tc.id);
-      if (outcome && ui.renderResult) {
-        const node = ui.renderResult(outcome.result);
-        if (node != null) {
-          rendered.push(<React.Fragment key={tc.id}>{node}</React.Fragment>);
-          continue;
-        }
-      }
-
-      // Per-talent pending: only when this step is on the active run
-      // (we don't replay pending UI for persisted steps that lacked
-      // an outcome — that's an error case and is already represented
-      // by the assistant's natural-language follow-up).
-      if (isActiveRun && ui.renderPending) {
-        rendered.push(
-          <React.Fragment key={tc.id}>{ui.renderPending()}</React.Fragment>,
-        );
-      }
     }
 
-    if (rendered.length > 0) {
-      return <>{rendered}</>;
-    }
-    return null;
-  }
-
-  // Pending phase: only meaningful for the active run; persisted steps
-  // with no toolCalls have no talent UI to show.
-  if (!isActiveRun) {
-    return null;
-  }
-
-  if (pendingTalentNames && pendingTalentNames.length > 0) {
-    const specific = pendingTalentNames
-      .map((name, idx) => {
-        const ui = talentUIRegistry.get(name);
-        if (ui?.renderPending) {
-          return (
-            <React.Fragment key={pendingTalentNames[idx]}>
-              {ui.renderPending()}
-            </React.Fragment>
-          );
-        }
-        return null;
-      })
-      .filter(Boolean);
-    if (specific.length > 0) {
-      return <>{specific}</>;
-    }
-  }
-
-  // Generic fallback: only when actively generating a tool call.
-  if (isGeneratingToolCall) {
-    return (
-      <View testID="talent-call-pending" style={styles.pendingContainer}>
-        <Text style={styles.pendingText}>
-          {l10n.chat.generatingPreviewPending}
-        </Text>
-      </View>
+    // 3. No registered UI (or renderResult returned null) — subtle
+    //    "used X" chip so the user still sees the tool was invoked.
+    rendered.push(
+      <React.Fragment key={call.id}>
+        <ToolUsedChip toolName={name} />
+      </React.Fragment>,
     );
   }
 
-  return null;
+  if (rendered.length === 0) {
+    return null;
+  }
+  return <>{rendered}</>;
 };

--- a/src/components/TalentSurface/TalentSurface.tsx
+++ b/src/components/TalentSurface/TalentSurface.tsx
@@ -4,6 +4,7 @@ import {talentUIRegistry} from '../../services/talents/TalentUIRegistry';
 import {AgentStep} from '../../utils/types';
 
 import {ToolErrorBlock} from '../ToolErrorBlock';
+import {ToolMetricsFooter} from '../ToolMetricsFooter';
 import {ToolUsedChip} from '../ToolUsedChip';
 
 interface TalentSurfaceProps {
@@ -66,20 +67,30 @@ export const TalentSurface: React.FC<TalentSurfaceProps> = ({step}) => {
     }
 
     // 2. Registered talent UI for this tool name — render its result.
+    //    The metrics footer (post-hoc tokens + duration) renders as a
+    //    sibling beneath the result so each TalentUI can stay focused
+    //    on its visual envelope; the footer is identical across all
+    //    talents (visual family with AssistantTurnFooter).
     const ui = talentUIRegistry.get(name);
     if (ui?.renderResult) {
       const node = ui.renderResult(outcome.result);
       if (node != null) {
-        rendered.push(<React.Fragment key={call.id}>{node}</React.Fragment>);
+        rendered.push(
+          <React.Fragment key={call.id}>
+            {node}
+            {call.metrics && <ToolMetricsFooter metrics={call.metrics} />}
+          </React.Fragment>,
+        );
         continue;
       }
     }
 
     // 3. No registered UI (or renderResult returned null) — subtle
     //    "used X" chip so the user still sees the tool was invoked.
+    //    The chip carries metrics inline (same line) when present.
     rendered.push(
       <React.Fragment key={call.id}>
-        <ToolUsedChip toolName={name} />
+        <ToolUsedChip toolName={name} metrics={call.metrics} />
       </React.Fragment>,
     );
   }

--- a/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
+++ b/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
@@ -43,9 +43,7 @@ describe('TalentSurface', () => {
 
   it('#2 unregistered tool with non-error outcome → ToolUsedChip', () => {
     const step: AgentStep = {
-      toolCalls: [
-        {id: 'c0', function: {name: 'datetime', arguments: '{}'}},
-      ],
+      toolCalls: [{id: 'c0', function: {name: 'datetime', arguments: '{}'}}],
       toolOutcomes: [
         {
           callId: 'c0',
@@ -62,9 +60,7 @@ describe('TalentSurface', () => {
 
   it('#3 error outcome → ToolErrorBlock (subtle, low-prominence)', () => {
     const step: AgentStep = {
-      toolCalls: [
-        {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
-      ],
+      toolCalls: [{id: 'c0', function: {name: 'render_html', arguments: '{}'}}],
       toolOutcomes: [
         {
           callId: 'c0',
@@ -90,9 +86,7 @@ describe('TalentSurface', () => {
       renderResult: () => <Text testID="html-result">should NOT fire</Text>,
     });
     const step: AgentStep = {
-      toolCalls: [
-        {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
-      ],
+      toolCalls: [{id: 'c0', function: {name: 'render_html', arguments: '{}'}}],
       toolOutcomes: [
         {
           callId: 'c0',
@@ -169,14 +163,10 @@ describe('TalentSurface', () => {
     talentUIRegistry.register({
       name: 'render_html',
       renderResult: result =>
-        result.type === 'html' ? (
-          <Text testID="ui">{result.html}</Text>
-        ) : null,
+        result.type === 'html' ? <Text testID="ui">{result.html}</Text> : null,
     });
     const step: AgentStep = {
-      toolCalls: [
-        {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
-      ],
+      toolCalls: [{id: 'c0', function: {name: 'render_html', arguments: '{}'}}],
       toolOutcomes: [
         // Wrong type for this UI — renderResult returns null.
         {

--- a/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
+++ b/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
@@ -7,12 +7,19 @@ import {TalentSurface} from '../TalentSurface';
 import {talentUIRegistry} from '../../../services/talents/TalentUIRegistry';
 import {AgentStep} from '../../../utils/types';
 
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => {
+  const {Text: PaperText} = require('react-native-paper');
+  return props => <PaperText>{props.name}</PaperText>;
+});
+
 describe('TalentSurface', () => {
   beforeEach(() => {
     talentUIRegistry.reset();
   });
 
-  it('#3 renders registered renderResult for each step.toolCall whose outcome is present', () => {
+  // The four-priority dispatch (WHAT §4a): error > talent UI > chip > none.
+
+  it('#1 talent UI: outcome present + non-error + UI registered → renderResult fires', () => {
     talentUIRegistry.register({
       name: 'calculate',
       renderResult: result => (
@@ -34,105 +41,157 @@ describe('TalentSurface', () => {
     expect(getByTestId('calc-result')).toBeTruthy();
   });
 
-  it('#4 active run with pendingTalentNames=[] + isGeneratingToolCall=true → renders generic "preparing tool" copy', () => {
-    const {getByTestId} = render(
-      <TalentSurface
-        step={undefined}
-        isActiveRun
-        pendingTalentNames={[]}
-        isGeneratingToolCall
-      />,
-    );
-    expect(getByTestId('talent-call-pending')).toBeTruthy();
-  });
-
-  it('#5 active run with pendingTalentNames=["calculate"] → renders the talent-specific renderPending', () => {
-    talentUIRegistry.register({
-      name: 'calculate',
-      renderPending: () => <Text testID="calc-pending">pending-calc</Text>,
-    });
-    const {getByTestId} = render(
-      <TalentSurface
-        step={undefined}
-        isActiveRun
-        pendingTalentNames={['calculate']}
-        isGeneratingToolCall
-      />,
-    );
-    expect(getByTestId('calc-pending')).toBeTruthy();
-  });
-
-  it('persisted step (not active) with no toolOutcome and no renderPending → null', () => {
-    talentUIRegistry.register({
-      name: 'calculate',
-      renderPending: () => <Text testID="pending">pending</Text>,
-    });
-    const step: AgentStep = {
-      toolCalls: [{id: 'c0', function: {name: 'calculate', arguments: '{}'}}],
-    };
-    const {queryByTestId} = render(<TalentSurface step={step} />);
-    expect(queryByTestId('pending')).toBeNull();
-  });
-
-  it('persisted step on active run shows pending UI for unresolved tool calls', () => {
-    talentUIRegistry.register({
-      name: 'calculate',
-      renderPending: () => <Text testID="active-pending">active-pending</Text>,
-    });
-    const step: AgentStep = {
-      toolCalls: [{id: 'c0', function: {name: 'calculate', arguments: '{}'}}],
-    };
-    const {getByTestId} = render(<TalentSurface step={step} isActiveRun />);
-    expect(getByTestId('active-pending')).toBeTruthy();
-  });
-
-  it('renders nothing when there are no toolCalls and no active-run hints', () => {
-    const {queryByTestId} = render(<TalentSurface />);
-    expect(queryByTestId('talent-call-pending')).toBeNull();
-  });
-
-  it('skips tool calls whose talent is not registered', () => {
+  it('#2 unregistered tool with non-error outcome → ToolUsedChip', () => {
     const step: AgentStep = {
       toolCalls: [
-        {id: 'c0', function: {name: 'unregistered_talent', arguments: '{}'}},
+        {id: 'c0', function: {name: 'datetime', arguments: '{}'}},
       ],
       toolOutcomes: [
         {
           callId: 'c0',
-          toolName: 'unregistered_talent',
-          result: {type: 'text', summary: 'x'},
-          responseContent: 'x',
+          toolName: 'datetime',
+          result: {type: 'text', summary: '8:28 AM'},
+          responseContent: '8:28 AM',
         },
       ],
     };
-    const {queryByTestId} = render(<TalentSurface step={step} />);
-    // No registered renderer fires; no generic pending UI either.
-    expect(queryByTestId('talent-call-pending')).toBeNull();
+    const {getByTestId, getByText} = render(<TalentSurface step={step} />);
+    expect(getByTestId('tool-used-chip')).toBeTruthy();
+    expect(getByText('used datetime')).toBeTruthy();
   });
 
-  it('renders pending UI when no toolCalls but pendingTalentNames is set', () => {
+  it('#3 error outcome → ToolErrorBlock (subtle, low-prominence)', () => {
+    const step: AgentStep = {
+      toolCalls: [
+        {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+      ],
+      toolOutcomes: [
+        {
+          callId: 'c0',
+          toolName: 'render_html',
+          result: {
+            type: 'error',
+            summary: 'failed',
+            errorMessage: 'invalid markup',
+          },
+          responseContent: 'failed',
+        },
+      ],
+    };
+    const {getByTestId, getByText} = render(<TalentSurface step={step} />);
+    expect(getByTestId('tool-error-block')).toBeTruthy();
+    expect(getByText('render_html failed')).toBeTruthy();
+    expect(getByText('invalid markup')).toBeTruthy();
+  });
+
+  it('#3b error outcome wins over registered talent UI (priority order)', () => {
     talentUIRegistry.register({
       name: 'render_html',
-      renderPending: () => <Text testID="html-pending">rendering…</Text>,
+      renderResult: () => <Text testID="html-result">should NOT fire</Text>,
     });
-    const {getByTestId} = render(
-      <TalentSurface
-        step={undefined}
-        isActiveRun
-        pendingTalentNames={['render_html']}
-      />,
-    );
-    expect(getByTestId('html-pending')).toBeTruthy();
+    const step: AgentStep = {
+      toolCalls: [
+        {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+      ],
+      toolOutcomes: [
+        {
+          callId: 'c0',
+          toolName: 'render_html',
+          result: {
+            type: 'error',
+            summary: 'oops',
+            errorMessage: 'not great',
+          },
+          responseContent: 'oops',
+        },
+      ],
+    };
+    const {getByTestId, queryByTestId} = render(<TalentSurface step={step} />);
+    expect(getByTestId('tool-error-block')).toBeTruthy();
+    expect(queryByTestId('html-result')).toBeNull();
   });
 
-  it('renders nothing for non-active run with empty pendingTalentNames (legacy persisted no-tool path)', () => {
-    const {queryByTestId} = render(
-      <TalentSurface
-        step={undefined}
-        isActiveRun={false}
-        pendingTalentNames={['x']}
-      />,
+  it('#4 no outcome yet (in-flight) → renders nothing (PendingIndicator covers UX)', () => {
+    talentUIRegistry.register({
+      name: 'calculate',
+      renderResult: () => <Text testID="should-not-fire">x</Text>,
+    });
+    const step: AgentStep = {
+      toolCalls: [{id: 'c0', function: {name: 'calculate', arguments: '{}'}}],
+    };
+    const {queryByTestId} = render(<TalentSurface step={step} />);
+    expect(queryByTestId('should-not-fire')).toBeNull();
+    expect(queryByTestId('tool-used-chip')).toBeNull();
+    expect(queryByTestId('tool-error-block')).toBeNull();
+  });
+
+  it('#5 multi-tool turn renders blocks in step.toolCalls array order (I2)', () => {
+    talentUIRegistry.register({
+      name: 'render_html',
+      renderResult: r => (
+        <Text testID={`preview-${r.summary}`}>preview-{r.summary}</Text>
+      ),
+    });
+    const step: AgentStep = {
+      toolCalls: [
+        {id: 'c1', function: {name: 'render_html', arguments: '{}'}},
+        {id: 'c2', function: {name: 'render_html', arguments: '{}'}},
+      ],
+      toolOutcomes: [
+        {
+          callId: 'c1',
+          toolName: 'render_html',
+          result: {type: 'html', html: '<p>1</p>', summary: 'one'},
+          responseContent: 'one',
+        },
+        {
+          callId: 'c2',
+          toolName: 'render_html',
+          result: {type: 'html', html: '<p>2</p>', summary: 'two'},
+          responseContent: 'two',
+        },
+      ],
+    };
+    const {getByTestId} = render(<TalentSurface step={step} />);
+    expect(getByTestId('preview-one')).toBeTruthy();
+    expect(getByTestId('preview-two')).toBeTruthy();
+  });
+
+  it('renders nothing when step is undefined or has no toolCalls', () => {
+    const {queryByTestId} = render(<TalentSurface />);
+    expect(queryByTestId('tool-used-chip')).toBeNull();
+    expect(queryByTestId('tool-error-block')).toBeNull();
+  });
+
+  it('falls back to ToolUsedChip when renderResult returns null (e.g. unsupported result.type)', () => {
+    // RenderHtmlTalentUI returns null when result.type !== 'html'; the
+    // dispatcher should fall through to the chip.
+    talentUIRegistry.register({
+      name: 'render_html',
+      renderResult: result =>
+        result.type === 'html' ? (
+          <Text testID="ui">{result.html}</Text>
+        ) : null,
+    });
+    const step: AgentStep = {
+      toolCalls: [
+        {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+      ],
+      toolOutcomes: [
+        // Wrong type for this UI — renderResult returns null.
+        {
+          callId: 'c0',
+          toolName: 'render_html',
+          result: {type: 'text', summary: 'plain'},
+          responseContent: 'plain',
+        },
+      ],
+    };
+    const {queryByTestId, getByTestId, getByText} = render(
+      <TalentSurface step={step} />,
     );
-    expect(queryByTestId('talent-call-pending')).toBeNull();
+    expect(queryByTestId('ui')).toBeNull();
+    expect(getByTestId('tool-used-chip')).toBeTruthy();
+    expect(getByText('used render_html')).toBeTruthy();
   });
 });

--- a/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
+++ b/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
@@ -184,4 +184,123 @@ describe('TalentSurface', () => {
     expect(getByTestId('tool-used-chip')).toBeTruthy();
     expect(getByText('used render_html')).toBeTruthy();
   });
+
+  // ---------- WHAT §9e — Multi-tool partial completion ----------
+
+  it('#9e multi-tool partial completion: talent block + error block render together in array order (I2)', () => {
+    // WHAT §9e: step₀ has [A, B]; A succeeds (talent UI registered),
+    // B fails (error result). Per I2, blocks emit in step.toolCalls
+    // array order. Both must appear simultaneously after
+    // step_finished — ChatView's pending indicator stops covering
+    // them once outcomes land.
+    talentUIRegistry.register({
+      name: 'render_html',
+      renderResult: result =>
+        result.type === 'html' ? (
+          <Text testID={`html-${result.summary}`}>html-{result.summary}</Text>
+        ) : null,
+    });
+    const step: AgentStep = {
+      toolCalls: [
+        {id: 'c1', function: {name: 'render_html', arguments: '{}'}},
+        {id: 'c2', function: {name: 'render_html', arguments: '{}'}},
+      ],
+      toolOutcomes: [
+        {
+          callId: 'c1',
+          toolName: 'render_html',
+          result: {type: 'html', html: '<p>ok</p>', summary: 'ok'},
+          responseContent: 'ok',
+        },
+        {
+          callId: 'c2',
+          toolName: 'render_html',
+          result: {
+            type: 'error',
+            summary: 'failed',
+            errorMessage: 'invalid markup',
+          },
+          responseContent: 'failed',
+        },
+      ],
+    };
+    const {getByTestId, getByText} = render(<TalentSurface step={step} />);
+    // Talent UI for the successful call.
+    expect(getByTestId('html-ok')).toBeTruthy();
+    // Error block for the failed call.
+    expect(getByTestId('tool-error-block')).toBeTruthy();
+    expect(getByText('render_html failed')).toBeTruthy();
+  });
+
+  // ---------- WHAT §9c — Persistence load with deleted talent ----------
+
+  describe('persistence load with deleted talent (WHAT §9c)', () => {
+    it('persisted turn references render_html but registry has no entry → ToolUsedChip renders, no row drop, no crash', () => {
+      // Simulate the post-load state: TalentUIRegistry was reset
+      // (e.g. talent removed from the build, or registry init lost
+      // a race with the chat reload). The persisted step still has
+      // a valid html outcome; per WHAT §9c / D8 the UI must
+      // gracefully fall back to the subtle "used X" chip — no
+      // crash, no missing row.
+      // Note: registry was reset() in the outer beforeEach.
+      const step: AgentStep = {
+        toolCalls: [
+          {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+        ],
+        toolOutcomes: [
+          {
+            callId: 'c0',
+            toolName: 'render_html',
+            // Real (non-error) result — the rich UI would normally
+            // render this, but the UI is gone after reload.
+            result: {
+              type: 'html',
+              html: '<p>preview</p>',
+              summary: 'preview',
+            },
+            responseContent: 'preview',
+          },
+        ],
+      };
+      const {getByTestId, getByText, queryByTestId} = render(
+        <TalentSurface step={step} />,
+      );
+      // Tool-used chip surfaces the call (intent issue #3 fix —
+      // tool's name is visible even though the rich UI is gone).
+      expect(getByTestId('tool-used-chip')).toBeTruthy();
+      expect(getByText('used render_html')).toBeTruthy();
+      // No error block — outcome is non-error.
+      expect(queryByTestId('tool-error-block')).toBeNull();
+    });
+
+    it('persisted error outcome with deleted talent UI → still renders ToolErrorBlock (error wins over missing UI)', () => {
+      // Edge of WHAT §9c: even with no registered UI, an error
+      // outcome remains an error. Priority order error > talent UI
+      // > chip says the error block wins regardless of registry
+      // state.
+      const step: AgentStep = {
+        toolCalls: [
+          {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+        ],
+        toolOutcomes: [
+          {
+            callId: 'c0',
+            toolName: 'render_html',
+            result: {
+              type: 'error',
+              summary: 'oops',
+              errorMessage: 'something broke',
+            },
+            responseContent: 'oops',
+          },
+        ],
+      };
+      const {getByTestId, queryByTestId} = render(
+        <TalentSurface step={step} />,
+      );
+      expect(getByTestId('tool-error-block')).toBeTruthy();
+      // Chip is suppressed by the error-takes-priority rule.
+      expect(queryByTestId('tool-used-chip')).toBeNull();
+    });
+  });
 });

--- a/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
+++ b/src/components/TalentSurface/__tests__/TalentSurface.test.tsx
@@ -303,4 +303,96 @@ describe('TalentSurface', () => {
       expect(queryByTestId('tool-used-chip')).toBeNull();
     });
   });
+
+  // ---------- Per-call metrics flow ----------
+  //
+  // Generation metrics are attached to step.toolCalls[i].metrics by
+  // the runner. TalentSurface forwards them to the chip (inline
+  // suffix) or renders a sibling ToolMetricsFooter beneath the
+  // talent UI's result. Both paths must degrade gracefully when
+  // metrics are absent (older persisted calls).
+  describe('per-call metrics', () => {
+    it('renders ToolMetricsFooter beneath a talent UI when metrics are present', () => {
+      talentUIRegistry.register({
+        name: 'render_html',
+        renderResult: () => <Text testID="html-preview">preview</Text>,
+      });
+      const step: AgentStep = {
+        toolCalls: [
+          {
+            id: 'c0',
+            function: {name: 'render_html', arguments: '{}'},
+            metrics: {tokens: 1500, durationMs: 35000},
+          },
+        ],
+        toolOutcomes: [
+          {
+            callId: 'c0',
+            toolName: 'render_html',
+            result: {
+              type: 'html',
+              html: '<p>x</p>',
+              summary: 'preview',
+            },
+            responseContent: 'preview',
+          },
+        ],
+      };
+      const {getByTestId, getByText} = render(<TalentSurface step={step} />);
+      expect(getByTestId('html-preview')).toBeTruthy();
+      expect(getByTestId('tool-metrics-footer')).toBeTruthy();
+      expect(getByText(/1.500 tokens.+35s/)).toBeTruthy();
+    });
+
+    it('omits the footer when metrics are absent (older persisted call)', () => {
+      talentUIRegistry.register({
+        name: 'render_html',
+        renderResult: () => <Text testID="html-preview">preview</Text>,
+      });
+      const step: AgentStep = {
+        toolCalls: [
+          {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+        ],
+        toolOutcomes: [
+          {
+            callId: 'c0',
+            toolName: 'render_html',
+            result: {
+              type: 'html',
+              html: '<p>x</p>',
+              summary: 'preview',
+            },
+            responseContent: 'preview',
+          },
+        ],
+      };
+      const {getByTestId, queryByTestId} = render(
+        <TalentSurface step={step} />,
+      );
+      expect(getByTestId('html-preview')).toBeTruthy();
+      expect(queryByTestId('tool-metrics-footer')).toBeNull();
+    });
+
+    it('passes metrics through to ToolUsedChip for unregistered talents', () => {
+      const step: AgentStep = {
+        toolCalls: [
+          {
+            id: 'c0',
+            function: {name: 'datetime', arguments: '{}'},
+            metrics: {tokens: 7, durationMs: 1200},
+          },
+        ],
+        toolOutcomes: [
+          {
+            callId: 'c0',
+            toolName: 'datetime',
+            result: {type: 'text', summary: '8:28 AM'},
+            responseContent: '8:28 AM',
+          },
+        ],
+      };
+      const {getByText} = render(<TalentSurface step={step} />);
+      expect(getByText(/used datetime.+7 tokens.+1s/)).toBeTruthy();
+    });
+  });
 });

--- a/src/components/TextMessage/TextMessage.tsx
+++ b/src/components/TextMessage/TextMessage.tsx
@@ -53,10 +53,10 @@ export interface TextMessageProps extends TextMessageTopLevelProps {
   messageWidth: number;
   showName: boolean;
   /**
-   * When provided, the component renders this step's `content` and
-   * `reasoningContent` in place of `message.text`. Set by the
-   * AssistantTurn renderer for each step within a turn — same
-   * component, per-step content.
+   * When provided, the component renders this step's `content` in
+   * place of `message.text`. Set by the AssistantTurn renderer for
+   * each step within a turn — same component, per-step content.
+   * Reasoning is rendered separately via ReasoningBlock.
    */
   step?: AgentStep;
 }
@@ -72,15 +72,13 @@ export const TextMessage = ({
 }: TextMessageProps) => {
   // For AssistantTurn rendering, the per-step `content` is the
   // authoritative source. For legacy `Text` messages, fall back to
-  // `message.text`. Same fallback for `reasoningContent`.
+  // `message.text`. Reasoning is rendered separately via
+  // ReasoningBlock — TextMessage only owns the content side.
   const visibleText: string = step
     ? (step.content ?? '')
     : 'text' in message
       ? message.text
       : '';
-  const reasoningContent: string | undefined = step
-    ? step.reasoningContent
-    : undefined;
   const theme = useTheme();
   const user = React.useContext(UserContext);
   const [previewData, setPreviewData] = React.useState(
@@ -279,7 +277,6 @@ export const TextMessage = ({
             markdownText={visibleText.trim()}
             maxMessageWidth={messageWidth}
             selectable={false}
-            reasoningContent={reasoningContent}
           />
         </View>
       )}

--- a/src/components/TextMessage/styles.ts
+++ b/src/components/TextMessage/styles.ts
@@ -38,7 +38,10 @@ export const styles = ({
         : theme.fonts.receivedMessageBodyTextStyle),
     },
     textContainer: {
-      marginHorizontal: theme.insets.messageInsetsHorizontal,
+      marginHorizontal:
+        user?.id === message.author.id
+          ? theme.insets.messageInsetsHorizontal
+          : 0,
       marginVertical: theme.insets.messageInsetsVertical,
     },
     imageContainer: {

--- a/src/components/ThinkingBubble/ThinkingBubble.tsx
+++ b/src/components/ThinkingBubble/ThinkingBubble.tsx
@@ -36,9 +36,19 @@ enum BubbleState {
 
 interface ThinkingBubbleProps {
   children?: React.ReactNode;
+  /**
+   * When true, auto-collapse the bubble (typically when the step's main
+   * content has started streaming, signalling the model has moved past
+   * the reasoning block). Respects user intent — once the user manually
+   * toggles, this prop no longer drives state.
+   */
+  autoCollapse?: boolean;
 }
 
-export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({children}) => {
+export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
+  children,
+  autoCollapse,
+}) => {
   const theme = useTheme();
   const l10n = useContext(L10nContext);
   const styles = createStyles(theme);
@@ -49,6 +59,25 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({children}) => {
 
   // Track animation state to optimize rendering
   const [isAnimating, setIsAnimating] = useState(false);
+
+  // Once the user manually toggles, the autoCollapse signal is ignored
+  // for the lifetime of this bubble (per-row instance). Without this,
+  // a user who expanded mid-stream would get re-collapsed when content
+  // tokens start arriving — undesired.
+  const userToggledRef = useRef(false);
+
+  // React to autoCollapse: rising-edge collapse only, and only if the
+  // user hasn't taken control. Default streaming state is PARTIAL so
+  // the user can watch the reasoning live; the collapse fires once
+  // content begins streaming (or the step finalizes).
+  useEffect(() => {
+    if (autoCollapse && !userToggledRef.current) {
+      setBubbleState(BubbleState.COLLAPSED);
+      chevronRotation.setValue(0);
+    }
+    // chevronRotation is a stable ref, intentionally omitted
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoCollapse]);
 
   const chevronRotation = useRef(new Animated.Value(0)).current;
 
@@ -233,31 +262,59 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({children}) => {
   };
 
   const handlePress = () => {
+    // Mark that the user has taken control — autoCollapse becomes
+    // a no-op from here on for this bubble instance.
+    userToggledRef.current = true;
     toggleState();
     animateChevronScale();
   };
 
+  // Text-only collapsed render: a single inline tappable row with a
+  // small chevron + label. No card, no border, no shadow. The whole
+  // row is the tap target.
+  if (bubbleState === BubbleState.COLLAPSED) {
+    return (
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={l10n.components.thinkingBubble.reasoning}
+        activeOpacity={0.6}
+        onPress={handlePress}
+        hitSlop={{top: 8, bottom: 8, left: 8, right: 8}}>
+        <View style={styles.collapsedRow} testID="thinking-bubble-collapsed">
+          <Animated.View
+            style={{
+              transform: [{rotate: chevronRotationDeg}, {scale: chevronScale}],
+            }}>
+            <ChevronDownIcon
+              testID="chevron-icon"
+              width={12}
+              height={12}
+              stroke={theme.colors.thinkingBubbleText}
+            />
+          </Animated.View>
+          <Text style={styles.collapsedRowLabel}>
+            {l10n.components.thinkingBubble.reasoning}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+
+  // PARTIAL / EXPANDED — original card rendering.
   return (
     <TouchableOpacity
-      style={bubbleState !== BubbleState.COLLAPSED && styles.shadowContainer}
+      style={styles.shadowContainer}
       activeOpacity={0.9}
       onPress={handlePress}>
       <View style={containerStyle}>
         {/* Header */}
-        <View
-          style={[
-            styles.headerContainer,
-            bubbleState === BubbleState.COLLAPSED &&
-              styles.collapsedHeaderContainer,
-          ]}>
+        <View style={styles.headerContainer}>
           <Text variant="titleSmall" style={styles.headerText}>
             {l10n.components.thinkingBubble.reasoning}
           </Text>
           <Animated.View
             style={[
               styles.chevronContainer,
-              bubbleState === BubbleState.COLLAPSED &&
-                styles.collapsedChevronContainer, // Smaller chevron in collapsed state
               {
                 transform: [
                   {rotate: chevronRotationDeg},
@@ -267,8 +324,8 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({children}) => {
             ]}>
             <ChevronDownIcon
               testID="chevron-icon"
-              width={bubbleState === BubbleState.COLLAPSED ? 16 : 18}
-              height={bubbleState === BubbleState.COLLAPSED ? 16 : 18}
+              width={18}
+              height={18}
               stroke={theme.colors.thinkingBubbleText}
             />
           </Animated.View>

--- a/src/components/ThinkingBubble/ThinkingBubble.tsx
+++ b/src/components/ThinkingBubble/ThinkingBubble.tsx
@@ -13,7 +13,7 @@ import {
 import {Text} from 'react-native-paper';
 import LinearGradient from 'react-native-linear-gradient';
 import MaskedView from '@react-native-masked-view/masked-view';
-import {ChevronDownIcon} from '../../assets/icons';
+import {ChevronRightIcon, ChevronDownIcon} from '../../assets/icons';
 
 import {useTheme} from '../../hooks';
 import {L10nContext} from '../../utils';
@@ -285,7 +285,7 @@ export const ThinkingBubble: React.FC<ThinkingBubbleProps> = ({
             style={{
               transform: [{rotate: chevronRotationDeg}, {scale: chevronScale}],
             }}>
-            <ChevronDownIcon
+            <ChevronRightIcon
               testID="chevron-icon"
               width={12}
               height={12}

--- a/src/components/ThinkingBubble/__tests__/ThinkingBubble.test.tsx
+++ b/src/components/ThinkingBubble/__tests__/ThinkingBubble.test.tsx
@@ -67,24 +67,35 @@ describe('ThinkingBubble', () => {
   });
 
   it('transitions through all states when pressed multiple times', () => {
-    const {getByText} = renderThinkingBubble();
+    const {getByText, queryByTestId} = renderThinkingBubble();
 
-    const headerText = getByText(l10n.en.components.thinkingBubble.reasoning);
+    // The reasoning label is rendered in PARTIAL/EXPANDED inside
+    // headerContainer and in COLLAPSED inside collapsedRow — different
+    // elements, same text. Re-query after each press so the press
+    // event lands on the live element.
+    const press = () =>
+      fireEvent.press(getByText(l10n.en.components.thinkingBubble.reasoning));
 
-    // First press: PARTIAL to EXPANDED
-    fireEvent.press(headerText);
+    // Initial: PARTIAL — no collapsed row
+    expect(queryByTestId('thinking-bubble-collapsed')).toBeNull();
+
+    // Press 1: PARTIAL → EXPANDED (still card, no collapsed row)
+    press();
+    expect(queryByTestId('thinking-bubble-collapsed')).toBeNull();
     expect(
       require('react-native').LayoutAnimation.configureNext,
     ).toHaveBeenCalledTimes(1);
 
-    // Second press: EXPANDED to COLLAPSED
-    fireEvent.press(headerText);
+    // Press 2: EXPANDED → COLLAPSED (text-only row appears)
+    press();
+    expect(queryByTestId('thinking-bubble-collapsed')).not.toBeNull();
     expect(
       require('react-native').LayoutAnimation.configureNext,
     ).toHaveBeenCalledTimes(2);
 
-    // Third press: COLLAPSED to PARTIAL
-    fireEvent.press(headerText);
+    // Press 3: COLLAPSED → PARTIAL (back to card)
+    press();
+    expect(queryByTestId('thinking-bubble-collapsed')).toBeNull();
     expect(
       require('react-native').LayoutAnimation.configureNext,
     ).toHaveBeenCalledTimes(3);

--- a/src/components/ThinkingBubble/styles.ts
+++ b/src/components/ThinkingBubble/styles.ts
@@ -22,7 +22,10 @@ export const createStyles = (theme: Theme) => {
       }),
     },
     container: {
-      marginVertical: 16, // Increased margin for better elevation appearance
+      // Tightened from 16 → 6 (Idea G). With auto-collapse + text-only
+      // collapsed state, the expanded card is rare; the original 16
+      // bloated the layout for the common collapsed case.
+      marginVertical: 6,
       borderRadius: 20,
       overflow: 'hidden',
       backgroundColor: bubbleBackground,
@@ -121,6 +124,22 @@ export const createStyles = (theme: Theme) => {
     maskSolid: {
       flex: 1,
       backgroundColor: 'black',
+    },
+    // Text-only collapsed state (Idea A): a single inline tappable
+    // row, no card / no border / no shadow. Kept on the left edge so
+    // it reads as a metadata annotation, not a chat bubble.
+    collapsedRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      alignSelf: 'flex-start',
+      //paddingVertical: 4,
+      paddingHorizontal: 4,
+      gap: 6,
+    },
+    collapsedRowLabel: {
+      fontSize: 12,
+      color: textColor,
+      opacity: 0.75,
     },
   });
 };

--- a/src/components/ToolErrorBlock/ToolErrorBlock.tsx
+++ b/src/components/ToolErrorBlock/ToolErrorBlock.tsx
@@ -51,9 +51,7 @@ export const ToolErrorBlock: React.FC<ToolErrorBlockProps> = ({
         </Text>
       </View>
       {errorMessage ? (
-        <Text
-          style={componentStyles.message}
-          testID="tool-error-block-message">
+        <Text style={componentStyles.message} testID="tool-error-block-message">
           {errorMessage}
         </Text>
       ) : null}

--- a/src/components/ToolErrorBlock/ToolErrorBlock.tsx
+++ b/src/components/ToolErrorBlock/ToolErrorBlock.tsx
@@ -1,0 +1,62 @@
+import React, {useContext} from 'react';
+import {View} from 'react-native';
+
+import {Text} from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import {useTheme} from '../../hooks';
+
+import {styles} from './styles';
+
+import {L10nContext} from '../../utils';
+import {t} from '../../locales';
+
+interface ToolErrorBlockProps {
+  toolName: string;
+  errorMessage?: string;
+}
+
+/**
+ * Subtle, low-prominence inline error block rendered when a tool
+ * call's outcome is an error (`result.type === 'error'`). Per WHAT
+ * D2 / I3, this must NOT visually compete with bubbles — only a
+ * warning icon plus low-prominence text. Falls back to "Tool call
+ * failed" copy when no errorMessage is supplied.
+ *
+ * Renders nothing if `toolName` is empty.
+ */
+export const ToolErrorBlock: React.FC<ToolErrorBlockProps> = ({
+  toolName,
+  errorMessage,
+}) => {
+  const theme = useTheme();
+  const l10n = useContext(L10nContext);
+
+  if (!toolName) {
+    return null;
+  }
+
+  const componentStyles = styles({theme});
+
+  return (
+    <View style={componentStyles.container} testID="tool-error-block">
+      <View style={componentStyles.row}>
+        <Icon
+          name="alert-circle-outline"
+          style={componentStyles.icon}
+          testID="tool-error-block-icon"
+        />
+        <Text style={componentStyles.label}>
+          {t(l10n.chat.toolErrorBlock, {name: toolName})}
+        </Text>
+      </View>
+      {errorMessage ? (
+        <Text
+          style={componentStyles.message}
+          testID="tool-error-block-message">
+          {errorMessage}
+        </Text>
+      ) : null}
+    </View>
+  );
+};

--- a/src/components/ToolErrorBlock/__tests__/ToolErrorBlock.test.tsx
+++ b/src/components/ToolErrorBlock/__tests__/ToolErrorBlock.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import {render} from '../../../../jest/test-utils';
+
+import {ToolErrorBlock} from '../ToolErrorBlock';
+
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => {
+  const {Text: PaperText} = require('react-native-paper');
+  return props => <PaperText>{props.name}</PaperText>;
+});
+
+describe('ToolErrorBlock', () => {
+  it('renders the error block with name + message when message provided', () => {
+    const {getByTestId, getByText} = render(
+      <ToolErrorBlock
+        toolName="render_html"
+        errorMessage="invalid markup"
+      />,
+    );
+    expect(getByTestId('tool-error-block')).toBeTruthy();
+    expect(getByText('render_html failed')).toBeTruthy();
+    expect(getByText('invalid markup')).toBeTruthy();
+    expect(getByText('alert-circle-outline')).toBeTruthy();
+  });
+
+  it('renders the error block without a message line when errorMessage missing', () => {
+    const {getByText, queryByTestId} = render(
+      <ToolErrorBlock toolName="datetime" />,
+    );
+    expect(getByText('datetime failed')).toBeTruthy();
+    expect(queryByTestId('tool-error-block-message')).toBeNull();
+  });
+
+  it('renders nothing when toolName is empty', () => {
+    const {queryByTestId} = render(<ToolErrorBlock toolName="" />);
+    expect(queryByTestId('tool-error-block')).toBeNull();
+  });
+});

--- a/src/components/ToolErrorBlock/__tests__/ToolErrorBlock.test.tsx
+++ b/src/components/ToolErrorBlock/__tests__/ToolErrorBlock.test.tsx
@@ -12,10 +12,7 @@ jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => {
 describe('ToolErrorBlock', () => {
   it('renders the error block with name + message when message provided', () => {
     const {getByTestId, getByText} = render(
-      <ToolErrorBlock
-        toolName="render_html"
-        errorMessage="invalid markup"
-      />,
+      <ToolErrorBlock toolName="render_html" errorMessage="invalid markup" />,
     );
     expect(getByTestId('tool-error-block')).toBeTruthy();
     expect(getByText('render_html failed')).toBeTruthy();

--- a/src/components/ToolErrorBlock/index.ts
+++ b/src/components/ToolErrorBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './ToolErrorBlock';

--- a/src/components/ToolErrorBlock/styles.ts
+++ b/src/components/ToolErrorBlock/styles.ts
@@ -1,0 +1,30 @@
+import {StyleSheet} from 'react-native';
+
+import {Theme} from '../../utils/types';
+
+export const styles = ({theme}: {theme: Theme}) =>
+  StyleSheet.create({
+    container: {
+      paddingHorizontal: 12,
+      paddingVertical: 4,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    icon: {
+      fontSize: 14,
+      marginRight: 6,
+      color: theme.colors.error,
+    },
+    label: {
+      fontSize: 12,
+      color: theme.colors.error,
+    },
+    message: {
+      fontSize: 11,
+      marginTop: 2,
+      marginLeft: 20,
+      color: theme.colors.onSurfaceVariant,
+    },
+  });

--- a/src/components/ToolMetricsFooter/ToolMetricsFooter.tsx
+++ b/src/components/ToolMetricsFooter/ToolMetricsFooter.tsx
@@ -51,7 +51,8 @@ const styles = ({theme}: {theme: Theme}) =>
     container: {
       paddingTop: 4,
       paddingBottom: 8,
-      paddingHorizontal: 12,
+      // No horizontal padding — aligns with the AI text / footer / chip
+      // at the assistant row's marginLeft (single shared gutter).
     },
     text: {
       color: theme.colors.textSecondary,

--- a/src/components/ToolMetricsFooter/ToolMetricsFooter.tsx
+++ b/src/components/ToolMetricsFooter/ToolMetricsFooter.tsx
@@ -1,0 +1,60 @@
+import React, {useContext} from 'react';
+import {StyleSheet, View} from 'react-native';
+
+import {Text} from 'react-native-paper';
+
+import {useTheme} from '../../hooks';
+import {L10nContext} from '../../utils';
+import {t} from '../../locales';
+import {AgentToolCallMetrics, Theme} from '../../utils/types';
+
+interface ToolMetricsFooterProps {
+  metrics: AgentToolCallMetrics;
+}
+
+/**
+ * Small post-hoc footer rendered beneath a talent UI's result (e.g.
+ * the HTML preview), showing how much the model "spent" on the tool
+ * call: `1,500 tokens · 35s`. Visually aligned with
+ * AssistantTurnFooter (same fontSize / colour) so it reads as part
+ * of the same chrome family without competing with the result above.
+ *
+ * Renders nothing if `metrics.tokens` is 0 — that's the cue for
+ * "metrics absent" (older persisted calls, or steps where the runner
+ * didn't see any tool-call tokens).
+ */
+export const ToolMetricsFooter: React.FC<ToolMetricsFooterProps> = ({
+  metrics,
+}) => {
+  const theme = useTheme();
+  const l10n = useContext(L10nContext);
+
+  if (metrics.tokens <= 0) {
+    return null;
+  }
+
+  const componentStyles = styles({theme});
+  const seconds = Math.max(1, Math.round(metrics.durationMs / 1000));
+  const text = `${t(l10n.components.toolMetrics.tokens, {
+    count: metrics.tokens.toLocaleString(),
+  })} · ${t(l10n.components.toolMetrics.elapsed, {seconds})}`;
+
+  return (
+    <View style={componentStyles.container} testID="tool-metrics-footer">
+      <Text style={componentStyles.text}>{text}</Text>
+    </View>
+  );
+};
+
+const styles = ({theme}: {theme: Theme}) =>
+  StyleSheet.create({
+    container: {
+      paddingTop: 4,
+      paddingBottom: 8,
+      paddingHorizontal: 12,
+    },
+    text: {
+      color: theme.colors.textSecondary,
+      fontSize: 10,
+    },
+  });

--- a/src/components/ToolMetricsFooter/__tests__/ToolMetricsFooter.test.tsx
+++ b/src/components/ToolMetricsFooter/__tests__/ToolMetricsFooter.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import {render} from '../../../../jest/test-utils';
+
+import {ToolMetricsFooter} from '../ToolMetricsFooter';
+
+describe('ToolMetricsFooter', () => {
+  it('renders tokens + seconds when metrics are present', () => {
+    const {getByTestId, getByText} = render(
+      <ToolMetricsFooter metrics={{tokens: 1500, durationMs: 35000}} />,
+    );
+    expect(getByTestId('tool-metrics-footer')).toBeTruthy();
+    // Locale-formatted number, then seconds.
+    expect(getByText(/1.500 tokens.+35s/)).toBeTruthy();
+  });
+
+  it('renders nothing when tokens is 0 (graceful degradation)', () => {
+    const {queryByTestId} = render(
+      <ToolMetricsFooter metrics={{tokens: 0, durationMs: 1234}} />,
+    );
+    expect(queryByTestId('tool-metrics-footer')).toBeNull();
+  });
+
+  it('floors sub-1s durations to "1s" so the footer never reads "0s"', () => {
+    const {getByText} = render(
+      <ToolMetricsFooter metrics={{tokens: 5, durationMs: 200}} />,
+    );
+    expect(getByText(/5 tokens.+1s/)).toBeTruthy();
+  });
+});

--- a/src/components/ToolMetricsFooter/index.ts
+++ b/src/components/ToolMetricsFooter/index.ts
@@ -1,0 +1,1 @@
+export * from './ToolMetricsFooter';

--- a/src/components/ToolUsedChip/ToolUsedChip.tsx
+++ b/src/components/ToolUsedChip/ToolUsedChip.tsx
@@ -10,9 +10,17 @@ import {styles} from './styles';
 
 import {L10nContext} from '../../utils';
 import {t} from '../../locales';
+import {AgentToolCallMetrics} from '../../utils/types';
 
 interface ToolUsedChipProps {
   toolName: string;
+  /**
+   * Optional generation metrics — tokens emitted while the model
+   * produced this call's arguments and the wall-clock duration.
+   * Surfaced as a same-line suffix when present. Older persisted
+   * tool calls won't carry metrics; the chip degrades gracefully.
+   */
+  metrics?: AgentToolCallMetrics;
 }
 
 /**
@@ -25,7 +33,10 @@ interface ToolUsedChipProps {
  *
  * Renders nothing if `toolName` is empty.
  */
-export const ToolUsedChip: React.FC<ToolUsedChipProps> = ({toolName}) => {
+export const ToolUsedChip: React.FC<ToolUsedChipProps> = ({
+  toolName,
+  metrics,
+}) => {
   const theme = useTheme();
   const l10n = useContext(L10nContext);
 
@@ -34,6 +45,15 @@ export const ToolUsedChip: React.FC<ToolUsedChipProps> = ({toolName}) => {
   }
 
   const componentStyles = styles({theme});
+  const baseLabel = t(l10n.chat.toolUsedChip, {name: toolName});
+  const labelWithMetrics =
+    metrics && metrics.tokens > 0
+      ? `${baseLabel} · ${t(l10n.components.toolMetrics.tokens, {
+          count: metrics.tokens.toLocaleString(),
+        })} · ${t(l10n.components.toolMetrics.elapsed, {
+          seconds: Math.max(1, Math.round(metrics.durationMs / 1000)),
+        })}`
+      : baseLabel;
 
   return (
     <View style={componentStyles.container} testID="tool-used-chip">
@@ -42,9 +62,7 @@ export const ToolUsedChip: React.FC<ToolUsedChipProps> = ({toolName}) => {
         style={componentStyles.icon}
         testID="tool-used-chip-icon"
       />
-      <Text style={componentStyles.label}>
-        {t(l10n.chat.toolUsedChip, {name: toolName})}
-      </Text>
+      <Text style={componentStyles.label}>{labelWithMetrics}</Text>
     </View>
   );
 };

--- a/src/components/ToolUsedChip/ToolUsedChip.tsx
+++ b/src/components/ToolUsedChip/ToolUsedChip.tsx
@@ -1,0 +1,50 @@
+import React, {useContext} from 'react';
+import {View} from 'react-native';
+
+import {Text} from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import {useTheme} from '../../hooks';
+
+import {styles} from './styles';
+
+import {L10nContext} from '../../utils';
+import {t} from '../../locales';
+
+interface ToolUsedChipProps {
+  toolName: string;
+}
+
+/**
+ * Subtle, low-prominence "used X" chip rendered for tool calls that
+ * have no registered TalentUI (e.g. datetime, calculate). Per WHAT
+ * I3 / D8, this gives the user feedback that *something* happened
+ * without dominating the chat layout. Intentionally minimal — no
+ * card, no border; only a small wrench icon and onSurfaceVariant
+ * text on a single line.
+ *
+ * Renders nothing if `toolName` is empty.
+ */
+export const ToolUsedChip: React.FC<ToolUsedChipProps> = ({toolName}) => {
+  const theme = useTheme();
+  const l10n = useContext(L10nContext);
+
+  if (!toolName) {
+    return null;
+  }
+
+  const componentStyles = styles({theme});
+
+  return (
+    <View style={componentStyles.container} testID="tool-used-chip">
+      <Icon
+        name="wrench-outline"
+        style={componentStyles.icon}
+        testID="tool-used-chip-icon"
+      />
+      <Text style={componentStyles.label}>
+        {t(l10n.chat.toolUsedChip, {name: toolName})}
+      </Text>
+    </View>
+  );
+};

--- a/src/components/ToolUsedChip/__tests__/ToolUsedChip.test.tsx
+++ b/src/components/ToolUsedChip/__tests__/ToolUsedChip.test.tsx
@@ -24,4 +24,36 @@ describe('ToolUsedChip', () => {
     const {queryByTestId} = render(<ToolUsedChip toolName="" />);
     expect(queryByTestId('tool-used-chip')).toBeNull();
   });
+
+  it('appends generation metrics when present', () => {
+    const {getByText} = render(
+      <ToolUsedChip
+        toolName="calculate"
+        metrics={{tokens: 19, durationMs: 2300}}
+      />,
+    );
+    // Format: `used calculate · 19 tokens · 2s` (rounded seconds, min 1).
+    expect(getByText(/used calculate.+19 tokens.+2s/)).toBeTruthy();
+  });
+
+  it('omits metrics when tokens is 0 (graceful degradation for older calls)', () => {
+    const {getByText, queryByText} = render(
+      <ToolUsedChip
+        toolName="calculate"
+        metrics={{tokens: 0, durationMs: 0}}
+      />,
+    );
+    expect(getByText('used calculate')).toBeTruthy();
+    expect(queryByText(/tokens/)).toBeNull();
+  });
+
+  it('floors sub-1s durations to "1s" so the suffix never reads "0s"', () => {
+    const {getByText} = render(
+      <ToolUsedChip
+        toolName="calculate"
+        metrics={{tokens: 4, durationMs: 200}}
+      />,
+    );
+    expect(getByText(/4 tokens.+1s/)).toBeTruthy();
+  });
 });

--- a/src/components/ToolUsedChip/__tests__/ToolUsedChip.test.tsx
+++ b/src/components/ToolUsedChip/__tests__/ToolUsedChip.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import {render} from '../../../../jest/test-utils';
+
+import {ToolUsedChip} from '../ToolUsedChip';
+
+jest.mock('react-native-vector-icons/MaterialCommunityIcons', () => {
+  const {Text: PaperText} = require('react-native-paper');
+  return props => <PaperText>{props.name}</PaperText>;
+});
+
+describe('ToolUsedChip', () => {
+  it('renders the chip with the tool name (en l10n template)', () => {
+    const {getByText, getByTestId} = render(
+      <ToolUsedChip toolName="datetime" />,
+    );
+    expect(getByTestId('tool-used-chip')).toBeTruthy();
+    expect(getByText('used datetime')).toBeTruthy();
+    // Subtle: shows wrench icon, no card chrome.
+    expect(getByText('wrench-outline')).toBeTruthy();
+  });
+
+  it('renders nothing when toolName is empty', () => {
+    const {queryByTestId} = render(<ToolUsedChip toolName="" />);
+    expect(queryByTestId('tool-used-chip')).toBeNull();
+  });
+});

--- a/src/components/ToolUsedChip/index.ts
+++ b/src/components/ToolUsedChip/index.ts
@@ -1,0 +1,1 @@
+export * from './ToolUsedChip';

--- a/src/components/ToolUsedChip/styles.ts
+++ b/src/components/ToolUsedChip/styles.ts
@@ -4,19 +4,24 @@ import {Theme} from '../../utils/types';
 
 export const styles = ({theme}: {theme: Theme}) =>
   StyleSheet.create({
+    // Tightened (Idea C): smaller icon + label + reduced vertical
+    // padding so the chip reads as a metadata annotation rather than
+    // a UI element competing with bubbles.
     container: {
       flexDirection: 'row',
       alignItems: 'center',
       paddingHorizontal: 12,
-      paddingVertical: 4,
+      paddingVertical: 0,
     },
     icon: {
-      fontSize: 14,
+      fontSize: 12,
       marginRight: 6,
       color: theme.colors.onSurfaceVariant,
+      opacity: 0.75,
     },
     label: {
-      fontSize: 12,
+      fontSize: 11,
       color: theme.colors.onSurfaceVariant,
+      opacity: 0.85,
     },
   });

--- a/src/components/ToolUsedChip/styles.ts
+++ b/src/components/ToolUsedChip/styles.ts
@@ -1,0 +1,22 @@
+import {StyleSheet} from 'react-native';
+
+import {Theme} from '../../utils/types';
+
+export const styles = ({theme}: {theme: Theme}) =>
+  StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 12,
+      paddingVertical: 4,
+    },
+    icon: {
+      fontSize: 14,
+      marginRight: 6,
+      color: theme.colors.onSurfaceVariant,
+    },
+    label: {
+      fontSize: 12,
+      color: theme.colors.onSurfaceVariant,
+    },
+  });

--- a/src/components/ToolUsedChip/styles.ts
+++ b/src/components/ToolUsedChip/styles.ts
@@ -6,22 +6,23 @@ export const styles = ({theme}: {theme: Theme}) =>
   StyleSheet.create({
     // Tightened (Idea C): smaller icon + label + reduced vertical
     // padding so the chip reads as a metadata annotation rather than
-    // a UI element competing with bubbles.
+    // a UI element competing with bubbles. No left padding — the
+    // assistant row's marginLeft already provides the gutter, and
+    // the chip aligns with the AI text body / footer at that edge.
     container: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingHorizontal: 12,
       paddingVertical: 0,
     },
     icon: {
       fontSize: 12,
       marginRight: 6,
-      color: theme.colors.onSurfaceVariant,
+      color: theme.colors.textSecondary,
       opacity: 0.75,
     },
     label: {
       fontSize: 11,
-      color: theme.colors.onSurfaceVariant,
+      color: theme.colors.textSecondary,
       opacity: 0.85,
     },
   });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -53,6 +53,8 @@ export * from './TextDivider';
 export * from './TextInput';
 export * from './TalentSurface';
 export * from './TextMessage';
+export * from './ToolErrorBlock';
+export * from './ToolUsedChip';
 export * from './UsageStats';
 export * from './VideoPalEmptyPlaceholder';
 export * from './VisionDownloadSheet';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,6 +42,7 @@ export * from './ModelSettingsSheet';
 export * from './ModelTypeTag';
 export * from './ProjectionModelSelector';
 export * from './RenameModal';
+export * from './ReasoningBlock';
 export * from './ResponseBubble';
 export * from './Selector';
 export * from './SendButton';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,6 +31,7 @@ export * from './ImageMessage';
 export * from './KeyboardAccessoryView';
 export * from './LoadingBubble';
 export * from './MarkdownView';
+export * from './PendingIndicator';
 export * from './Menu';
 export * from './Message';
 export * from './ModelsHeaderRight';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -56,6 +56,7 @@ export * from './TextInput';
 export * from './TalentSurface';
 export * from './TextMessage';
 export * from './ToolErrorBlock';
+export * from './ToolMetricsFooter';
 export * from './ToolUsedChip';
 export * from './UsageStats';
 export * from './VideoPalEmptyPlaceholder';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './AssistantTurnFooter';
 export * from './AttachmentButton';
 export * from './Avatar';
 export * from './Bubble';

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -380,7 +380,9 @@ describe('useChatSession — AssistantTurn integration', () => {
     const calledIds = callsArgs.flatMap(c =>
       (c[2] as Array<{id: string}>).map(x => x.id),
     );
-    const outcomeCallIds = outcomeArgs.map(c => (c[2] as {callId: string}).callId);
+    const outcomeCallIds = outcomeArgs.map(
+      c => (c[2] as {callId: string}).callId,
+    );
     // No empty ids emitted — runner normalized them.
     expect(calledIds.every(id => id.length > 0)).toBe(true);
     // Every outcome's callId must appear in the appendToolCall set.

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -287,6 +287,111 @@ describe('useChatSession — AssistantTurn integration', () => {
     (talentRegistry as any).engines.delete('calculate');
   });
 
+  it('#hookTest2 tool turn: appendToolCall lands ids that match the upcoming appendToolOutcome callId by construction (per-frame id-match invariant)', async () => {
+    // WHAT §5 cleanup #1 regression guard. The runner attaches its
+    // normalized toolCalls to step_finished; the hook calls
+    // appendToolCall with that list before appendToolOutcome fires
+    // for each call. Per WHAT §6 canonical scenarios, the invariant
+    // is: at every render frame, step.toolCalls[i].id === outcome.callId
+    // (vacuously true while outcomes lag the calls; strictly enforced
+    // as soon as both are present). This test verifies the invariant
+    // by intercepting both writers and checking the call-order
+    // produces matching ids.
+    const fakeTalent: TalentEngine = {
+      name: 'calculate',
+      execute: async () => ({type: 'text', summary: '4'}) as TalentResult,
+      toToolDefinition: () => ({
+        type: 'function',
+        function: {name: 'calculate', description: '', parameters: {}},
+      }),
+    };
+    talentRegistry.register(fakeTalent);
+    palStore.pals = [
+      {
+        id: 'pal-1',
+        type: 'local',
+        name: 'Calc Pal',
+        systemPrompt: '',
+        parameters: {},
+        parameterSchema: [],
+        isSystemPromptChanged: false,
+        useAIPrompt: false,
+        source: 'local',
+        pact: {talents: [{name: 'calculate', necessity: 'optional'}]},
+      } as any,
+    ];
+    chatSessionStore.sessions = [
+      {
+        id: 'session-1',
+        title: '',
+        date: '',
+        messages: [],
+        completionSettings: {},
+        settingsSource: 'pal',
+        activePalId: 'pal-1',
+      } as any,
+    ];
+    chatSessionStore.activeSessionId = 'session-1';
+
+    let turnIndex = 0;
+    if (modelStore.context) {
+      modelStore.context.completion = jest.fn().mockImplementation(async () => {
+        turnIndex += 1;
+        if (turnIndex === 1) {
+          return {
+            text: '',
+            content: '',
+            tool_calls: [
+              {
+                // Empty id from llama.rn — the runner reconciles via
+                // normalizeToolCallIds. The hook MUST receive the
+                // normalized id, not this raw one.
+                id: '',
+                type: 'function',
+                function: {name: 'calculate', arguments: '{"e":"2+2"}'},
+              },
+            ],
+          };
+        }
+        return {text: '4', content: '4'};
+      });
+    }
+
+    const appendToolCallSpy = chatSessionStore.appendToolCall as jest.Mock;
+    const appendToolOutcomeSpy =
+      chatSessionStore.appendToolOutcome as jest.Mock;
+
+    const {result} = renderHook(() =>
+      useChatSession({current: null}, textMessage.author, mockAssistant),
+    );
+    await act(async () => {
+      await result.current.handleSendPress(textMessage);
+    });
+
+    expect(appendToolCallSpy).toHaveBeenCalled();
+    expect(appendToolOutcomeSpy).toHaveBeenCalled();
+
+    // For every appendToolCall invocation, every call.id MUST match a
+    // subsequently-appended outcome.callId (within the same step).
+    // The invariant: step.toolCalls[i].id === outcome.callId by
+    // construction.
+    const callsArgs = appendToolCallSpy.mock.calls;
+    const outcomeArgs = appendToolOutcomeSpy.mock.calls;
+    const calledIds = callsArgs.flatMap(c =>
+      (c[2] as Array<{id: string}>).map(x => x.id),
+    );
+    const outcomeCallIds = outcomeArgs.map(c => (c[2] as {callId: string}).callId);
+    // No empty ids emitted — runner normalized them.
+    expect(calledIds.every(id => id.length > 0)).toBe(true);
+    // Every outcome's callId must appear in the appendToolCall set.
+    for (const cid of outcomeCallIds) {
+      expect(calledIds).toContain(cid);
+    }
+
+    // Cleanup
+    (talentRegistry as any).engines.delete('calculate');
+  });
+
   it('handleStopPress aborts the in-flight runner before stopCompletion fires', async () => {
     let resolveCompletion: (v: any) => void;
     const completionPromise = new Promise(resolve => {

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
   chatSessionStore.agentUiState = {
     status: 'idle',
     pendingTalentNames: [],
+    pendingToolTokens: 0,
     hitMaxTurns: false,
   };
 

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -75,6 +75,15 @@ describe('useChatSession — AssistantTurn integration', () => {
 
     // The hook adds the user message AND the empty assistant turn.
     expect(chatSessionStore.addMessageToCurrentSession).toHaveBeenCalled();
+    // The empty assistant turn is added WITHOUT metadata.copyable so the
+    // turn footer's copy button stays hidden during streaming. copyable
+    // is set later at run_finished (asserted below) or at the abort
+    // catch path (covered by #3 / hookTest5). Per WHAT D1 / I1.
+    const addAssistantCall = (
+      chatSessionStore.addMessageToCurrentSession as jest.Mock
+    ).mock.calls.find(args => args[0]?.type === 'assistant_turn');
+    expect(addAssistantCall).toBeDefined();
+    expect(addAssistantCall![0].metadata.copyable).toBeUndefined();
     // pushAgentStep called for each step_started — one in this happy path.
     expect(chatSessionStore.pushAgentStep).toHaveBeenCalled();
     // Per-token writes go through updateActiveStepStreaming.

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -11,6 +11,7 @@ import {
 import {useChatSession} from '../useChatSession';
 import {chatSessionStore, modelStore, palStore} from '../../store';
 import {assistant} from '../../utils/chat';
+import {chatSessionRepository} from '../../repositories/ChatSessionRepository';
 import {talentRegistry} from '../../services/talents';
 import type {MessageType} from '../../utils/types';
 import type {TalentEngine, TalentResult} from '../../services/talents/types';
@@ -432,5 +433,483 @@ describe('useChatSession — AssistantTurn integration', () => {
     await act(async () => {
       await sendPromise;
     });
+  });
+
+  // ---------- Tester augmentation: per-frame id-match invariant under
+  // multi-tool / multi-step / abort variations. The implementer's
+  // hookTest2 covers the single-tool case; these add coverage for the
+  // remaining shapes called out in WHAT §5 cleanup #1. ----------
+
+  it('#hookTest3 multi-tool turn: appendToolCall lands TWO normalized ids before two appendToolOutcome calls (per-frame id-match holds across tools)', async () => {
+    // Both tools succeed. The runner emits one step_finished with
+    // toolCalls.length === 2; the hook calls appendToolCall once with
+    // both, then appendToolOutcome twice (one per tool). Per WHAT §5
+    // cleanup #1, the ids attached to step_finished MUST match the
+    // outcome callIds by construction — the runner reuses the same
+    // normalized list for tool_call_started and tool_call_finished.
+    const calcTalent: TalentEngine = {
+      name: 'calculate',
+      execute: async () => ({type: 'text', summary: '4'}) as TalentResult,
+      toToolDefinition: () => ({
+        type: 'function',
+        function: {name: 'calculate', description: '', parameters: {}},
+      }),
+    };
+    const dtTalent: TalentEngine = {
+      name: 'datetime',
+      execute: async () => ({type: 'text', summary: '8:28 AM'}) as TalentResult,
+      toToolDefinition: () => ({
+        type: 'function',
+        function: {name: 'datetime', description: '', parameters: {}},
+      }),
+    };
+    talentRegistry.register(calcTalent);
+    talentRegistry.register(dtTalent);
+    palStore.pals = [
+      {
+        id: 'pal-1',
+        type: 'local',
+        name: 'Multi Pal',
+        systemPrompt: '',
+        parameters: {},
+        parameterSchema: [],
+        isSystemPromptChanged: false,
+        useAIPrompt: false,
+        source: 'local',
+        pact: {
+          talents: [
+            {name: 'calculate', necessity: 'optional'},
+            {name: 'datetime', necessity: 'optional'},
+          ],
+        },
+      } as any,
+    ];
+    chatSessionStore.sessions = [
+      {
+        id: 'session-1',
+        title: '',
+        date: '',
+        messages: [],
+        completionSettings: {},
+        settingsSource: 'pal',
+        activePalId: 'pal-1',
+      } as any,
+    ];
+    chatSessionStore.activeSessionId = 'session-1';
+
+    let turnIndex = 0;
+    if (modelStore.context) {
+      modelStore.context.completion = jest.fn().mockImplementation(async () => {
+        turnIndex += 1;
+        if (turnIndex === 1) {
+          // Both ids are empty — runner MUST normalize them via the
+          // per-run seed. The hook's appendToolCall receives the
+          // normalized list (not the raw empties).
+          return {
+            text: '',
+            content: '',
+            tool_calls: [
+              {
+                id: '',
+                type: 'function',
+                function: {name: 'calculate', arguments: '{"e":"2+2"}'},
+              },
+              {
+                id: '',
+                type: 'function',
+                function: {name: 'datetime', arguments: '{}'},
+              },
+            ],
+          };
+        }
+        return {text: '4 at 8:28', content: '4 at 8:28'};
+      });
+    }
+
+    const appendToolCallSpy = chatSessionStore.appendToolCall as jest.Mock;
+    const appendToolOutcomeSpy =
+      chatSessionStore.appendToolOutcome as jest.Mock;
+
+    const {result} = renderHook(() =>
+      useChatSession({current: null}, textMessage.author, mockAssistant),
+    );
+    await act(async () => {
+      await result.current.handleSendPress(textMessage);
+    });
+
+    // appendToolCall called once for the multi-tool step (turn 0).
+    const toolCallCalls = appendToolCallSpy.mock.calls.filter(
+      c => (c[2] as Array<{id: string}>).length === 2,
+    );
+    expect(toolCallCalls).toHaveLength(1);
+    const calls = toolCallCalls[0][2] as Array<{
+      id: string;
+      function: {name: string};
+    }>;
+    expect(calls).toHaveLength(2);
+    expect(calls.every(c => c.id.length > 0)).toBe(true);
+    // Distinct synthetic ids per index — runner appends `_<idx>` to
+    // the seed.
+    expect(calls[0].id).not.toBe(calls[1].id);
+
+    // appendToolOutcome called twice (one per tool), each callId
+    // matching one of the appendToolCall ids. This is the per-frame
+    // id-match invariant for the multi-tool case.
+    const outcomeIds = appendToolOutcomeSpy.mock.calls.map(
+      c => (c[2] as {callId: string}).callId,
+    );
+    expect(outcomeIds).toHaveLength(2);
+    const calledIds = calls.map(c => c.id);
+    for (const oid of outcomeIds) {
+      expect(calledIds).toContain(oid);
+    }
+    // Tool names match too — calculate came first, datetime second.
+    expect(calls[0].function.name).toBe('calculate');
+    expect(calls[1].function.name).toBe('datetime');
+
+    // Cleanup
+    (talentRegistry as any).engines.delete('calculate');
+    (talentRegistry as any).engines.delete('datetime');
+  });
+
+  it('#hookTest4 tool-followed-by-tool (multi-step chain): appendToolCall fires per step, ids stay distinct across steps', async () => {
+    // Step 0: invoke calculate. Step 1: invoke datetime. Step 2:
+    // final answer. Per WHAT §5 cleanup #1 the runner attaches a
+    // fresh normalized list to each step_finished; ids carry
+    // `seed + turn` so distinct across steps.
+    const calcTalent: TalentEngine = {
+      name: 'calculate',
+      execute: async () => ({type: 'text', summary: '4'}) as TalentResult,
+      toToolDefinition: () => ({
+        type: 'function',
+        function: {name: 'calculate', description: '', parameters: {}},
+      }),
+    };
+    const dtTalent: TalentEngine = {
+      name: 'datetime',
+      execute: async () => ({type: 'text', summary: '8:28 AM'}) as TalentResult,
+      toToolDefinition: () => ({
+        type: 'function',
+        function: {name: 'datetime', description: '', parameters: {}},
+      }),
+    };
+    talentRegistry.register(calcTalent);
+    talentRegistry.register(dtTalent);
+    palStore.pals = [
+      {
+        id: 'pal-1',
+        type: 'local',
+        name: 'Multi Pal',
+        systemPrompt: '',
+        parameters: {},
+        parameterSchema: [],
+        isSystemPromptChanged: false,
+        useAIPrompt: false,
+        source: 'local',
+        pact: {
+          talents: [
+            {name: 'calculate', necessity: 'optional'},
+            {name: 'datetime', necessity: 'optional'},
+          ],
+        },
+      } as any,
+    ];
+    chatSessionStore.sessions = [
+      {
+        id: 'session-1',
+        title: '',
+        date: '',
+        messages: [],
+        completionSettings: {},
+        settingsSource: 'pal',
+        activePalId: 'pal-1',
+      } as any,
+    ];
+    chatSessionStore.activeSessionId = 'session-1';
+
+    let turnIndex = 0;
+    if (modelStore.context) {
+      modelStore.context.completion = jest.fn().mockImplementation(async () => {
+        turnIndex += 1;
+        if (turnIndex === 1) {
+          return {
+            text: '',
+            content: '',
+            tool_calls: [
+              {
+                id: '',
+                type: 'function',
+                function: {name: 'calculate', arguments: '{"e":"2+2"}'},
+              },
+            ],
+          };
+        }
+        if (turnIndex === 2) {
+          return {
+            text: '',
+            content: '',
+            tool_calls: [
+              {
+                id: '',
+                type: 'function',
+                function: {name: 'datetime', arguments: '{}'},
+              },
+            ],
+          };
+        }
+        return {text: 'done', content: 'done'};
+      });
+    }
+
+    const appendToolCallSpy = chatSessionStore.appendToolCall as jest.Mock;
+    const appendToolOutcomeSpy =
+      chatSessionStore.appendToolOutcome as jest.Mock;
+
+    const {result} = renderHook(() =>
+      useChatSession({current: null}, textMessage.author, mockAssistant),
+    );
+    await act(async () => {
+      await result.current.handleSendPress(textMessage);
+    });
+
+    // appendToolCall fired twice — once per tool-using step.
+    expect(appendToolCallSpy).toHaveBeenCalledTimes(2);
+
+    // Each appendToolCall list has exactly one call with a non-empty
+    // synthetic id; ids are distinct across steps (seed + turn).
+    const allCalledIds = appendToolCallSpy.mock.calls.flatMap(c =>
+      (c[2] as Array<{id: string}>).map(x => x.id),
+    );
+    expect(allCalledIds).toHaveLength(2);
+    expect(allCalledIds.every(id => id.length > 0)).toBe(true);
+    expect(new Set(allCalledIds).size).toBe(2); // distinct
+
+    // appendToolOutcome called twice; each callId matches one of the
+    // appendToolCall ids (per-frame id-match across step boundary).
+    const outcomeIds = appendToolOutcomeSpy.mock.calls.map(
+      c => (c[2] as {callId: string}).callId,
+    );
+    expect(outcomeIds).toHaveLength(2);
+    for (const oid of outcomeIds) {
+      expect(allCalledIds).toContain(oid);
+    }
+
+    // Cleanup
+    (talentRegistry as any).engines.delete('calculate');
+    (talentRegistry as any).engines.delete('datetime');
+  });
+
+  it('#hookTest5 abort during tool execution: appendToolCall still lands; partial outcomes preserved', async () => {
+    // The runner finishes the in-flight tool call (executeOne is
+    // not cancelled mid-execution per AgentRunner.ts:390-397
+    // "Stop-mid-tool" comment). The abort is observed at the next
+    // turn boundary. So appendToolCall + appendToolOutcome both
+    // fire for the in-flight tool, then the run ends without a
+    // follow-up turn. The hook's catch path is NOT entered (no
+    // engineError). The id-match invariant must still hold.
+    let resolveTalent: (r: TalentResult) => void;
+    const talentPromise = new Promise<TalentResult>(resolve => {
+      resolveTalent = resolve;
+    });
+    const slowTalent: TalentEngine = {
+      name: 'calculate',
+      execute: async () => talentPromise,
+      toToolDefinition: () => ({
+        type: 'function',
+        function: {name: 'calculate', description: '', parameters: {}},
+      }),
+    };
+    talentRegistry.register(slowTalent);
+    palStore.pals = [
+      {
+        id: 'pal-1',
+        type: 'local',
+        name: 'Slow Pal',
+        systemPrompt: '',
+        parameters: {},
+        parameterSchema: [],
+        isSystemPromptChanged: false,
+        useAIPrompt: false,
+        source: 'local',
+        pact: {talents: [{name: 'calculate', necessity: 'optional'}]},
+      } as any,
+    ];
+    chatSessionStore.sessions = [
+      {
+        id: 'session-1',
+        title: '',
+        date: '',
+        messages: [],
+        completionSettings: {},
+        settingsSource: 'pal',
+        activePalId: 'pal-1',
+      } as any,
+    ];
+    chatSessionStore.activeSessionId = 'session-1';
+
+    if (modelStore.context) {
+      modelStore.context.completion = jest.fn().mockImplementation(async () => {
+        return {
+          text: '',
+          content: '',
+          tool_calls: [
+            {
+              id: '',
+              type: 'function',
+              function: {name: 'calculate', arguments: '{"e":"2+2"}'},
+            },
+          ],
+        };
+      });
+    }
+
+    const appendToolCallSpy = chatSessionStore.appendToolCall as jest.Mock;
+    const appendToolOutcomeSpy =
+      chatSessionStore.appendToolOutcome as jest.Mock;
+
+    const {result} = renderHook(() =>
+      useChatSession({current: null}, textMessage.author, mockAssistant),
+    );
+    const sendPromise = result.current.handleSendPress(textMessage);
+
+    // Wait until the runner has yielded step_finished + the
+    // appendToolCall write has fired. We can't observe runner state
+    // directly, so wait for the spy.
+    await act(async () => {
+      // Spin a few microtasks until appendToolCall fires.
+      for (let i = 0; i < 30; i++) {
+        if (appendToolCallSpy.mock.calls.length > 0) {
+          break;
+        }
+        await Promise.resolve();
+      }
+    });
+
+    expect(appendToolCallSpy).toHaveBeenCalled();
+    const calls = appendToolCallSpy.mock.calls[0][2] as Array<{
+      id: string;
+    }>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0].id.length).toBeGreaterThan(0);
+
+    // Now press stop while the talent is still pending.
+    await act(async () => {
+      await result.current.handleStopPress();
+    });
+
+    // Resolve the talent so the runner can proceed past
+    // tool_call_finished and observe signal.aborted.
+    resolveTalent!({type: 'text', summary: '4'} as TalentResult);
+
+    await act(async () => {
+      await sendPromise;
+    });
+
+    // The outcome was emitted (executeOne completed); per-frame
+    // id-match holds across the abort boundary.
+    expect(appendToolOutcomeSpy).toHaveBeenCalled();
+    const outcomeId = (
+      appendToolOutcomeSpy.mock.calls[0][2] as {callId: string}
+    ).callId;
+    expect(outcomeId).toBe(calls[0].id);
+
+    // Cleanup
+    (talentRegistry as any).engines.delete('calculate');
+  });
+
+  it('#hookTest6 abort with no partial content (Scenario H path B / WHAT §9a): empty turn deleted via repository, no interrupted-metadata write', async () => {
+    // The runner throws BEFORE any token / step_finished. The hook's
+    // catch path sees `hasPartialContent === false` → calls
+    // chatSessionRepository.deleteMessage(turnId) and skips the
+    // updateMessage({metadata: {interrupted, copyable}}) write. A
+    // system message about the failure is added below.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const deleteMessageSpy = jest
+      .spyOn(chatSessionRepository, 'deleteMessage')
+      .mockResolvedValue(undefined);
+
+    if (modelStore.context) {
+      modelStore.context.completion = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'));
+    }
+    const ref: {
+      current: {createdAt: number; id: string; sessionId: string} | null;
+    } = {current: null};
+
+    // Seed the active session as empty so the empty-turn (created
+    // by prepareCompletion) is the only message at error time.
+    const turnId = 'empty-turn-id';
+    chatSessionStore.sessions = [
+      {
+        id: 'session-1',
+        title: '',
+        date: '',
+        messages: [],
+        completionSettings: {},
+        settingsSource: 'pal',
+      },
+    ] as any;
+    chatSessionStore.activeSessionId = 'session-1';
+
+    // The hook calls addMessageToCurrentSession twice: once for the
+    // user text, once for the empty assistant turn. Tag the second
+    // (assistant_turn) with our known id and inject it into the
+    // session, so the catch path's lookup succeeds.
+    let addCount = 0;
+    (
+      chatSessionStore.addMessageToCurrentSession as jest.Mock
+    ).mockImplementation(async (msg: any) => {
+      addCount += 1;
+      if (msg.type === 'assistant_turn') {
+        msg.id = turnId;
+        // Mirror real behaviour: the message lands in the active
+        // session.
+        const session = chatSessionStore.sessions.find(
+          s => s.id === chatSessionStore.activeSessionId,
+        );
+        if (session) {
+          (session as any).messages = [msg, ...session.messages];
+        }
+      } else {
+        msg.id = `user-${addCount}`;
+      }
+    });
+
+    const updateMessageSpy = chatSessionStore.updateMessage as jest.Mock;
+    updateMessageSpy.mockClear();
+
+    const {result} = renderHook(() =>
+      useChatSession(ref, textMessage.author, mockAssistant),
+    );
+    await act(async () => {
+      await result.current.handleSendPress(textMessage);
+    });
+
+    // PATH B: the empty turn is deleted from the repository.
+    expect(deleteMessageSpy).toHaveBeenCalledWith(turnId);
+
+    // No `interrupted` metadata write — that branch only fires when
+    // partial content exists. Filter all updateMessage calls to
+    // those that wrote metadata.interrupted=true; should be empty.
+    const interruptedCalls = updateMessageSpy.mock.calls.filter(
+      c => c[2]?.metadata?.interrupted === true,
+    );
+    expect(interruptedCalls).toHaveLength(0);
+
+    // The empty turn is removed from the in-memory session by the
+    // catch path's runInAction filter.
+    const session = chatSessionStore.sessions.find(s => s.id === 'session-1');
+    expect(session?.messages.find((m: any) => m.id === turnId)).toBeUndefined();
+
+    // A system message about the failure is added to surface the
+    // error to the user.
+    const sysCall = (
+      chatSessionStore.addMessageToCurrentSession as jest.Mock
+    ).mock.calls.find(c => c[0]?.metadata?.system === true);
+    expect(sysCall).toBeDefined();
+
+    deleteMessageSpy.mockRestore();
+    errSpy.mockRestore();
   });
 });

--- a/src/hooks/__tests__/useChatSession.test.ts
+++ b/src/hooks/__tests__/useChatSession.test.ts
@@ -142,6 +142,27 @@ describe('useChatSession', () => {
     expect(modelStore.context?.stopCompletion).not.toHaveBeenCalled();
   });
 
+  it('handleStopPress sets isStopping immediately so the UI can gate sends', async () => {
+    // Simulate a real in-flight chat: inferencing is true and the
+    // engine has been wired (mock above). The stop press should:
+    //   - flip isStopping to true (UI feedback + send-button gate)
+    //   - leave inferencing alone (cleared later by the runner exit)
+    // The cleanup of isStopping happens in the for-await loop, so it
+    // is exercised in `should set inferencing correctly during send`.
+    modelStore.setInferencing(true);
+    const {result} = renderHook(() =>
+      useChatSession({current: null}, textMessage.author, mockAssistant),
+    );
+
+    await result.current.handleStopPress();
+
+    expect(chatSessionStore.setIsStopping).toHaveBeenCalledWith(true);
+    // inferencing flag is NOT cleared by handleStopPress anymore — the
+    // runner's for-await cleanup is the single owner of that.
+    const calls = (chatSessionStore.setIsGenerating as jest.Mock).mock.calls;
+    expect(calls.find(c => c[0] === false)).toBeUndefined();
+  });
+
   it('should set inferencing correctly during send', async () => {
     let resolveCompletion: (value: any) => void;
     const completionPromise = new Promise(resolve => {

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -475,11 +475,13 @@ export const useChatSession = (
       modelStore.setInferencing(false);
       modelStore.setIsStreaming(false);
       chatSessionStore.setIsGenerating(false);
+      chatSessionStore.setIsStopping(false);
     } catch (error) {
       console.error('Completion error:', error);
       modelStore.setInferencing(false);
       modelStore.setIsStreaming(false);
       chatSessionStore.setIsGenerating(false);
+      chatSessionStore.setIsStopping(false);
       // Reset agentUiState back to idle so renderers don't get
       // stuck in a failed state across the next user message.
       chatSessionStore.setAgentUiState(initialAgentUiState);
@@ -560,13 +562,15 @@ export const useChatSession = (
   };
 
   const handleStopPress = async () => {
-    // Abort first so the runner's signal listener (registered in
-    // runAgent) fires `engine.stopCompletion()` from inside the
-    // generator with a guaranteed-fresh engine handle. The direct
-    // call below is a redundant safety net — kept because the
-    // runner-side path depends on the runner being alive and
-    // listening, and we've previously shipped bugs where the
-    // fire-and-forget call swallowed errors silently.
+    // Enter the `stopping` state IMMEDIATELY: the user gets visible
+    // feedback ("Stopping…") and the send button is gated off so a
+    // new completion can't try to use the still-busy native context.
+    // We do NOT touch `inferencing` / `isGenerating` here — those get
+    // cleared by the for-await cleanup in handleSendPress once the
+    // runner has actually exited (native llama.rn has returned from
+    // its current llama_decode chunk; see ChatSessionStore.isStopping
+    // for the rationale).
+    chatSessionStore.setIsStopping(true);
     abortRef.current?.abort();
     if (modelStore.inferencing && modelStore.engine) {
       try {
@@ -575,10 +579,9 @@ export const useChatSession = (
         console.warn('engine.stopCompletion failed:', error);
       }
     }
-    modelStore.setInferencing(false);
-    modelStore.setIsStreaming(false);
-    chatSessionStore.setIsGenerating(false);
-
+    // Note: deactivateKeepAwake intentionally stays here so the device
+    // can sleep as soon as the user signals stop, even if native is
+    // still finishing the current chunk.
     try {
       deactivateKeepAwake();
     } catch (error) {

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -212,15 +212,17 @@ async function applyEventToStore(
       // Per-token writes go through the throttled streaming path so
       // they coalesce. Only forward fields that were actually present
       // in this delta to avoid clobbering existing content with empty.
+      // toolCalls are NO LONGER written here (WHAT §5 cleanup #1) —
+      // the reducer still consumes `event.delta.toolCalls` for
+      // pendingTalentNames, but the canonical step.toolCalls write
+      // happens after step_finished via appendToolCall (Step 4) so
+      // ids match outcomes by construction.
       const partial: Partial<MessageType.AssistantTurn['steps'][number]> = {};
       if (event.delta.content) {
         partial.content = event.delta.content.replace(/^\s+/, '');
       }
       if (event.delta.reasoningContent) {
         partial.reasoningContent = event.delta.reasoningContent;
-      }
-      if (event.delta.toolCalls) {
-        partial.toolCalls = event.delta.toolCalls;
       }
       if (Object.keys(partial).length > 0) {
         chatSessionStore.updateActiveStepStreaming(

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -248,6 +248,17 @@ async function applyEventToStore(
       );
       return;
     case 'step_finished':
+      // WHAT §5 cleanup #1: land step.toolCalls AFTER step_finished
+      // with the runner's authoritative normalized ids, so they match
+      // the outcomes' callIds by construction. Skipped for text-only
+      // and final-of-chain steps (no payload attached).
+      if (event.toolCalls && event.toolCalls.length > 0) {
+        await chatSessionStore.appendToolCall(
+          ctx.messageId,
+          ctx.sessionId,
+          event.toolCalls,
+        );
+      }
       await chatSessionStore.finalizeActiveStep(ctx.messageId, ctx.sessionId);
       return;
     case 'run_finished': {

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -150,7 +150,11 @@ const prepareCompletion = async ({
     metadata: {
       contextId,
       conversationId: conversationIdRef,
-      copyable: true,
+      // copyable is intentionally absent here — see WHAT D1/I1: the
+      // turn footer's copy button renders iff metadata.copyable is set,
+      // and at this point the turn has nothing worth copying yet.
+      // copyable is set later: at run_finished (success/maxTurns) or
+      // at the abort catch path with partial content.
       multimodal: hasImages,
     },
   };

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -560,12 +560,20 @@ export const useChatSession = (
   };
 
   const handleStopPress = async () => {
-    // Signal the runner first so the abort fires at the next turn
-    // boundary; engine.stopCompletion() then halts the in-flight
-    // engine call (terminating the current step's streaming).
+    // Abort first so the runner's signal listener (registered in
+    // runAgent) fires `engine.stopCompletion()` from inside the
+    // generator with a guaranteed-fresh engine handle. The direct
+    // call below is a redundant safety net — kept because the
+    // runner-side path depends on the runner being alive and
+    // listening, and we've previously shipped bugs where the
+    // fire-and-forget call swallowed errors silently.
     abortRef.current?.abort();
     if (modelStore.inferencing && modelStore.engine) {
-      modelStore.engine.stopCompletion();
+      try {
+        await modelStore.engine.stopCompletion();
+      } catch (error) {
+        console.warn('engine.stopCompletion failed:', error);
+      }
     }
     modelStore.setInferencing(false);
     modelStore.setIsStreaming(false);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -517,6 +517,14 @@
     "thinkingBubble": {
       "reasoning": "Reasoning"
     },
+    "pendingIndicator": {
+      "preparingTool": "Preparing tool",
+      "buildingPage": "Building page",
+      "calculating": "Calculating",
+      "lookingUpTime": "Looking up time",
+      "tokens": "{{count}} tokens",
+      "elapsed": "{{seconds}}s"
+    },
     "chatEmptyPlaceholder": {
       "noModelsTitle": "No Models Available",
       "noModelsDescription": "Download a model to start chatting with PocketPal",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -521,7 +521,9 @@
       "preparingTool": "Preparing tool",
       "buildingPage": "Building page",
       "calculating": "Calculating",
-      "lookingUpTime": "Looking up time",
+      "lookingUpTime": "Looking up time"
+    },
+    "toolMetrics": {
       "tokens": "{{count}} tokens",
       "elapsed": "{{seconds}}s"
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -521,7 +521,8 @@
       "preparingTool": "Preparing tool",
       "buildingPage": "Building page",
       "calculating": "Calculating",
-      "lookingUpTime": "Looking up time"
+      "lookingUpTime": "Looking up time",
+      "stopping": "Stopping…"
     },
     "toolMetrics": {
       "tokens": "{{count}} tokens",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1070,7 +1070,9 @@
     "toolCompatWarning": "This model may not support tool calling. Results may be unreliable.",
     "softCapWarning": "Start a new chat for best performance.",
     "generatingPreview": "Generating preview… ({{tokens}} tokens)",
-    "generatingPreviewPending": "Generating preview…"
+    "generatingPreviewPending": "Generating preview…",
+    "toolUsedChip": "used {{name}}",
+    "toolErrorBlock": "{{name}} failed"
   },
   "htmlPreview": {
     "defaultTitle": "Preview",

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -130,9 +130,6 @@ export const ChatScreen: React.FC = observer(() => {
     activePalId,
   ]);
 
-  // Show loading bubble only during the thinking phase (inferencing but not streaming)
-  const isThinking = modelStore.inferencing && !modelStore.isStreaming;
-
   // Tool-compatibility one-time banner: when the active Pal declares tools but
   // the loaded model's jinja template lacks `toolUseCaps`, surface an inline
   // warning. Persisted per model id so the warning fires at most once.
@@ -210,7 +207,6 @@ export const ChatScreen: React.FC = observer(() => {
         onPalSettingsSelect={handleOpenPalSheet}
         user={user}
         isStopVisible={modelStore.inferencing}
-        isThinking={isThinking}
         isStreaming={modelStore.isStreaming}
         sendButtonVisibilityMode="always"
         showImageUpload={true}

--- a/src/screens/ChatScreen/VideoPalScreen.tsx
+++ b/src/screens/ChatScreen/VideoPalScreen.tsx
@@ -270,7 +270,6 @@ export const VideoPalScreen = observer(({activePal}: VideoPalScreenProps) => {
             onPalSettingsSelect={handleOpenPalSheet}
             user={user}
             isStopVisible={modelStore.inferencing}
-            isThinking={modelStore.inferencing && !modelStore.isStreaming}
             isStreaming={modelStore.isStreaming}
             sendButtonVisibilityMode="editing"
             textInputProps={{

--- a/src/services/agent/AgentRunner.ts
+++ b/src/services/agent/AgentRunner.ts
@@ -424,9 +424,20 @@ export async function* runAgent(
         break;
       }
 
+      // Use `content` (parsed natural-language preamble), NOT `text`
+      // (raw streamed bytes). For tool-calling turns `text` includes
+      // the model's tool-call markers and the full arguments JSON
+      // (e.g. the entire `render_html` html string); putting that into
+      // assistantMsg.content makes the chat template render the
+      // tool_call TWICE on replay — once via `content` and once via
+      // the structured `tool_calls` field. That doubles the prompt
+      // size and breaks KV-cache prefix-match against turn N-1's
+      // streamed bytes, so the engine fully prefills again. `content`
+      // is the clean preamble (often empty for tool-only turns); the
+      // structured `tool_calls` arg below carries the actual call.
       messages = buildNextTurnMessages(
         messages,
-        finishedResult.text ?? finishedResult.content ?? '',
+        finishedResult.content ?? '',
         calls,
         outcomes,
         finishedResult.reasoning_content,

--- a/src/services/agent/AgentRunner.ts
+++ b/src/services/agent/AgentRunner.ts
@@ -285,6 +285,12 @@ export async function* runAgent(
       // (verified by Test #21).
       let accumulatedText = '';
       let markerSeenThisStep = false;
+      // Per-step generation metrics (post-hoc display in chip / preview
+      // footer). Counts streaming `token` events that carry tool_calls
+      // and tracks the time between the first such event and step
+      // finalisation. Reset every iteration via the surrounding `let`s.
+      let toolCallTokenCount = 0;
+      let toolCallStartedAt: number | null = null;
 
       // Bridge engine streaming callback into the iterator.
       const queue = new EventQueue<AgentEvent>();
@@ -310,6 +316,12 @@ export async function* runAgent(
             // this explicit sequence for a marker that straddles two
             // chunks.
             queue.push({type: 'token', delta});
+            if (delta.toolCalls && delta.toolCalls.length > 0) {
+              if (toolCallStartedAt === null) {
+                toolCallStartedAt = Date.now();
+              }
+              toolCallTokenCount += 1;
+            }
             if (delta.content) {
               accumulatedText += delta.content;
               if (!markerSeenThisStep && triggerMarkers.length > 0) {
@@ -359,10 +371,26 @@ export async function* runAgent(
       // ids that match the upcoming outcomes by construction.
       const finishedResult = lastResult;
       const rawToolCalls = finishedResult?.tool_calls ?? [];
-      const calls =
+      const callsWithoutMetrics =
         rawToolCalls.length === 0
           ? undefined
           : normalizeToolCallIds(rawToolCalls, callIdSeed + turn);
+      // Attach per-step generation metrics: tokens counted across the
+      // streaming run and ms from first tool-call token to here. The
+      // step total is replicated onto each call — for multi-tool steps
+      // this slightly overstates per-call cost, but the alternative
+      // (omitting metrics on multi-tool) is worse UX and the case is
+      // rare. Only attach when we actually saw tool-call tokens.
+      const calls =
+        callsWithoutMetrics && toolCallStartedAt !== null
+          ? callsWithoutMetrics.map(call => ({
+              ...call,
+              metrics: {
+                tokens: toolCallTokenCount,
+                durationMs: Date.now() - toolCallStartedAt!,
+              },
+            }))
+          : callsWithoutMetrics;
 
       yield {type: 'step_finished', turn, toolCalls: calls};
 

--- a/src/services/agent/AgentRunner.ts
+++ b/src/services/agent/AgentRunner.ts
@@ -258,6 +258,27 @@ export async function* runAgent(
 
   yield {type: 'run_started', messageId};
 
+  // When the consumer aborts mid-stream (e.g. user taps the stop
+  // button while the engine is generating tokens), the runner is the
+  // only layer that has BOTH the abort signal AND the engine handle —
+  // so it owns the abort→engine.stopCompletion translation. Without
+  // this, the signal would only be observed between turns and the
+  // in-flight engine.completion call could keep running native
+  // generation while the JS layer believed the run had stopped. The
+  // async IIFE handles all return shapes (Promise that resolves /
+  // rejects, sync function returning undefined, sync throw) without
+  // ever propagating an error out of the abort handler.
+  const onAbort = () => {
+    void (async () => {
+      try {
+        await engine.stopCompletion?.();
+      } catch (err) {
+        console.warn('[agent] engine.stopCompletion failed:', err);
+      }
+    })();
+  };
+  signal?.addEventListener('abort', onAbort);
+
   let messages = initialParams.messages;
   let turn = 0;
   // Holds the engine's CompletionResult after each turn finishes.
@@ -463,5 +484,7 @@ export async function* runAgent(
     yield {type: 'run_finished', result};
   } catch (error) {
     yield {type: 'run_failed', error: error as Error};
+  } finally {
+    signal?.removeEventListener('abort', onAbort);
   }
 }

--- a/src/services/agent/AgentRunner.ts
+++ b/src/services/agent/AgentRunner.ts
@@ -353,20 +353,27 @@ export async function* runAgent(
         return;
       }
 
-      yield {type: 'step_finished', turn};
-
+      // Compute normalized tool calls BEFORE the step_finished yield
+      // so the event payload can carry them. The hook's appendToolCall
+      // writer (WHAT §5 cleanup #1) lands them on step.toolCalls with
+      // ids that match the upcoming outcomes by construction.
       const finishedResult = lastResult;
+      const rawToolCalls = finishedResult?.tool_calls ?? [];
+      const calls =
+        rawToolCalls.length === 0
+          ? undefined
+          : normalizeToolCallIds(rawToolCalls, callIdSeed + turn);
+
+      yield {type: 'step_finished', turn, toolCalls: calls};
+
       if (!finishedResult) {
         break;
       }
 
-      const rawToolCalls = finishedResult.tool_calls ?? [];
-      if (rawToolCalls.length === 0) {
+      if (!calls || calls.length === 0) {
         // No tools requested — final answer landed.
         break;
       }
-
-      const calls = normalizeToolCallIds(rawToolCalls, callIdSeed + turn);
 
       const outcomes: AgentToolOutcome[] = [];
       for (const call of calls) {

--- a/src/services/agent/AgentRunner.ts
+++ b/src/services/agent/AgentRunner.ts
@@ -269,7 +269,7 @@ export async function* runAgent(
   // rejects, sync function returning undefined, sync throw) without
   // ever propagating an error out of the abort handler.
   const onAbort = () => {
-    void (async () => {
+    (async () => {
       try {
         await engine.stopCompletion?.();
       } catch (err) {

--- a/src/services/agent/AgentRunner.types.ts
+++ b/src/services/agent/AgentRunner.types.ts
@@ -79,12 +79,26 @@ export interface AgentUiState {
     | 'done'
     | 'failed';
   pendingTalentNames: string[];
+  /**
+   * Number of streaming token events received during the current
+   * tool-call generation phase. The PendingIndicator surfaces this
+   * so the user can tell that long tool calls (e.g. `render_html`
+   * building a complex page) are still progressing rather than hung.
+   * Reset to 0 on transitions out of `generating_tool_call`.
+   *
+   * Counts events, not characters: each `case 'token'` while
+   * generating a tool call increments by 1, so the unit matches the
+   * model's intuition (and is independent of how the engine encodes
+   * arguments). For llama.rn this aligns with native token callbacks.
+   */
+  pendingToolTokens: number;
   hitMaxTurns: boolean;
 }
 
 export const initialAgentUiState: AgentUiState = {
   status: 'idle',
   pendingTalentNames: [],
+  pendingToolTokens: 0,
   hitMaxTurns: false,
 };
 

--- a/src/services/agent/AgentRunner.types.ts
+++ b/src/services/agent/AgentRunner.types.ts
@@ -45,7 +45,21 @@ export type AgentEvent =
   | {type: 'marker_seen'; marker: string}
   | {type: 'tool_call_started'; call: AgentToolCall}
   | {type: 'tool_call_finished'; outcome: AgentToolOutcome}
-  | {type: 'step_finished'; turn: number}
+  | {
+      type: 'step_finished';
+      turn: number;
+      /**
+       * The runner's authoritative normalized tool calls for this
+       * step, attached when the step actually invoked tools. Optional
+       * because text-only steps and the final step of a multi-turn
+       * chain don't have any. When present, ids are reconciled with
+       * outcome callIds via {@link normalizeToolCallIds} — the hook's
+       * `appendToolCall` writer relies on this to make
+       * `step.toolCalls[i].id === outcome.callId` true by construction.
+       * See WHAT §5 cleanup #1.
+       */
+      toolCalls?: AgentToolCall[];
+    }
   | {type: 'run_finished'; result: AgentRunResult}
   | {type: 'run_failed'; error: Error};
 

--- a/src/services/agent/AgentRunner.types.ts
+++ b/src/services/agent/AgentRunner.types.ts
@@ -58,11 +58,10 @@ export type AgentEvent =
 export interface AgentUiState {
   status:
     | 'idle'
-    | 'preparing'
+    | 'prefill'
     | 'streaming_text'
     | 'generating_tool_call'
     | 'executing_tool'
-    | 'streaming_followup'
     | 'done'
     | 'failed';
   pendingTalentNames: string[];

--- a/src/services/agent/__tests__/AgentRunner.test.ts
+++ b/src/services/agent/__tests__/AgentRunner.test.ts
@@ -1140,4 +1140,178 @@ describe('runAgent', () => {
       expect(argLens[i]).toBeGreaterThan(argLens[i - 1]);
     }
   });
+
+  // ---------- Per-call metrics (post-hoc tokens + duration) ----------
+  //
+  // The runner counts streaming `token` events that carry tool_calls
+  // and tracks the wall-clock duration from the first such event to
+  // step finalisation. The metrics ride on the normalized toolCalls
+  // attached to `step_finished`, which the hook persists via
+  // appendToolCall — so post-hoc UI (chip + preview footer) can show
+  // them without any new persistence path.
+  it('attaches per-call generation metrics on step_finished', async () => {
+    const stages = ['{"a":', '{"a":1', '{"a":12', '{"a":123}'];
+    const engine = makeScriptedEngine({
+      scripts: [
+        {
+          tokens: stages.map(args => ({
+            tool_calls: [
+              {
+                id: 'c0',
+                type: 'function' as const,
+                function: {name: 'calculate', arguments: args},
+              },
+            ],
+          })),
+          result: {
+            text: '',
+            content: '',
+            tool_calls: [
+              {
+                id: 'c0',
+                type: 'function',
+                function: {
+                  name: 'calculate',
+                  arguments: stages[stages.length - 1],
+                },
+              },
+            ],
+          },
+        },
+        {
+          tokens: [{content: 'done'}],
+          result: {text: 'done', content: 'done'},
+        },
+      ],
+    });
+    const events = await collect(
+      runAgent({
+        engine,
+        initialParams: baseParams,
+        allowedTalentNames: ['calculate'],
+        talentLookup: () =>
+          makeTalent('calculate', () => ({type: 'text', summary: '0'})),
+        triggerMarkers: [],
+        messageId: 'm',
+      }),
+    );
+    const stepFinished = events.find(
+      (e): e is Extract<AgentEvent, {type: 'step_finished'}> =>
+        e.type === 'step_finished' && !!e.toolCalls && e.toolCalls.length > 0,
+    );
+    expect(stepFinished).toBeDefined();
+    const call = stepFinished!.toolCalls![0];
+    expect(call.metrics).toBeDefined();
+    expect(call.metrics!.tokens).toBe(stages.length);
+    // Duration is wall-clock — assert it's a non-negative finite number
+    // rather than a precise value (test scheduling is non-deterministic).
+    expect(call.metrics!.durationMs).toBeGreaterThanOrEqual(0);
+    expect(Number.isFinite(call.metrics!.durationMs)).toBe(true);
+  });
+
+  it('multi-tool steps replicate the step total onto each call', async () => {
+    const engine = makeScriptedEngine({
+      scripts: [
+        {
+          tokens: [
+            {
+              tool_calls: [
+                {
+                  id: 'c0',
+                  type: 'function',
+                  function: {name: 'calculate', arguments: '{}'},
+                },
+                {
+                  id: 'c1',
+                  type: 'function',
+                  function: {name: 'datetime', arguments: '{}'},
+                },
+              ],
+            },
+            {
+              tool_calls: [
+                {
+                  id: 'c0',
+                  type: 'function',
+                  function: {name: 'calculate', arguments: '{"x":1}'},
+                },
+                {
+                  id: 'c1',
+                  type: 'function',
+                  function: {name: 'datetime', arguments: '{}'},
+                },
+              ],
+            },
+          ],
+          result: {
+            text: '',
+            content: '',
+            tool_calls: [
+              {
+                id: 'c0',
+                type: 'function',
+                function: {name: 'calculate', arguments: '{"x":1}'},
+              },
+              {
+                id: 'c1',
+                type: 'function',
+                function: {name: 'datetime', arguments: '{}'},
+              },
+            ],
+          },
+        },
+        {
+          tokens: [{content: 'done'}],
+          result: {text: 'done', content: 'done'},
+        },
+      ],
+    });
+    const events = await collect(
+      runAgent({
+        engine,
+        initialParams: baseParams,
+        allowedTalentNames: ['calculate', 'datetime'],
+        talentLookup: name =>
+          makeTalent(name, () => ({type: 'text', summary: '0'})),
+        triggerMarkers: [],
+        messageId: 'm',
+      }),
+    );
+    const stepFinished = events.find(
+      (e): e is Extract<AgentEvent, {type: 'step_finished'}> =>
+        e.type === 'step_finished' && !!e.toolCalls && e.toolCalls.length > 0,
+    );
+    expect(stepFinished).toBeDefined();
+    const calls = stepFinished!.toolCalls!;
+    expect(calls).toHaveLength(2);
+    expect(calls[0].metrics?.tokens).toBe(2);
+    expect(calls[1].metrics?.tokens).toBe(2);
+  });
+
+  it('omits metrics on text-only steps (no tool-call tokens seen)', async () => {
+    const engine = makeScriptedEngine({
+      scripts: [
+        {
+          tokens: [{content: 'hi there'}],
+          result: {text: 'hi there', content: 'hi there'},
+        },
+      ],
+    });
+    const events = await collect(
+      runAgent({
+        engine,
+        initialParams: baseParams,
+        allowedTalentNames: [],
+        talentLookup: () => undefined,
+        triggerMarkers: [],
+        messageId: 'm',
+      }),
+    );
+    const stepFinished = events.find(
+      (e): e is Extract<AgentEvent, {type: 'step_finished'}> =>
+        e.type === 'step_finished',
+    );
+    expect(stepFinished).toBeDefined();
+    expect(stepFinished!.toolCalls).toBeUndefined();
+  });
 });

--- a/src/services/agent/__tests__/AgentRunner.test.ts
+++ b/src/services/agent/__tests__/AgentRunner.test.ts
@@ -1058,4 +1058,86 @@ describe('runAgent', () => {
     expect(startedIdx[0]).toBeLessThan(finishedIdx[0]);
     expect(startedIdx[1]).toBeLessThan(finishedIdx[1]);
   });
+
+  // ---------- Tool-call-progress signal source ----------
+  //
+  // PendingIndicator surfaces a live char/line count during
+  // `generating_tool_call`, sourced from
+  // `delta.toolCalls[0].function.arguments`. That only works if the
+  // engine emits incremental tool_calls deltas mid-stream. This test
+  // proves OUR pipeline works in that case — if the indicator stays
+  // empty on device, the problem is upstream (the engine isn't
+  // streaming tool_calls; on-device verification via the
+  // [pending-debug] logs).
+  it('progressive tool_calls deltas reach the iterator with growing args', async () => {
+    const stages = [
+      '{"html":"<!doc',
+      '{"html":"<!doctype html>\\n<html>',
+      '{"html":"<!doctype html>\\n<html>\\n<body>"',
+    ];
+    const engine = makeScriptedEngine({
+      scripts: [
+        {
+          tokens: stages.map(args => ({
+            tool_calls: [
+              {
+                id: 'c0',
+                type: 'function',
+                function: {name: 'render_html', arguments: args},
+              },
+            ],
+          })),
+          result: {
+            text: '',
+            content: '',
+            tool_calls: [
+              {
+                id: 'c0',
+                type: 'function',
+                function: {
+                  name: 'render_html',
+                  arguments: stages[stages.length - 1],
+                },
+              },
+            ],
+          },
+        },
+        {
+          tokens: [{content: 'done'}],
+          result: {text: 'done', content: 'done'},
+        },
+      ],
+    });
+    const events = await collect(
+      runAgent({
+        engine,
+        initialParams: baseParams,
+        allowedTalentNames: ['render_html'],
+        talentLookup: () =>
+          makeTalent('render_html', () => ({
+            type: 'html',
+            html: 'x',
+            summary: 's',
+          })),
+        triggerMarkers: [],
+        messageId: 'm',
+      }),
+    );
+    // Each scripted token chunk produced a `token` event whose
+    // delta.toolCalls[0].function.arguments matches the staged length.
+    const tokenEvents = events.filter(
+      (e): e is Extract<AgentEvent, {type: 'token'}> => e.type === 'token',
+    );
+    const argLens = tokenEvents
+      .map(e => {
+        const a = e.delta.toolCalls?.[0]?.function?.arguments;
+        return typeof a === 'string' ? a.length : -1;
+      })
+      .filter(n => n >= 0);
+    expect(argLens).toEqual(stages.map(s => s.length));
+    // Strictly increasing — the count source for the indicator.
+    for (let i = 1; i < argLens.length; i++) {
+      expect(argLens[i]).toBeGreaterThan(argLens[i - 1]);
+    }
+  });
 });

--- a/src/services/agent/__tests__/agentStateReducer.test.ts
+++ b/src/services/agent/__tests__/agentStateReducer.test.ts
@@ -306,4 +306,115 @@ describe('agentStateReducer', () => {
       'done',
     ]);
   });
+
+  // ---------- WHAT §3 / D4 / I4 — PendingIndicator no-flicker
+  //   The active-set predicate (`isPending`) at ChatView is:
+  //   status ∈ { prefill, generating_tool_call, executing_tool }
+  //   It must stay stable through a fast streaming sequence — i.e.
+  //   once status flips to `streaming_text`, no token event flips it
+  //   back. Otherwise the indicator would visibly flicker on/off
+  //   between tokens (one of the user-visible problems intent #2
+  //   was meant to fix). ----------
+
+  describe('PendingIndicator no-flicker invariant (WHAT §3 / D4 / I4)', () => {
+    const isPending = (s: AgentUiState) =>
+      s.status === 'prefill' ||
+      s.status === 'generating_tool_call' ||
+      s.status === 'executing_tool';
+
+    it('rapid token sequence (50 short content deltas) keeps isPending=false throughout streaming', () => {
+      // Walk through prefill → streaming_text → … 50 short token
+      // deltas representing fast character-by-character streaming.
+      // Once we leave prefill on the first content token, isPending
+      // must stay false until the run finishes.
+      let s = initialAgentUiState;
+      s = agentStateReducer(s, {type: 'run_started', messageId: 'm1'});
+      s = agentStateReducer(s, {
+        type: 'step_started',
+        turn: 0,
+        isFollowUp: false,
+      });
+      // First content token → flip prefill → streaming_text.
+      s = agentStateReducer(s, {type: 'token', delta: {content: 'H'}});
+      expect(s.status).toBe('streaming_text');
+      expect(isPending(s)).toBe(false);
+
+      const transitions: boolean[] = [];
+      // Simulate a fast burst of 50 token events. Each token only
+      // carries a single character (worst-case fragmentation).
+      for (let i = 0; i < 50; i++) {
+        s = agentStateReducer(s, {
+          type: 'token',
+          delta: {content: String.fromCharCode(33 + (i % 90))},
+        });
+        transitions.push(isPending(s));
+      }
+      // No flicker: every frame is non-pending.
+      expect(transitions.every(p => p === false)).toBe(true);
+      // Sanity — status never left streaming_text.
+      expect(s.status).toBe('streaming_text');
+    });
+
+    it('mixed reasoningContent + content tokens never flip isPending back to true mid-stream', () => {
+      // Some models interleave reasoning and content tokens. Both
+      // are "visible deltas" per the reducer; neither should flip
+      // status back to prefill once we've started streaming.
+      let s = initialAgentUiState;
+      s = agentStateReducer(s, {type: 'run_started', messageId: 'm1'});
+      s = agentStateReducer(s, {
+        type: 'step_started',
+        turn: 0,
+        isFollowUp: false,
+      });
+      // First reasoning token still flips prefill → streaming_text
+      // (the predicate `hasVisibleDelta` includes reasoningContent).
+      s = agentStateReducer(s, {
+        type: 'token',
+        delta: {reasoningContent: 'Let me think…'},
+      });
+      expect(s.status).toBe('streaming_text');
+
+      const events: AgentEvent[] = [
+        {type: 'token', delta: {reasoningContent: ' more'}},
+        {type: 'token', delta: {content: 'Hello'}},
+        {type: 'token', delta: {content: ', '}},
+        {type: 'token', delta: {reasoningContent: ' actually'}},
+        {type: 'token', delta: {content: 'world'}},
+      ];
+      const transitions: string[] = [];
+      for (const e of events) {
+        s = agentStateReducer(s, e);
+        transitions.push(s.status);
+      }
+      // Every transition stays in streaming_text; predicate stays
+      // false throughout.
+      expect(transitions.every(t => t === 'streaming_text')).toBe(true);
+    });
+
+    it('empty / whitespace-only token deltas do NOT toggle the predicate (idempotent on no-visible-delta)', () => {
+      // The reducer's `hasVisibleDelta` check requires content or
+      // reasoningContent length > 0. Empty deltas (e.g. partial
+      // chunks the engine emits between visible tokens) must be
+      // no-ops. If they leaked through and reset status, the
+      // indicator would briefly reappear between tokens — flicker.
+      let s = initialAgentUiState;
+      s = agentStateReducer(s, {type: 'run_started', messageId: 'm1'});
+      s = agentStateReducer(s, {
+        type: 'step_started',
+        turn: 0,
+        isFollowUp: false,
+      });
+      s = agentStateReducer(s, {type: 'token', delta: {content: 'hello'}});
+      expect(s.status).toBe('streaming_text');
+
+      // A no-op token (empty delta) must not change status.
+      const before = s;
+      const after = agentStateReducer(s, {
+        type: 'token',
+        delta: {content: ''},
+      });
+      expect(after).toEqual(before);
+      expect(isPending(after)).toBe(false);
+    });
+  });
 });

--- a/src/services/agent/__tests__/agentStateReducer.test.ts
+++ b/src/services/agent/__tests__/agentStateReducer.test.ts
@@ -80,13 +80,39 @@ describe('agentStateReducer', () => {
     expect(next.pendingTalentNames).toEqual([]);
   });
 
-  it('#6 step_started with isFollowUp=true → streaming_text (D5: streaming_followup collapsed)', () => {
+  it('#6 step_started with isFollowUp=true → prefill (covers Scenario I phase 7 dead zone)', () => {
     const next = agentStateReducer(
       {...initialAgentUiState, status: 'executing_tool'},
       {type: 'step_started', turn: 1, isFollowUp: true},
     );
-    expect(next.status).toBe('streaming_text');
+    expect(next.status).toBe('prefill');
     expect(next.pendingTalentNames).toEqual([]);
+  });
+
+  it('#6c follow-up: first content/reasoning token after prefill → streaming_text (Scenario I phase 8)', () => {
+    const afterStepStarted = agentStateReducer(
+      {...initialAgentUiState, status: 'executing_tool'},
+      {type: 'step_started', turn: 1, isFollowUp: true},
+    );
+    expect(afterStepStarted.status).toBe('prefill');
+    const afterToken = agentStateReducer(afterStepStarted, {
+      type: 'token',
+      delta: {content: 'hello'},
+    });
+    expect(afterToken.status).toBe('streaming_text');
+  });
+
+  it('#6d follow-up: empty content token in prefill preserves prefill (no premature flip)', () => {
+    const prefillState: AgentUiState = {
+      status: 'prefill',
+      pendingTalentNames: [],
+      hitMaxTurns: false,
+    };
+    const next = agentStateReducer(prefillState, {
+      type: 'token',
+      delta: {content: ''},
+    });
+    expect(next.status).toBe('prefill');
   });
 
   it('#6b step_started with isFollowUp=false → streaming_text', () => {
@@ -254,6 +280,18 @@ describe('agentStateReducer', () => {
       states.push({...s});
     }
     const statuses = states.map(x => x.status);
+    // Scenario I phase walk:
+    //   run_started        → prefill
+    //   step_started(0)    → streaming_text
+    //   token(content)     → streaming_text (already streaming)
+    //   token(toolCalls)   → generating_tool_call
+    //   tool_call_started  → executing_tool
+    //   tool_call_finished → executing_tool
+    //   step_finished      → executing_tool (no-op)
+    //   step_started(F=t)  → prefill (follow-up dead zone covered)
+    //   token(content)     → streaming_text (first follow-up token)
+    //   step_finished      → streaming_text (no-op)
+    //   run_finished       → done
     expect(statuses).toEqual([
       'prefill',
       'streaming_text',
@@ -262,7 +300,7 @@ describe('agentStateReducer', () => {
       'executing_tool',
       'executing_tool',
       'executing_tool',
-      'streaming_text',
+      'prefill',
       'streaming_text',
       'streaming_text',
       'done',

--- a/src/services/agent/__tests__/agentStateReducer.test.ts
+++ b/src/services/agent/__tests__/agentStateReducer.test.ts
@@ -11,13 +11,13 @@ const noopRunResult = {
 describe('agentStateReducer', () => {
   // ---------- Story Test Requirements (Reducer) #1–#7 ----------
 
-  it('#1 run_started → status preparing', () => {
+  it('#1 run_started → status prefill', () => {
     const next = agentStateReducer(initialAgentUiState, {
       type: 'run_started',
       messageId: 'm1',
     });
     expect(next).toEqual<AgentUiState>({
-      status: 'preparing',
+      status: 'prefill',
       pendingTalentNames: [],
       hitMaxTurns: false,
     });
@@ -80,18 +80,18 @@ describe('agentStateReducer', () => {
     expect(next.pendingTalentNames).toEqual([]);
   });
 
-  it('#6 step_started with isFollowUp=true → streaming_followup', () => {
+  it('#6 step_started with isFollowUp=true → streaming_text (D5: streaming_followup collapsed)', () => {
     const next = agentStateReducer(
       {...initialAgentUiState, status: 'executing_tool'},
       {type: 'step_started', turn: 1, isFollowUp: true},
     );
-    expect(next.status).toBe('streaming_followup');
+    expect(next.status).toBe('streaming_text');
     expect(next.pendingTalentNames).toEqual([]);
   });
 
   it('#6b step_started with isFollowUp=false → streaming_text', () => {
     const next = agentStateReducer(
-      {...initialAgentUiState, status: 'preparing'},
+      {...initialAgentUiState, status: 'prefill'},
       {type: 'step_started', turn: 0, isFollowUp: false},
     );
     expect(next.status).toBe('streaming_text');
@@ -99,7 +99,7 @@ describe('agentStateReducer', () => {
 
   it('#7 run_finished hitMaxTurns=true → done, hitMaxTurns=true', () => {
     const next = agentStateReducer(
-      {...initialAgentUiState, status: 'streaming_followup'},
+      {...initialAgentUiState, status: 'streaming_text'},
       {
         type: 'run_finished',
         result: {...noopRunResult, hitMaxTurns: true},
@@ -255,16 +255,16 @@ describe('agentStateReducer', () => {
     }
     const statuses = states.map(x => x.status);
     expect(statuses).toEqual([
-      'preparing',
+      'prefill',
       'streaming_text',
       'streaming_text',
       'generating_tool_call',
       'executing_tool',
       'executing_tool',
       'executing_tool',
-      'streaming_followup',
-      'streaming_followup',
-      'streaming_followup',
+      'streaming_text',
+      'streaming_text',
+      'streaming_text',
       'done',
     ]);
   });

--- a/src/services/agent/__tests__/agentStateReducer.test.ts
+++ b/src/services/agent/__tests__/agentStateReducer.test.ts
@@ -19,6 +19,7 @@ describe('agentStateReducer', () => {
     expect(next).toEqual<AgentUiState>({
       status: 'prefill',
       pendingTalentNames: [],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     });
   });
@@ -35,6 +36,7 @@ describe('agentStateReducer', () => {
     const initial: AgentUiState = {
       status: 'generating_tool_call',
       pendingTalentNames: ['calculate'],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
     const event: AgentEvent = {
@@ -68,6 +70,7 @@ describe('agentStateReducer', () => {
       {
         status: 'generating_tool_call',
         pendingTalentNames: ['calculate'],
+        pendingToolTokens: 0,
         hitMaxTurns: false,
       },
       {
@@ -106,6 +109,7 @@ describe('agentStateReducer', () => {
     const prefillState: AgentUiState = {
       status: 'prefill',
       pendingTalentNames: [],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
     const next = agentStateReducer(prefillState, {
@@ -159,6 +163,7 @@ describe('agentStateReducer', () => {
     const before: AgentUiState = {
       status: 'executing_tool',
       pendingTalentNames: ['calculate'],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
     const next = agentStateReducer(before, {
@@ -174,6 +179,7 @@ describe('agentStateReducer', () => {
     const before: AgentUiState = {
       status: 'streaming_text',
       pendingTalentNames: [],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
     const next = agentStateReducer(before, {
@@ -187,6 +193,7 @@ describe('agentStateReducer', () => {
     const before: AgentUiState = {
       status: 'streaming_text',
       pendingTalentNames: [],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
     const next = agentStateReducer(before, {
@@ -200,6 +207,7 @@ describe('agentStateReducer', () => {
     const before: AgentUiState = {
       status: 'executing_tool',
       pendingTalentNames: [],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
     const next = agentStateReducer(before, {
@@ -218,10 +226,78 @@ describe('agentStateReducer', () => {
     const before: AgentUiState = {
       status: 'streaming_text',
       pendingTalentNames: [],
+      pendingToolTokens: 0,
       hitMaxTurns: false,
     };
     const next = agentStateReducer(before, {type: 'step_finished', turn: 0});
     expect(next).toEqual(before);
+  });
+
+  it('token with toolCalls increments pendingToolTokens by 1', () => {
+    const next = agentStateReducer(initialAgentUiState, {
+      type: 'token',
+      delta: {
+        toolCalls: [
+          {id: 'c0', function: {name: 'render_html', arguments: '{"html":"<'}},
+        ],
+      },
+    });
+    expect(next.pendingToolTokens).toBe(1);
+  });
+
+  it('subsequent token events accumulate the token count', () => {
+    let state = initialAgentUiState;
+    for (let i = 0; i < 5; i++) {
+      state = agentStateReducer(state, {
+        type: 'token',
+        delta: {
+          toolCalls: [
+            {
+              id: 'c0',
+              function: {name: 'render_html', arguments: 'x'.repeat(i)},
+            },
+          ],
+        },
+      });
+    }
+    expect(state.pendingToolTokens).toBe(5);
+  });
+
+  it('pendingTalentNames stay stable when later deltas drop the function name', () => {
+    // llama.rn sometimes emits the function name only on the first
+    // tool-call delta and leaves it empty on subsequent ones — the
+    // reducer must carry the original names through so the indicator
+    // label doesn't flicker.
+    const after1 = agentStateReducer(initialAgentUiState, {
+      type: 'token',
+      delta: {
+        toolCalls: [
+          {id: 'c0', function: {name: 'render_html', arguments: '{'}},
+        ],
+      },
+    });
+    expect(after1.pendingTalentNames).toEqual(['render_html']);
+    const after2 = agentStateReducer(after1, {
+      type: 'token',
+      delta: {
+        toolCalls: [{id: 'c0', function: {name: '', arguments: '{"html":"'}}],
+      },
+    });
+    expect(after2.pendingTalentNames).toEqual(['render_html']);
+  });
+
+  it('tool_call_started clears pendingToolTokens', () => {
+    const before: AgentUiState = {
+      status: 'generating_tool_call',
+      pendingTalentNames: ['render_html'],
+      pendingToolTokens: 47,
+      hitMaxTurns: false,
+    };
+    const next = agentStateReducer(before, {
+      type: 'tool_call_started',
+      call: {id: 'c0', function: {name: 'render_html', arguments: '{}'}},
+    });
+    expect(next.pendingToolTokens).toBe(0);
   });
 
   it('toolCalls without function names are filtered out of pendingTalentNames', () => {

--- a/src/services/agent/__tests__/agentStateReducer.test.ts
+++ b/src/services/agent/__tests__/agentStateReducer.test.ts
@@ -115,12 +115,18 @@ describe('agentStateReducer', () => {
     expect(next.status).toBe('prefill');
   });
 
-  it('#6b step_started with isFollowUp=false → streaming_text', () => {
+  it('#6b step_started with isFollowUp=false → prefill (initial step also waits for first token; WHAT §3)', () => {
+    // Both initial and follow-up step_started events keep status at
+    // `prefill`. The transition to `streaming_text` happens on the
+    // first content/reasoning token via `case 'token'`. This is what
+    // makes the PendingIndicator visible during the gap between
+    // run_started and the first token (especially for slow first-token
+    // models or cold context).
     const next = agentStateReducer(
       {...initialAgentUiState, status: 'prefill'},
       {type: 'step_started', turn: 0, isFollowUp: false},
     );
-    expect(next.status).toBe('streaming_text');
+    expect(next.status).toBe('prefill');
   });
 
   it('#7 run_finished hitMaxTurns=true → done, hitMaxTurns=true', () => {
@@ -282,8 +288,8 @@ describe('agentStateReducer', () => {
     const statuses = states.map(x => x.status);
     // Scenario I phase walk:
     //   run_started        → prefill
-    //   step_started(0)    → streaming_text
-    //   token(content)     → streaming_text (already streaming)
+    //   step_started(0)    → prefill (initial dead zone covered)
+    //   token(content)     → streaming_text (first content token flips)
     //   token(toolCalls)   → generating_tool_call
     //   tool_call_started  → executing_tool
     //   tool_call_finished → executing_tool
@@ -294,7 +300,7 @@ describe('agentStateReducer', () => {
     //   run_finished       → done
     expect(statuses).toEqual([
       'prefill',
-      'streaming_text',
+      'prefill',
       'streaming_text',
       'generating_tool_call',
       'executing_tool',

--- a/src/services/agent/agentStateReducer.ts
+++ b/src/services/agent/agentStateReducer.ts
@@ -26,14 +26,14 @@ export function agentStateReducer(
   switch (event.type) {
     case 'run_started':
       return {
-        status: 'preparing',
+        status: 'prefill',
         pendingTalentNames: [],
         hitMaxTurns: false,
       };
     case 'step_started':
       return {
         ...state,
-        status: event.isFollowUp ? 'streaming_followup' : 'streaming_text',
+        status: 'streaming_text',
         pendingTalentNames: [],
       };
     case 'token': {

--- a/src/services/agent/agentStateReducer.ts
+++ b/src/services/agent/agentStateReducer.ts
@@ -28,6 +28,7 @@ export function agentStateReducer(
       return {
         status: 'prefill',
         pendingTalentNames: [],
+        pendingToolTokens: 0,
         hitMaxTurns: false,
       };
     case 'step_started':
@@ -50,6 +51,7 @@ export function agentStateReducer(
         ...state,
         status: 'prefill',
         pendingTalentNames: [],
+        pendingToolTokens: 0,
       };
     case 'token': {
       const incomingToolCalls = event.delta.toolCalls;
@@ -57,10 +59,24 @@ export function agentStateReducer(
         const names = incomingToolCalls
           .map(tc => tc.function?.name)
           .filter((n): n is string => !!n);
+        // Each token event during tool-call generation = one token
+        // emitted by the model. Counting events sidesteps engine
+        // encoding details (cumulative vs incremental arguments;
+        // llama.rn vs OpenAI streaming shape) — every emit is +1.
+        const carryNames =
+          state.status === 'generating_tool_call' &&
+          state.pendingTalentNames.length > 0
+            ? state.pendingTalentNames
+            : names;
         return {
           ...state,
           status: 'generating_tool_call',
-          pendingTalentNames: names,
+          // Preserve the names from the first delta — later deltas
+          // sometimes drop the function name once it's already been
+          // emitted, leaving us with anonymous calls. Honouring the
+          // first non-empty set keeps the label stable across the run.
+          pendingTalentNames: carryNames,
+          pendingToolTokens: state.pendingToolTokens + 1,
         };
       }
       // Plain content/reasoning token: if we were waiting in `prefill`
@@ -92,6 +108,7 @@ export function agentStateReducer(
         ...state,
         status: 'executing_tool',
         pendingTalentNames: [],
+        pendingToolTokens: 0,
       };
     case 'tool_call_finished':
       // Stay in executing_tool until step_finished or the next token
@@ -103,6 +120,7 @@ export function agentStateReducer(
       return {
         status: 'done',
         pendingTalentNames: [],
+        pendingToolTokens: 0,
         hitMaxTurns: !!event.result.hitMaxTurns,
       };
     case 'run_failed':
@@ -110,6 +128,7 @@ export function agentStateReducer(
         ...state,
         status: 'failed',
         pendingTalentNames: [],
+        pendingToolTokens: 0,
       };
     default: {
       const _exhaustive: never = event;

--- a/src/services/agent/agentStateReducer.ts
+++ b/src/services/agent/agentStateReducer.ts
@@ -31,9 +31,17 @@ export function agentStateReducer(
         hitMaxTurns: false,
       };
     case 'step_started':
+      // Follow-up steps route through `prefill` so the indicator (D4,
+      // owned by ChatView) covers the dead zone between the tool
+      // finishing and the first follow-up token. The first content/
+      // reasoning `token` for the follow-up flips status back to
+      // `streaming_text` via the regular path. Initial steps (turn 0)
+      // were already in `prefill` from `run_started`; flipping to
+      // `streaming_text` here on the !isFollowUp branch is the
+      // conventional "first step is opening for tokens" transition.
       return {
         ...state,
-        status: 'streaming_text',
+        status: event.isFollowUp ? 'prefill' : 'streaming_text',
         pendingTalentNames: [],
       };
     case 'token': {
@@ -48,10 +56,23 @@ export function agentStateReducer(
           pendingTalentNames: names,
         };
       }
-      // Plain content/reasoning token: preserve current status and
-      // pendingTalentNames. Critically, do NOT clear pendingTalentNames
-      // when content arrives during a tool-call assembly — the
-      // legacy metadata-bag bug that motivated this refactor.
+      // Plain content/reasoning token: if we were waiting in `prefill`
+      // (initial step or follow-up routed through prefill per WHAT §3),
+      // the first such token flips status to `streaming_text` so the
+      // indicator (D4) hides as soon as visible output starts. Do NOT
+      // clear pendingTalentNames here — that's the regression guard for
+      // the legacy metadata-bag bug where streamed content overwrote
+      // the tool-call hint.
+      const hasVisibleDelta =
+        (event.delta.content && event.delta.content.length > 0) ||
+        (event.delta.reasoningContent &&
+          event.delta.reasoningContent.length > 0);
+      if (state.status === 'prefill' && hasVisibleDelta) {
+        return {
+          ...state,
+          status: 'streaming_text',
+        };
+      }
       return state;
     }
     case 'marker_seen':

--- a/src/services/agent/agentStateReducer.ts
+++ b/src/services/agent/agentStateReducer.ts
@@ -31,17 +31,24 @@ export function agentStateReducer(
         hitMaxTurns: false,
       };
     case 'step_started':
-      // Follow-up steps route through `prefill` so the indicator (D4,
-      // owned by ChatView) covers the dead zone between the tool
-      // finishing and the first follow-up token. The first content/
-      // reasoning `token` for the follow-up flips status back to
-      // `streaming_text` via the regular path. Initial steps (turn 0)
-      // were already in `prefill` from `run_started`; flipping to
-      // `streaming_text` here on the !isFollowUp branch is the
-      // conventional "first step is opening for tokens" transition.
+      // Both initial and follow-up steps route through `prefill` so the
+      // indicator (D4, owned by ChatView) covers the dead zone between
+      // step setup and the first content/reasoning token. The first
+      // such token flips status to `streaming_text` via the regular
+      // `case 'token'` path below (the prefill→streaming_text rule).
+      //
+      // For initial steps, `prefill` was already set by `run_started`,
+      // but explicitly setting it here keeps the rule uniform across
+      // both branches and prevents the indicator from disappearing in
+      // the brief window between run_started and the first token.
+      //
+      // For follow-up steps, this transitions out of `executing_tool`
+      // (where the previous step left us) into `prefill` until the
+      // follow-up's first token lands. The `isFollowUp` flag remains on
+      // the event for any per-step UI that needs it.
       return {
         ...state,
-        status: event.isFollowUp ? 'prefill' : 'streaming_text',
+        status: 'prefill',
         pendingTalentNames: [],
       };
     case 'token': {

--- a/src/services/talents/RenderHtmlEngine.ts
+++ b/src/services/talents/RenderHtmlEngine.ts
@@ -33,7 +33,8 @@ export class RenderHtmlEngine implements TalentEngine {
       type: 'html',
       html,
       title,
-      summary: `Rendered HTML preview: "${title ?? 'Untitled'}"`,
+      summary: `[render_html SUCCESS] The html has been rendered into a preview above, and the user can see and toggle to see the code. 
+Reply with at most one short sentence what you build`,
     };
   }
 

--- a/src/services/talents/TalentUIRegistry.ts
+++ b/src/services/talents/TalentUIRegistry.ts
@@ -6,7 +6,17 @@ export interface TalentUI {
   readonly name: string;
   /** Render the completed result. Receives the typed TalentResult. */
   renderResult?(result: TalentResult): React.ReactNode;
-  /** Render a pending/loading state while the talent executes. */
+  /**
+   * Render a pending/loading state while the talent executes.
+   *
+   * @deprecated No longer called by TalentSurface (WHAT §4a, D4). The
+   * pending UX is owned by ChatView via PendingIndicator (D4 / I4) —
+   * a single subtle dot-row covers all in-flight phases including
+   * the dead zones in Scenario I phases 5 and 7. Existing
+   * implementations are kept for now to avoid a contract break, but
+   * new TalentUIs should NOT supply this method; it will be removed
+   * in a follow-up cleanup story.
+   */
   renderPending?(): React.ReactNode;
 }
 

--- a/src/services/talents/__tests__/RenderHtmlEngine.test.ts
+++ b/src/services/talents/__tests__/RenderHtmlEngine.test.ts
@@ -3,6 +3,17 @@ import {RenderHtmlEngine} from '../RenderHtmlEngine';
 describe('RenderHtmlEngine', () => {
   const engine = new RenderHtmlEngine();
 
+  // The success summary is what the model reads as the tool result on
+  // its follow-up turn. It must (a) signal SUCCESS so the model
+  // doesn't apologize, (b) tell the model the user can already see
+  // the preview so it doesn't re-describe it, and (c) cap the
+  // follow-up at one sentence.
+  const expectSuccessSummary = (summary: string) => {
+    expect(summary).toMatch(/render_html.*SUCCESS/i);
+    expect(summary).toMatch(/preview/i);
+    expect(summary).toMatch(/one short sentence/i);
+  };
+
   it('exposes name "render_html"', () => {
     expect(engine.name).toBe('render_html');
   });
@@ -16,7 +27,7 @@ describe('RenderHtmlEngine', () => {
     if (result.type === 'html') {
       expect(result.html).toBe('<p>hi</p>');
       expect(result.title).toBe('Greeting');
-      expect(result.summary).toBe('Rendered HTML preview: "Greeting"');
+      expectSuccessSummary(result.summary);
     }
   });
 
@@ -27,9 +38,11 @@ describe('RenderHtmlEngine', () => {
     }
   });
 
-  it('defaults title to "Untitled" in summary when missing', async () => {
-    const result = await engine.execute({html: '<p>hi</p>'});
-    expect(result.summary).toBe('Rendered HTML preview: "Untitled"');
+  it('summary is independent of title presence (preview is what the user sees)', async () => {
+    const withTitle = await engine.execute({html: '<p/>', title: 'X'});
+    const withoutTitle = await engine.execute({html: '<p/>'});
+    expect(withTitle.summary).toBe(withoutTitle.summary);
+    expectSuccessSummary(withoutTitle.summary);
   });
 
   it('returns an error TalentResult for missing html', async () => {
@@ -52,7 +65,9 @@ describe('RenderHtmlEngine', () => {
 
   it('ignores non-string title values (treats as undefined)', async () => {
     const result = await engine.execute({html: '<p/>', title: 42 as any});
-    expect(result.summary).toBe('Rendered HTML preview: "Untitled"');
+    if (result.type === 'html') {
+      expect(result.title).toBeUndefined();
+    }
   });
 
   it('does not sanitize or mutate the html payload (pass-through)', async () => {

--- a/src/services/talents/__tests__/pact-cleanup.test.ts
+++ b/src/services/talents/__tests__/pact-cleanup.test.ts
@@ -74,13 +74,17 @@ describe('PACT cleanup: result-keyed metadata by call ID', () => {
     const engine = new RenderHtmlEngine();
     const result = await engine.execute({html: '<p>test</p>', title: 'T'});
 
-    // The result must carry type, html, title, and summary as a unit
-    expect(result).toEqual({
-      type: 'html',
-      html: '<p>test</p>',
-      title: 'T',
-      summary: 'Rendered HTML preview: "T"',
-    });
+    // The result must carry type, html, title, and summary as a unit.
+    // The summary text itself is owned by RenderHtmlEngine — we
+    // assert structure (all four fields present, type narrowed) and
+    // leave the wording to RenderHtmlEngine.test.
+    expect(result.type).toBe('html');
+    if (result.type === 'html') {
+      expect(result.html).toBe('<p>test</p>');
+      expect(result.title).toBe('T');
+      expect(typeof result.summary).toBe('string');
+      expect(result.summary.length).toBeGreaterThan(0);
+    }
 
     // Verify it's a single object, not spread fields
     expect('type' in result).toBe(true);

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -548,6 +548,31 @@ class ChatSessionStore {
     }, remainingTime);
   }
 
+  /**
+   * Drain the throttled streaming slot synchronously. Call before any
+   * structural change to `turn.steps` (e.g. pushAgentStep or
+   * finalizeActiveStep) so a pending update scheduled for the previous
+   * `lastIdx` lands on the step it was intended for, not on a freshly
+   * pushed step that happens to be `lastIdx` when the timer fires.
+   *
+   * Without this, the regression sequence is: final `token` for step 0
+   * schedules the throttle (fires in 150ms) → step_finished + tool_call
+   * events run synchronously → step_started(1) pushes step 1 → throttle
+   * timer fires → applies step 0's pending content to step 1, briefly
+   * showing step 0's text duplicated under the talent block until the
+   * follow-up step's first real token replaces it.
+   */
+  private flushStreamingUpdate(): void {
+    if (this.streamingThrottleTimer) {
+      clearTimeout(this.streamingThrottleTimer);
+      this.streamingThrottleTimer = null;
+    }
+    if (this.pendingStreamingUpdate) {
+      this.applyStreamingUpdate();
+      this.lastStreamingUpdateTime = Date.now();
+    }
+  }
+
   // Update message during streaming - no database write, triggers reactivity
   // Throttled to avoid excessive re-renders. Accepts either a Text-shaped
   // partial (legacy path) or an AssistantTurn-shaped partial (new
@@ -723,6 +748,11 @@ class ChatSessionStore {
     sessionId: string,
     step: AgentStep,
   ): Promise<void> {
+    // Drain any pending throttled update onto the CURRENT lastIdx
+    // before structurally extending the array. Otherwise a pending
+    // step-0 write would land on the freshly pushed step-1 when the
+    // timer fires.
+    this.flushStreamingUpdate();
     const targetSessionId = sessionId || this.activeSessionId;
     if (!targetSessionId) {
       return;
@@ -857,6 +887,12 @@ class ChatSessionStore {
    * whole `steps` array wholesale.
    */
   async finalizeActiveStep(id: string, sessionId: string): Promise<void> {
+    // Drain any pending throttled update first so the final partial
+    // content for this step lands BEFORE we mark it `partial: false`
+    // and replace the array. Otherwise a late-firing timer could
+    // either (a) write to a stale array reference or (b) write to
+    // whatever step happens to be lastIdx after this finalize completes.
+    this.flushStreamingUpdate();
     const targetSessionId = sessionId || this.activeSessionId;
     if (!targetSessionId) {
       return;

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -71,6 +71,20 @@ class ChatSessionStore {
   isEditMode: boolean = false;
   editingMessageId: string | null = null;
   isGenerating: boolean = false;
+  /**
+   * True between the moment the user taps Stop and the moment the
+   * runner's loop has actually finished (i.e. native llama.rn has
+   * returned from its in-flight `llama_decode` chunk and the for-await
+   * loop in `useChatSession` exits). During this window the JS layer
+   * cannot start a new completion (the native context is still busy)
+   * — the send button must be disabled and the user needs visible
+   * "Stopping…" feedback so they don't mistake the silent gap for the
+   * stop having succeeded already.
+   *
+   * Cleared in the same place that clears `isGenerating` (after the
+   * for-await loop ends, success or failure).
+   */
+  isStopping: boolean = false;
   newChatCompletionSettings: CompletionParams = defaultCompletionSettings;
   newChatPalId: string | undefined = undefined;
   newChatSettingsSource: 'pal' | 'custom' = 'pal';
@@ -164,6 +178,10 @@ class ChatSessionStore {
 
   setIsGenerating(value: boolean) {
     this.isGenerating = value;
+  }
+
+  setIsStopping(value: boolean) {
+    this.isStopping = value;
   }
 
   /**

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -2,7 +2,12 @@ import {makeAutoObservable, runInAction} from 'mobx';
 import {format, isToday, isYesterday} from 'date-fns';
 import * as RNFS from '@dr.pogodin/react-native-fs';
 
-import {AgentStep, AgentToolOutcome, MessageType} from '../utils/types';
+import {
+  AgentStep,
+  AgentToolCall,
+  AgentToolOutcome,
+  MessageType,
+} from '../utils/types';
 import {CompletionParams} from '../utils/completionTypes';
 import {chatSessionRepository} from '../repositories/ChatSessionRepository';
 import {defaultCompletionParams} from '../utils/completionSettingsVersions';
@@ -744,6 +749,59 @@ class ChatSessionStore {
       await chatSessionRepository.updateMessage(id, {steps: nextSteps});
     } catch (error) {
       console.error('Failed to persist pushAgentStep:', error);
+    }
+  }
+
+  /**
+   * Replace the active (last) step's `toolCalls` array with the
+   * runner's authoritative normalized list. Called from the hook
+   * exactly once per step, on `step_finished`, with ids that match
+   * the upcoming `appendToolOutcome` callIds by construction (the
+   * runner reconciles ids via `normalizeToolCallIds` and attaches
+   * them to the `step_finished` event payload).
+   *
+   * Single-writer rule per WHAT §5 cleanup #1 — the streaming
+   * partial in `applyEventToStore` no longer carries `toolCalls`
+   * as of Step 3, so this is the ONLY writer for `step.toolCalls`
+   * after that change.
+   */
+  async appendToolCall(
+    id: string,
+    sessionId: string,
+    calls: AgentToolCall[],
+  ): Promise<void> {
+    const targetSessionId = sessionId || this.activeSessionId;
+    if (!targetSessionId) {
+      return;
+    }
+    const session = this.sessions.find(s => s.id === targetSessionId);
+    if (!session) {
+      return;
+    }
+    const index = session.messages.findIndex(msg => msg.id === id);
+    if (index < 0) {
+      return;
+    }
+    const message = session.messages[index];
+    if (message.type !== 'assistant_turn') {
+      return;
+    }
+    const turn = message as MessageType.AssistantTurn;
+    if (!turn.steps || turn.steps.length === 0) {
+      return;
+    }
+    let nextSteps: AgentStep[] = [];
+    runInAction(() => {
+      const lastIdx = turn.steps.length - 1;
+      const last = turn.steps[lastIdx];
+      const nextLast: AgentStep = {...last, toolCalls: calls};
+      nextSteps = [...turn.steps.slice(0, lastIdx), nextLast];
+      turn.steps = nextSteps;
+    });
+    try {
+      await chatSessionRepository.updateMessage(id, {steps: nextSteps});
+    } catch (error) {
+      console.error('Failed to persist appendToolCall:', error);
     }
   }
 

--- a/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
+++ b/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
@@ -44,6 +44,7 @@ describe('ChatSessionStore — AssistantTurn extensions', () => {
       chatSessionStore.setAgentUiState({
         status: 'generating_tool_call',
         pendingTalentNames: ['calculate'],
+        pendingToolTokens: 0,
         hitMaxTurns: false,
       });
       expect(chatSessionStore.isGeneratingToolCall).toBe(true);
@@ -51,6 +52,7 @@ describe('ChatSessionStore — AssistantTurn extensions', () => {
       chatSessionStore.setAgentUiState({
         status: 'streaming_text',
         pendingTalentNames: [],
+        pendingToolTokens: 0,
         hitMaxTurns: false,
       });
       expect(chatSessionStore.isGeneratingToolCall).toBe(false);
@@ -60,6 +62,7 @@ describe('ChatSessionStore — AssistantTurn extensions', () => {
       const next = {
         status: 'executing_tool' as const,
         pendingTalentNames: ['render_html'],
+        pendingToolTokens: 0,
         hitMaxTurns: false,
       };
       chatSessionStore.setAgentUiState(next);

--- a/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
+++ b/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
@@ -121,6 +121,70 @@ describe('ChatSessionStore — AssistantTurn extensions', () => {
       await chatSessionStore.pushAgentStep('m1', 'session1', {partial: true});
       expect(chatSessionRepository.updateMessage).not.toHaveBeenCalled();
     });
+
+    it('flushes any pending streaming update onto the OLD lastIdx before adding the new step (regression: stale throttle leaked step-0 content into step-1)', async () => {
+      // Simulates: final token for step 0 schedules a throttled write,
+      // step_finished + tool events run synchronously, step_started(1)
+      // pushes a new step. Without the flush, the timer fires later
+      // and applies step 0's pending content to step 1 (which is now
+      // lastIdx) — producing the duplicate-text-after-preview regression.
+      jest.useFakeTimers();
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(2_000_000);
+      try {
+        // Force the throttle to schedule a setTimeout (rather than
+        // applying inline) by setting lastStreamingUpdateTime to "just
+        // now" — so the first updateActiveStepStreaming call goes
+        // through the timer path.
+        (chatSessionStore as any).lastStreamingUpdateTime = 2_000_000;
+        (chatSessionStore as any).pendingStreamingUpdate = null;
+        if ((chatSessionStore as any).streamingThrottleTimer) {
+          clearTimeout((chatSessionStore as any).streamingThrottleTimer);
+          (chatSessionStore as any).streamingThrottleTimer = null;
+        }
+
+        const turn = makeAssistantTurn([
+          {content: "I'll generate the page", partial: true},
+        ]);
+        chatSessionStore.sessions = [
+          {
+            id: 'session1',
+            title: '',
+            date: '',
+            messages: [turn],
+            completionSettings: defaultCompletionSettings,
+            settingsSource: 'pal',
+          },
+        ];
+        chatSessionStore.activeSessionId = 'session1';
+
+        // Schedule a pending streaming update for step 0.
+        chatSessionStore.updateActiveStepStreaming(turn.id, 'session1', {
+          content: "I'll generate the page",
+        });
+        expect((chatSessionStore as any).pendingStreamingUpdate).not.toBeNull();
+        expect((chatSessionStore as any).streamingThrottleTimer).not.toBeNull();
+
+        // Now push step 1 BEFORE the throttle fires. The flush must
+        // drain the pending write onto step 0 first.
+        await chatSessionStore.pushAgentStep(turn.id, 'session1', {
+          partial: true,
+        });
+
+        const updated = chatSessionStore.sessions[0]
+          .messages[0] as MessageType.AssistantTurn;
+        expect(updated.steps).toHaveLength(2);
+        // Step 0 keeps its content (flushed onto the right step).
+        expect(updated.steps[0].content).toBe("I'll generate the page");
+        // Step 1 is empty (NOT polluted with step 0's content).
+        expect(updated.steps[1].content).toBeUndefined();
+        // Pending slot drained.
+        expect((chatSessionStore as any).pendingStreamingUpdate).toBeNull();
+        expect((chatSessionStore as any).streamingThrottleTimer).toBeNull();
+      } finally {
+        dateNowSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('appendToolOutcome', () => {

--- a/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
+++ b/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
@@ -233,7 +233,9 @@ describe('ChatSessionStore — AssistantTurn extensions', () => {
       expect(lastStep.toolCalls).toEqual(calls);
       expect(lastStep.toolOutcomes).toEqual([outcome]);
       // Single-writer invariant: ids match by construction.
-      expect(lastStep.toolCalls?.[0].id).toBe(lastStep.toolOutcomes?.[0].callId);
+      expect(lastStep.toolCalls?.[0].id).toBe(
+        lastStep.toolOutcomes?.[0].callId,
+      );
     });
 
     it('replaces (does not merge) the active step toolCalls', async () => {

--- a/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
+++ b/src/store/__tests__/ChatSessionStore.assistantTurn.test.ts
@@ -186,6 +186,121 @@ describe('ChatSessionStore — AssistantTurn extensions', () => {
     });
   });
 
+  describe('appendToolCall', () => {
+    it('writes step.toolCalls with ids that match outcomes appended afterwards', async () => {
+      const turn = makeAssistantTurn([
+        {content: 'preamble'},
+        {content: 'thinking', partial: true},
+      ]);
+      chatSessionStore.sessions = [
+        {
+          id: 'session1',
+          title: 'Session',
+          date: '',
+          messages: [turn],
+          completionSettings: defaultCompletionSettings,
+          settingsSource: 'pal',
+        },
+      ];
+      chatSessionStore.activeSessionId = 'session1';
+
+      // Runner-normalized calls (synthetic ids reconciled).
+      const calls = [
+        {
+          id: 'call_seed_0',
+          type: 'function' as const,
+          function: {name: 'calculate', arguments: '{}'},
+        },
+      ];
+      await chatSessionStore.appendToolCall(turn.id, 'session1', calls);
+
+      // Outcome arrives with the same id (runner uses the same
+      // normalized id for both events).
+      const outcome: AgentToolOutcome = {
+        callId: 'call_seed_0',
+        toolName: 'calculate',
+        result: {type: 'text', summary: '42'},
+        responseContent: '42',
+      };
+      await chatSessionStore.appendToolOutcome(turn.id, 'session1', outcome);
+
+      const updated = chatSessionStore.sessions[0]
+        .messages[0] as MessageType.AssistantTurn;
+      // Earlier step untouched.
+      expect(updated.steps[0]).toEqual({content: 'preamble'});
+      // Last step has both toolCalls and the outcome with matching id.
+      const lastStep = updated.steps[1];
+      expect(lastStep.toolCalls).toEqual(calls);
+      expect(lastStep.toolOutcomes).toEqual([outcome]);
+      // Single-writer invariant: ids match by construction.
+      expect(lastStep.toolCalls?.[0].id).toBe(lastStep.toolOutcomes?.[0].callId);
+    });
+
+    it('replaces (does not merge) the active step toolCalls', async () => {
+      // Even if a stale toolCalls array somehow exists on the active
+      // step, appendToolCall replaces it wholesale with the runner's
+      // authoritative list.
+      const stale = [
+        {
+          id: 'stale',
+          type: 'function' as const,
+          function: {name: 'old', arguments: '{}'},
+        },
+      ];
+      const turn = makeAssistantTurn([
+        {content: 'thinking', partial: true, toolCalls: stale},
+      ]);
+      chatSessionStore.sessions = [
+        {
+          id: 'session1',
+          title: '',
+          date: '',
+          messages: [turn],
+          completionSettings: defaultCompletionSettings,
+          settingsSource: 'pal',
+        },
+      ];
+      chatSessionStore.activeSessionId = 'session1';
+
+      const fresh = [
+        {
+          id: 'call_fresh_0',
+          type: 'function' as const,
+          function: {name: 'calculate', arguments: '{}'},
+        },
+      ];
+      await chatSessionStore.appendToolCall(turn.id, 'session1', fresh);
+
+      const updated = chatSessionStore.sessions[0]
+        .messages[0] as MessageType.AssistantTurn;
+      expect(updated.steps[0].toolCalls).toEqual(fresh);
+    });
+
+    it('returns silently when there are no steps yet', async () => {
+      const turn = makeAssistantTurn([]);
+      chatSessionStore.sessions = [
+        {
+          id: 'session1',
+          title: '',
+          date: '',
+          messages: [turn],
+          completionSettings: defaultCompletionSettings,
+          settingsSource: 'pal',
+        },
+      ];
+      chatSessionStore.activeSessionId = 'session1';
+
+      await chatSessionStore.appendToolCall(turn.id, 'session1', [
+        {
+          id: 'c0',
+          type: 'function',
+          function: {name: 'calculate', arguments: '{}'},
+        },
+      ]);
+      expect(chatSessionRepository.updateMessage).not.toHaveBeenCalled();
+    });
+  });
+
   describe('finalizeActiveStep', () => {
     it('marks the last step as partial=false and persists wholesale', async () => {
       const turn = makeAssistantTurn([

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -17,10 +17,26 @@ import type {TalentResult} from '../services/talents/types';
  * in memory and serialize back to string at the wire boundary in
  * `convertToChatMessages`.
  */
+/**
+ * Generation-side metrics for a tool call: how much work the model
+ * did to produce the call's `arguments` JSON, NOT how long the
+ * engine took to execute it. Surfaced post-hoc by the chip / preview
+ * footer so the user can see the "cost" of a tool call after it
+ * lands. Optional — older persisted calls (or steps where multi-tool
+ * accounting isn't useful) may carry no metrics.
+ */
+export interface AgentToolCallMetrics {
+  /** Streaming token events the runner counted while this call was being generated. */
+  tokens: number;
+  /** Wall-clock ms between the first generation token and step finalisation. */
+  durationMs: number;
+}
+
 export interface AgentToolCall {
   id: string;
   type?: 'function';
   function: {name: string; arguments: string | Record<string, unknown>};
+  metrics?: AgentToolCallMetrics;
 }
 
 /**


### PR DESCRIPTION
## Summary

- One footer per AssistantTurn (timing + copy) — fixes the duplicate-footer bug; chrome moves out of `Bubble` into a new turn-level `AssistantTurnFooter`, owned by `Message`.
- Subtle dot-row `PendingIndicator` below the latest turn, owned by `ChatView` — covers every dead zone (`prefill`, `generating_tool_call`, `executing_tool`, follow-up `prefill`); replaces `LoadingBubble` from chat.
- Visible feedback for tool calls without a registered UI: `ToolUsedChip` ("used X") for plain successes (e.g. datetime, calculate) and `ToolErrorBlock` ("X failed") for failed outcomes — both low-prominence, single-line, theme-aware.
- Reasoning rendered as its own per-step block before content (D3); `ThinkingBubble` PARTIAL default preserved.
- State machine cleaned up: `preparing` → `prefill`; `streaming_followup` collapsed into `streaming_text`; follow-up routes through `prefill` so the indicator covers phase 7 of Scenario I.
- Latent id-reconciliation bug from PR #709 fixed by construction: `step.toolCalls` is now appended once after `step_finished` with the runner's normalized synthetic ids, so `step.toolCalls[i].id === step.toolOutcomes[i].callId` always holds.

## Stacked-PR note

This PR is **stacked on PR #709** (`feature/TASK-20260502-2115`, the AssistantTurn data-shape refactor). It cannot merge until #709 lands. After #709 squash-merges to main, this branch will need to be rebased onto main before merge.

## Architecture doc

This story bootstraps the cumulative architecture library — `context/architecture/chat-flow.md` is the first flow doc under the new pipeline. The doc lives in the dev-team workflow repo (it cannot live in the same git PR as the app code), and the cross-repo SHA-link convention is established here:

- Architecture doc bootstrap: `dev-team@baeb825` (`docs(architecture): bootstrap chat-flow.md from TASK-20260504-2320 WHAT`)

The doc absorbs the WHAT delta (all `(P)` markers promoted to `(C)`; §10 retained per `templates/what-template.md`).

## Story

- TASK-20260504-2320 (this PR)
- Depends on TASK-20260502-2115 (PR #709)

## Test plan

### Automated

- [x] `yarn lint` — no new errors (6 pre-existing prettier errors in `HtmlPreviewBubble`/`PalSheet`/`SidebarContent`/`utils/index.ts` are inherited from base; no files in this PR's diff regress lint)
- [x] `yarn typecheck` — passes
- [x] `yarn test --coverage` — 162 suites, 2135 passed, 2 skipped, 0 failures
- [x] Coverage 69.96% / 63.77% / 67.37% / 70.02% (all above the 60% threshold)
- [x] Canonical scenarios A–G covered by `Message.assistantTurn.test.tsx`; H + I covered by `ChatView.assistantTurn.test.tsx`
- [x] Per-frame id-match invariant covered by `useChatSession.assistantTurn.test.ts`
- [x] PendingIndicator no-flicker invariant (50-token burst stays non-pending) covered by reducer + ChatView tests
- [x] Persistence load with deleted talent (§9c) and multi-tool partial completion (§9e) covered

### Visual capture (manual reviewer step)

Per `docs/workflows/visual-capture.md`, the visual-capture E2E spec must be run from a build environment. Reviewer runs:

```sh
yarn ios:build:e2e
cd e2e
VISUAL_CAPTURES='[…]' yarn e2e:ios --spec visual-capture --skip-build
```

The `VISUAL_CAPTURES` payload is documented in `workflows/stories/TASK-20260504-2320/how.md` (§ Visual Confirmation). For each scenario the reviewer should verify the `look_for` checklist:

- [ ] **A — text only**: single text bubble + ONE footer (timing + copy); no tool blocks; no dot indicator after settle.
- [ ] **B — datetime, no UI**: text preamble → subtle "used datetime" chip → text follow-up → ONE footer.
- [ ] **C — render_html with preamble + follow-up**: preamble → HtmlPreviewBubble → follow-up → ONE footer; no duplicate timings.
- [ ] **D — render_html, no preamble**: HtmlPreviewBubble first → text follow-up → ONE footer (no empty leading bubble).
- [ ] **E — tool failed**: preamble → subtle "render_html failed" inline error block → apology → ONE footer.
- [ ] **F — reasoning + content**: ThinkingBubble in PARTIAL → content bubble → ONE footer; chevron toggles PARTIAL ↔ EXPANDED ↔ COLLAPSED.
- [ ] **G — multi-tool**: preamble → two HtmlPreviewBubble blocks in array order → ONE footer.
- [ ] **H — abort with partial content**: partial bubble preserved → footer with copy only (no timing) → "completion stopped" system row.
- [ ] **I — dead-zone phases**: dot indicator visible in `prefill` (phase 2) / `generating_tool_call` (phase 4) / `executing_tool` (phase 5) / follow-up `prefill` (phase 7); hidden in `streaming_text` and `done`.

## Native verification

Not applicable — `NATIVE_CHANGES=NO`. No `package.json`, `ios/`, `android/`, Podfile, or `build.gradle` changes (verified: `git diff --name-only feature/TASK-20260502-2115..HEAD` contains no native paths).

## Documented deviations from HOW

Three small deviations were applied during implementation; all are documented in `how.md`'s handoff and (where structural) absorbed into `chat-flow.md`:

1. **Reducer `case 'token'` extension** — HOW assumed the existing token handler auto-flipped `prefill → streaming_text` on first content/reasoning token; it did not. Added a minimal extension. Aligns with WHAT §3 / Scenario I phase 8.
2. **Sender-name stays in `TextMessage`** — WHAT D9's literal "AssistantTurnFooter handles sender-name universally" would visually move the name from above the bubble to below it, a UX regression. Footer keeps timing + copy only; sender-name remains above the first text block. Documented in `chat-flow.md` §4b.
3. **`isFirstBlock` book-keeping retained** — `showName` is a per-row gate that has to apply to the first text block of a multi-step turn; dropping the flag entirely would render the sender-name above every text block.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)