### PR TITLE
chore(deps): bump react-native-speech 2.2.2 → 2.3.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3140,7 +3140,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNSpeech (2.2.2):
+  - RNSpeech (2.3.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3812,7 +3812,7 @@ SPEC CHECKSUMS:
   RNReanimated: 8f0185df21f0dea34ee8c9611ba88c17a290ed9a
   RNScreens: d6413aeb1878cdafd3c721e2c5218faf5d5d3b13
   RNShare: 81b8cfb58b1460c4a197d5379934bdf70980c124
-  RNSpeech: aa86fc1e5c1955b5d992f1d7f2ca99fbb4cd043c
+  RNSpeech: e337650c311b45d84d1debc6ae08cd266522ed07
   RNSVG: 82979f324e1cbf99f558a04e66f574a568ed54c0
   RNVectorIcons: e355dd0998d6b9020e560922a66614eb9636501b
   RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@gorhom/bottom-sheet": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@nozbe/watermelondb": "^0.28.0",
-    "@pocketpalai/react-native-speech": "2.2.2",
+    "@pocketpalai/react-native-speech": "2.3.1",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/slider": "^5.0.1",

--- a/src/services/tts/engines/kitten/__tests__/KittenEngine.test.ts
+++ b/src/services/tts/engines/kitten/__tests__/KittenEngine.test.ts
@@ -168,7 +168,7 @@ describe('KittenEngine', () => {
           modelPath: expect.stringMatching(/^file:\/\/.*kitten\.onnx$/),
           voicesPath: expect.stringMatching(/voices-manifest\.json$/),
           dictPath: expect.stringMatching(/en-us\.bin$/),
-          executionProviders: 'cpu',
+          executionProviders: ['cpu'],
         }),
       );
       expect(Speech.speak).toHaveBeenCalledWith('hello', anyVoice.id);

--- a/src/services/tts/engines/kitten/index.ts
+++ b/src/services/tts/engines/kitten/index.ts
@@ -153,7 +153,7 @@ export class KittenEngine implements Engine {
       modelPath: `file://${modelDir}/kitten.onnx`,
       voicesPath: `file://${modelDir}/voices-manifest.json`,
       dictPath: `file://${modelDir}/${TTS_DICT_FILENAME}`,
-      executionProviders: 'cpu',
+      executionProviders: ['cpu'],
       maxChunkSize: 200,
       silentMode: 'obey',
       ducking: true,

--- a/src/services/tts/engines/kokoro/__tests__/KokoroEngine.test.ts
+++ b/src/services/tts/engines/kokoro/__tests__/KokoroEngine.test.ts
@@ -246,7 +246,7 @@ describe('KokoroEngine', () => {
           tokenizerPath: expect.stringMatching(/tokenizer\.json$/),
           voicesPath: expect.stringMatching(/voices-manifest\.json$/),
           dictPath: expect.stringMatching(/en-us\.bin$/),
-          executionProviders: 'cpu',
+          executionProviders: ['cpu'],
         }),
       );
       expect(Speech.speak).toHaveBeenCalledWith('hello', anyVoice.id);

--- a/src/services/tts/engines/kokoro/index.ts
+++ b/src/services/tts/engines/kokoro/index.ts
@@ -31,9 +31,10 @@ export type KokoroProgressCallback = (progress: number) => void;
  *      manifest is (re)written at the end to point at the full voice
  *      catalog.
  *
- * CPU-only execution is forced (`executionProviders: 'cpu'`) across all
+ * CPU-only execution is forced (`executionProviders: ['cpu']`) across all
  * three neural engines for consistent battery/thermal behavior and easier
- * QA.
+ * QA. The library default on iOS would otherwise include CoreML; we keep
+ * it bare CPU for now.
  */
 export class KokoroEngine implements Engine {
   readonly id = 'kokoro' as const;
@@ -216,7 +217,7 @@ export class KokoroEngine implements Engine {
       tokenizerPath: `file://${modelDir}/tokenizer.json`,
       voicesPath: `file://${modelDir}/${KOKORO_VOICES_MANIFEST_FILENAME}`,
       dictPath: `file://${modelDir}/${TTS_DICT_FILENAME}`,
-      executionProviders: 'cpu',
+      executionProviders: ['cpu'],
       maxChunkSize: 200,
       silentMode: 'obey',
       ducking: true,

--- a/src/services/tts/engines/supertonic/__tests__/SupertonicEngine.test.ts
+++ b/src/services/tts/engines/supertonic/__tests__/SupertonicEngine.test.ts
@@ -222,6 +222,7 @@ describe('SupertonicEngine (v1.2 real)', () => {
           ),
           vocoderPath: expect.stringMatching(/^file:\/\/.*vocoder\.onnx$/),
           voicesPath: expect.stringMatching(/voices-manifest\.json$/),
+          executionProviders: ['cpu'],
         }),
       );
       expect(Speech.speak).toHaveBeenCalledWith('hello', anyVoice.id, {

--- a/src/services/tts/engines/supertonic/index.ts
+++ b/src/services/tts/engines/supertonic/index.ts
@@ -251,7 +251,7 @@ export class SupertonicEngine implements Engine {
       silentMode: 'obey',
       ducking: true,
       maxChunkSize: 200,
-      executionProviders: 'cpu',
+      executionProviders: ['cpu'],
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,10 +2153,10 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@pocketpalai/react-native-speech@2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@pocketpalai/react-native-speech/-/react-native-speech-2.2.2.tgz#b61ee6cff8f90773f4bb5c0630ac5dd4d5b01187"
-  integrity sha512-XiV4jBZFxa3EwRE2m7sz88KGXSu9toM+yCwZokgxW0JP6Mg7Y+Vfu5Oc3JZ0PoBB070zX6zVnMOaqH/dLl+dxw==
+"@pocketpalai/react-native-speech@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@pocketpalai/react-native-speech/-/react-native-speech-2.3.1.tgz#7fd0fa9167da4985dd6a4227ac41f22226074b12"
+  integrity sha512-U1az9eIwNFi/3RC+3JaIGpR8/qhCs4ou8E6z0owVVbvXSVpiNlMFZITzh3mX1Tk9bShNuWdl+rWqpKkfFKpgoA==
   dependencies:
     phonemize "^1.1.0"
 


### PR DESCRIPTION
## Summary

Bump `@pocketpalai/react-native-speech` from 2.2.2 to 2.3.1. Two upstream changes land in this jump:

### 2.3.0 — markdown stripping + engine hardening
- Markdown in LLM streams (`**bold**`, headers, tables, lists, hrules, etc.) is now stripped before chunking on both `Speech.speak` (non-streaming) and `Speech.createSpeechStream` paths. No code change on our side; the default is on.
- Empty-buffer engine streams no longer kill the session.
- Kitten: BERT crashes on oversized chunks are gone (split-and-recurse); near-empty chunks are skipped.
- Kokoro on Android: `'cpu'` EP previously remapped to `['xnnpack', 'cpu']` internally to dodge a silent-audio bug on bare CPU. **2.3.0 also reshaped the `executionProviders` API** from a string preset to `ExecutionProvider[]`, so consumers now pass exactly what they want.

### 2.3.1 — iOS silent-switch fix
- `silentMode: 'obey'` previously mapped to `AVAudioSessionCategorySoloAmbient` on iOS, which silenced neural TTS when the device ringer was muted (no diagnostic). Now maps to `AVAudioSessionCategoryPlayback` (matches OS-native path + standard TTS library conventions). `'respect'` is still available for callers who want the switch to mute.

## API migration applied

`executionProviders: 'cpu'` (string) → `executionProviders: ['cpu']` (array) in all three neural engines + their tests:
- `src/services/tts/engines/kokoro/index.ts`
- `src/services/tts/engines/supertonic/index.ts`
- `src/services/tts/engines/kitten/index.ts`

## CoreML guard

The new iOS default if `executionProviders` is omitted is `[{name: 'coreml', coreMlFlags: DEFAULT_COREML_FLAGS}, 'xnnpack', 'cpu']` — so omitting the field would now opt us into CoreML. We explicitly pass `['cpu']` to keep all three engines CPU-only across both platforms. Worth a note in the doc comment in `kokoro/index.ts` so future engine additions don't accidentally inherit CoreML.

Why CPU-only for now: Kokoro FP16 produces silent audio on both bare CPU and xnnpack in some scenarios (the FP32 swap in #717 fixes that for Kokoro). Supertonic and Kitten have not been validated against the new EP combinations. Sticking to bare CPU is the conservative path until we have device-matrix data.

## Test plan

- [x] `yarn typecheck` — clean (3 expected errors resolved)
- [x] `yarn lint` — 0 errors on changed files
- [x] `yarn test` — 2111 passed / 2 skipped / 158 suites
- [x] `bundle exec pod install` — succeeded
- [x] iOS Debug build (simulator) — `Build Succeeded`
- [x] Android Debug build (`./gradlew assembleDebug`) — `BUILD SUCCESSFUL`
- [ ] Manual verification on device — confirm neural TTS still plays cleanly on iOS + Android, and that iOS plays through silent switch (new 2.3.1 default).

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)