### PR TITLE
chore(deps): upgrade llama.rn to 0.12.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.0-rc.9):
+  - llama-rn (0.12.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3720,7 +3720,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 3abe0ea5bfd118e3cb7b0d70f01c6b206ce230bf
+  llama-rn: 06746f8446934552120be0c0c30286f425181b0c
   onnxruntime-c: 4a1a1a81da2087869dc9b6357f182952db2df29c
   onnxruntime-react-native: 4451eff6b1aa60589186c6a8422d436fba6a9192
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.12.0-rc.9",
+    "llama.rn": "0.12.0",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,10 +6515,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.0-rc.9:
-  version "0.12.0-rc.9"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0-rc.9.tgz#1f90a1a0bebc0c07ed39032cfa93ff4c6a69e571"
-  integrity sha512-6qmo0sOGs7mk7stAGPtQ13R002yV2sYWR5z0YmUNlBUWVeOVeSXfsG2CTAfbyEr6fjXhFNgZVPYEt0Hd7Yd27A==
+llama.rn@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0.tgz#115e0de1769e93c023ade4a6387e6ceea3bd7882"
+  integrity sha512-RDcY1wVxARBblNmYUncAfSrKnyPtCVwZFtERhyL9oZBcZshMK+p2/yjNYHvnU6UEokTlHUFFqGp+3CUcUJpVtQ==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

Routine native-dependency version bump: `llama.rn` `0.12.0-rc.9` → `0.12.0` (stable).

Same shape as PR #689 (rc.5 → rc.8), PR #664 (rc.2 → rc.3), and PR #608 (0.11.0 → 0.11.3): exactly three files touched and no app-side code changes.

## What ships with 0.12.0

- **llama.cpp bump** `b8827` → `b9084` (257 commits, 2026-04-17 → 2026-05-09). Highlights relevant to PocketPal:
  - **OpenCL / Adreno** — IQ4_NL support ([ggml-org/llama.cpp#22272](https://github.com/ggml-org/llama.cpp/pull/22272), closes #721), Adreno MoE optimizations (MxFP4, q4_0 GEMM), q4_0 refactor.
  - **Hexagon HTP** — HMX flash attention, HMX M-tail row processing, L2-norm / GATED_DELTA_NET / SOLVE_TRI / FILL / DAIG kernels, configurable vmem & buffer size.
  - **Metal** — `GGML_OP_MUL_MAT` Tensor API optimization, macOS GPU watchdog workaround, event-sync fix.
  - **General** — `llama : add option to save memory in device buffers` ([#22679](https://github.com/ggml-org/llama.cpp/pull/22679)), graceful error on unsupported architecture, recurrent state serialization fix.
  - **New models** — Mimo v2.5, MiniCPM-V 4.6, Sarashina2.2-vision-3b, Reka Edge 2603, Granite Speech 4.0-1b, Gemma4 family detection & NVFP4 variant.
- **`fix(cpp, jsi): avoid blocking ui during backend init`** ([mybigday/llama.rn@09e69c2](https://github.com/mybigday/llama.rn/commit/09e69c23d62d8b5f931257ac9a8b5fb8a054070a)) — backend init + device probing moved off the JS thread, reducing UI jank during first `initContext`.

## Changes

- `package.json` — pin bumped to `0.12.0`
- `yarn.lock` — only the `llama.rn@…` entry resolved to the stable tarball; no unrelated drift
- `ios/Podfile.lock` — `llama-rn (0.12.0)` with refreshed checksum `3abe0ea5…` → `06746f84…`; no other pods drift

## Verification (NATIVE_CHANGES=YES)

- `pod install` — clean (Podfile.lock committed)
- iOS Release build (`yarn ios:build:e2e`) — PASS (`.app` artefact in worktree)
- Android Release build (`./gradlew assembleRelease`) — PASS (`app-prod-release.apk` in worktree)
- E2E `quick-smoke` on iPhone 17 Pro Simulator — 1/1 PASS (smollm2-135m loaded + streamed tokens through the new native bridge), `e2e/reports/2026-05-12T08-02-52-111/summary.json`
- Lint — 0 errors (4 pre-existing warnings)
- TypeCheck — PASS
- Jest — 159 suites / 2222 passed / 2 skipped / 0 failed; coverage 70.62% statements, 70.67% lines

Story: TASK-20260512-0948

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)