### PR TITLE
chore(ci): rework e2e-tests into ref-targeted Android build-only workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,22 +1,13 @@
-name: E2E Tests (AWS Device Farm)
+name: E2E Android Build (manual)
 
 on:
-  # Manual trigger with platform selection
+  # Manual trigger targeting a specific branch or commit SHA
   workflow_dispatch:
     inputs:
-      platform:
-        description: 'Platform to test'
+      ref:
+        description: 'Branch name or commit SHA to build the E2E APK from'
         required: true
-        default: 'android'
-        type: choice
-        options:
-          - android
-          - ios
-          - both
-
-  # Optionally run on main branch pushes
-  # push:
-  #   branches: [main]
+        type: string
 
 env:
   NODE_VERSION: '22'
@@ -24,11 +15,12 @@ env:
 
 jobs:
   build-android:
-    if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -121,227 +113,6 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: android-apk
+          name: e2e-android-apk
           path: android/app/build/outputs/apk/e2e/releaseE2e/app-e2e-releaseE2e.apk
-
-  build-ios:
-    if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' }}
-    runs-on: macos-15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Create Env.xcconfig
-        run: |
-          cat > ios/Config/Env.xcconfig << 'EOL'
-          // This file contains environment-specific build settings.
-
-          GOOGLE_WEB_CLIENT_ID = dummy-web-client-id.apps.googleusercontent.com
-          REVERSED_GOOGLE_IOS_CLIENT_ID = com.googleusercontent.apps.dummy-ios-client-id
-
-          EOL
-
-      - name: Create dummy .env file for CI
-        run: |
-          cat > .env << 'EOL'
-          FIREBASE_FUNCTIONS_URL=https://dummy-firebase-url.com
-          SUPABASE_URL=https://dummy-supabase-url.supabase.co
-          SUPABASE_ANON_KEY=dummy-anon-key-for-ci-builds
-          PALSHUB_API_BASE_URL=https://dummy-palshub-api.com
-          APP_URL=pocketpal://app
-          ENABLE_PALSHUB_INTEGRATION=true
-          ENABLE_AUTHENTICATION=true
-          ENABLE_OFFLINE_MODE=true
-          GOOGLE_IOS_CLIENT_ID=dummy-ios-client-id.apps.googleusercontent.com
-          GOOGLE_WEB_CLIENT_ID=dummy-web-client-id.apps.googleusercontent.com
-          EOL
-
-      - name: Create dummy GoogleService-Info.plist for CI
-        run: |
-          cat > ios/GoogleService-Info.plist << 'EOL'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>CLIENT_ID</key>
-            <string>dummy-client-id.apps.googleusercontent.com</string>
-            <key>REVERSED_CLIENT_ID</key>
-            <string>com.googleusercontent.apps.dummy-client-id</string>
-            <key>API_KEY</key>
-            <string>dummy-api-key-for-ci-builds</string>
-            <key>GCM_SENDER_ID</key>
-            <string>000000000000</string>
-            <key>PLIST_VERSION</key>
-            <string>1</string>
-            <key>BUNDLE_ID</key>
-            <string>ai.pocketpal</string>
-            <key>PROJECT_ID</key>
-            <string>dummy-project-for-ci</string>
-            <key>STORAGE_BUCKET</key>
-            <string>dummy-project-for-ci.appspot.com</string>
-            <key>IS_ADS_ENABLED</key>
-            <false/>
-            <key>IS_ANALYTICS_ENABLED</key>
-            <false/>
-            <key>IS_APPINVITE_ENABLED</key>
-            <false/>
-            <key>IS_GCM_ENABLED</key>
-            <true/>
-            <key>IS_SIGNIN_ENABLED</key>
-            <true/>
-            <key>GOOGLE_APP_ID</key>
-            <string>1:000000000000:ios:0000000000000000</string>
-          </dict>
-          </plist>
-          EOL
-
-      - name: Install CocoaPods
-        run: |
-          cd ios
-          pod install
-
-      - name: Build iOS Release IPA
-        run: |
-          cd ios
-          xcodebuild -workspace PocketPal.xcworkspace \
-            -scheme PocketPal \
-            -configuration Release \
-            -sdk iphoneos \
-            -archivePath build/PocketPal.xcarchive \
-            archive \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO
-
-          # Create IPA from archive
-          mkdir -p build/Payload
-          cp -r build/PocketPal.xcarchive/Products/Applications/PocketPal.app build/Payload/
-          cd build
-          zip -r PocketPal.ipa Payload
-
-      - name: Upload IPA artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-ipa
-          path: ios/build/PocketPal.ipa
-
-  test-android:
-    needs: build-android
-    if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Download APK artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: android-apk
-          path: ./app
-
-      - name: Install E2E dependencies
-        run: |
-          cd e2e
-          yarn install --frozen-lockfile
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Run E2E tests on AWS Device Farm
-        env:
-          AWS_DEVICE_FARM_PROJECT_ARN: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
-          AWS_DEVICE_POOL_ARN_ANDROID: ${{ vars.AWS_DEVICE_POOL_ARN_ANDROID }}
-        run: |
-          cd e2e
-          yarn test:aws --platform android --app ../app/app-e2e-releaseE2e.apk
-
-      - name: Upload test artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-test-artifacts
-          path: e2e/device-farm-artifacts/
           retention-days: 30
-
-      - name: Publish Test Results
-        if: always()
-        uses: dorny/test-reporter@v1
-        with:
-          name: Android E2E Test Results
-          path: e2e/device-farm-artifacts/**/junit*.xml
-          reporter: java-junit
-          fail-on-error: false
-
-  test-ios:
-    needs: build-ios
-    if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Download IPA artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ios-ipa
-          path: ./app
-
-      - name: Install E2E dependencies
-        run: |
-          cd e2e
-          yarn install --frozen-lockfile
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Run E2E tests on AWS Device Farm
-        env:
-          AWS_DEVICE_FARM_PROJECT_ARN: ${{ vars.AWS_DEVICE_FARM_PROJECT_ARN }}
-          AWS_DEVICE_POOL_ARN_IOS: ${{ vars.AWS_DEVICE_POOL_ARN_IOS }}
-        run: |
-          cd e2e
-          yarn test:aws --platform ios --app ../app/PocketPal.ipa
-
-      - name: Upload test artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-test-artifacts
-          path: e2e/device-farm-artifacts/
-          retention-days: 30
-
-      - name: Publish Test Results
-        if: always()
-        uses: dorny/test-reporter@v1
-        with:
-          name: iOS E2E Test Results
-          path: e2e/device-farm-artifacts/**/junit*.xml
-          reporter: java-junit
-          fail-on-error: false

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '22'
   JAVA_VERSION: '17'
@@ -21,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary

- Reworked `.github/workflows/e2e-tests.yml` into a `workflow_dispatch`-only, Android-only, build-only artifact workflow.
- Replaced the `platform` choice input with a required free-form `ref` input (branch name or commit SHA); checkout now uses `ref: ${{ inputs.ref }}`. The same input targets a release ref, so no `release.yml` change is needed.
- Deleted the `build-ios`, `test-android`, and `test-ios` jobs entirely — removing all AWS Device Farm steps, `aws-actions/configure-aws-credentials`, every `secrets.AWS_*`/`vars.AWS_*` reference, and the `dorny/test-reporter` publish steps.
- The Android E2E build steps are preserved byte-for-byte: dummy `google-services.json` (incl. the `com.pocketpalai.e2e` client), dummy `.env`, dummy release keystore, and `E2E_BUILD=true ./gradlew assembleE2eReleaseE2e`. No real `secrets.*`/`vars.*` introduced.
- APK uploaded as artifact `e2e-android-apk` with `retention-days: 30`.
- Workflow renamed to `E2E Android Build (manual)` — no AWS/Device Farm reference.

## Verification

- YAML parses cleanly (`yaml.safe_load`).
- Safety grep clean: no `secrets.`/`vars.`/`aws`/`device farm`/`dorny`/`build-ios`/`test-android`/`test-ios`/`xcodebuild`/`pod install`/`platform` tokens anywhere.
- Exactly one job (`build-android`); only `.github/workflows/e2e-tests.yml` changed (8 insertions, 237 deletions).
- Out of scope and correctly untouched: `ci.yml`, `release.yml`, iOS E2E, `tools/fetch-pr-apk.sh`/`/run-pr-e2e` wiring.
- NATIVE_CHANGES=NO; no app/TS source, so lint/typecheck/Jest are N/A (static verification per how.md).

Story: TASK-20260518-2109

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
