### PR TITLE
[Bug]: Move iOS workflows to macOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
 
   # Job for iOS build
   build-ios:
-    runs-on: macos-15  # macOS 15 with Xcode 16
+    runs-on: macos-26  # Keep CI on the same Xcode major as the release workflow
     needs: [build-and-test, detect-changes]
     if: needs.detect-changes.outputs.translation_only != 'true'
     env:
@@ -346,6 +346,11 @@ jobs:
           cd ios
           pod install
           cd ..
+
+      - name: Select default Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app
+          xcodebuild -version
 
       - name: Build iOS Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
 
   # Job 2: iOS Build and Upload (runs on macOS)
   build_ios:
-    runs-on: macos-15 # macOS 15 with Xcode 16
+    runs-on: macos-26 # macOS 26 includes an iOS 26-capable Xcode toolchain
     needs: build_android
     if: ${{ always() && (needs.build_android.result == 'success' || needs.build_android.result == 'skipped') }}
     env:
@@ -164,10 +164,12 @@ jobs:
           ref: ${{ github.ref }}    # This ensures we get the latest changes including the version bump
           fetch-depth: 0
 
-      # Step 1: Setup Xcode to use the correct version
+      # Step 1: Select the default Xcode shipped on macOS 26.
+      # App Store Connect now requires uploads built with the iOS 26 SDK or later.
       - name: Setup Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.4.app
+          sudo xcode-select -s /Applications/Xcode.app
+          xcodebuild -version
 
       # Step 2: Set up Node.js
       - name: Set up Node.js


### PR DESCRIPTION
## Summary
- move the release iOS job to the GitHub Actions \ image
- switch the release Xcode selection off the hard-coded \ path and print the selected Xcode version
- align the regular iOS CI job to the same macOS/Xcode major so CI and release do not drift

## Verification
- parsed \ and \ successfully with Ruby YAML loading

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)