### PR TITLE
chore(deps): upgrade llama.rn to 0.12.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.0):
+  - llama-rn (0.12.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3720,7 +3720,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 06746f8446934552120be0c0c30286f425181b0c
+  llama-rn: 30cce807803745c870de7878dfd62f8b89836330
   onnxruntime-c: 4a1a1a81da2087869dc9b6357f182952db2df29c
   onnxruntime-react-native: 4451eff6b1aa60589186c6a8422d436fba6a9192
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "chat-formatter": "^0.3.4",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
-    "llama.rn": "0.12.0",
+    "llama.rn": "0.12.1",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,10 +6515,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.0.tgz#115e0de1769e93c023ade4a6387e6ceea3bd7882"
-  integrity sha512-RDcY1wVxARBblNmYUncAfSrKnyPtCVwZFtERhyL9oZBcZshMK+p2/yjNYHvnU6UEokTlHUFFqGp+3CUcUJpVtQ==
+llama.rn@0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.1.tgz#1e9c5d6ae24edffc5bafa5902b403af99b7b9122"
+  integrity sha512-oJG/2e8AHskcpVcenPx8riMq2Gc/hQx9Q6OdVi73gYKyF3/c32zZbaeWP+wfkBtSf4jO1VFFhcecaUz/29CvBw==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

Patch-level dependency bump: **llama.rn `0.12.0` → `0.12.1`**. Dependency-only — no PocketPal source files changed.

Diff footprint (on-pattern with prior llama.rn upgrades `0614148`, `f91144d`, `d4130b4`):

```diff
package.json     llama.rn 0.12.0 -> 0.12.1
yarn.lock        llama.rn tarball/integrity updated to 0.12.1
ios/Podfile.lock llama-rn 0.12.0 -> 0.12.1
                 checksum 06746f8446934552120be0c0c30286f425181b0c
                       -> 30cce807803745c870de7878dfd62f8b89836330
```

## Version mapping (verified against upstream)

| | llama.rn | llama.cpp build |
| --- | --- | --- |
| PocketPal baseline (`origin/main`, PR #722 `d4130b4`) | `0.12.0` | `b9084` |
| This PR | `0.12.1` | `b9204` |

Effective app-facing llama.cpp delta: **`b9084 → b9204`** (120 commits). Sources: [v0.12.0](https://github.com/mybigday/llama.rn/releases/tag/v0.12.0) · [v0.12.1](https://github.com/mybigday/llama.rn/releases/tag/v0.12.1) · [llama.cpp b9084…b9204](https://github.com/ggml-org/llama.cpp/compare/b9084...b9204)

## Changelog relevant to PocketPal

Of the 120 llama.cpp commits, the large majority are desktop/server-only and **do not affect PocketPal**: SYCL/Intel, CUDA/HIP (NVIDIA/AMD), Vulkan, WebGPU, ZenDNN/SpacemiT, multi-GPU NCCL/AllReduce, `llama-server`/router, WebUI restructure, speculative-decoding/MTP, llama-eval/AIME, docker/CI/docs, and GGUF conversion scripts (PocketPal consumes prebuilt GGUFs). The subset that reaches the app via the llama.rn JSI bridge (iOS Metal / Android OpenCL-Adreno / Hexagon):

**Chat formatting & structured output**
- **llama.rn 0.12.1 itself:** `pass response_format through chat formatting (#340)` — `response_format` (JSON-schema / structured output) is now forwarded into the chat-formatting path. Most directly relevant change for PocketPal Pals / structured-output flows.
- `common : enable streaming JSON argument values (#23173)` — streaming of tool-call JSON argument values.
- `common : delegate assistant continuation to underlying template handlers (#23089)` — assistant-prefill / continuation routed through the template handler (affects reasoning/thinking models that prefill the assistant turn).

**Tokenizer correctness (Qwen3.5)**
- `unicode,test: add Qwen3.5 non-backtracking tokenizer handler (#22110)` — fixes a potential `std::regex` stack overflow on Qwen3.5 tokenization. Relevant since PocketPal ships/benches Qwen3.5 models.

**Android — OpenCL / Adreno GPU backend**
- `opencl: fix crash when warming up MoE on Adreno (#22876)` — crash/stability fix for MoE models on Adreno.
- `opencl: add q4_1 MoE for Adreno (#22856)`, `opencl: add q5_0 and q5_1 MoE for Adreno (#22985)` — broader MoE quant coverage on Adreno.
- `opencl: add opt-in Adreno xmem F16xF32 GEMM for prefill (#22755)` — opt-in prefill speedup (off by default).

**Android — Hexagon backend**
- `hexagon: eliminate scalar VTCM loads via HVX splat helpers (#22993)` and `ggml-hexagon: cpy: add contiguous fast-path in reshape copy (#23076)` — Hexagon performance; `hexagon: add unary tanh op (#22999)` — op coverage.

**iOS — Metal backend**
- `metal : promote mul_mv/mul_mm batch divisors to function constants (#22711)` — Metal matmul tuning.

**Model loading & multimodal**
- `model : fix model type check for granite/llama3 and deepseek2/glm4.7 lite (#22870)` — corrects model-type detection for those GGUF families.
- New arch `sarvam_moe (#20275)`; `model : NvFP4 quantized LM head support (#23046)`.
- `mtmd: add chunks and fix preproc for qwen3a (#23073)` — vision preprocessing fix for qwen3a; `mtmd: add MiMo v2.5 vision (#22883)` — new vision model support.

No PocketPal-side API/contract changes are required by any of the above; the `response_format` change is internal to llama.rn's chat-formatting path and does not alter PocketPal's documented wire contract.

## Native verification (NATIVE_CHANGES=YES)

All run inside the dedicated worktree:

- `bundle exec pod install` — passed; `llama-rn` resolved to `0.12.1`
- `yarn ios:build` — passed; Build Succeeded
- `yarn build:android` — passed; BUILD SUCCESSFUL

## Targeted regression coverage

- `src/store/__tests__/ModelStore.test.ts` — passed (150/150)
- `src/utils/__tests__/completionSettingsVersions.test.ts` — passed (21/21)
- `src/__automation__/screens/__tests__/BenchmarkRunnerScreen.test.tsx` — passed (72/72)

## Architecture doc impact

None. Patch-level bump with zero PocketPal source changes; no `context/architecture/*.md` describes llama.rn version-specific behavior altered by this release.

---

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
