### PR TITLE
chore(ci): drop redundant workflow_dispatch ref input from e2e-tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,13 +1,10 @@
 name: E2E Android Build (manual)
 
 on:
-  # Manual trigger targeting a specific branch or commit SHA
+  # Manual trigger. Pick the branch/tag to build via the GitHub
+  # "Use workflow from" selector (or `gh workflow run --ref <branch>`);
+  # checkout below builds whatever ref the run was dispatched on.
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Branch name or commit SHA to build the E2E APK from'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -23,7 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup Java


### PR DESCRIPTION
## What

Follow-up to #729 (merged). Removes the `workflow_dispatch` `ref` input from `.github/workflows/e2e-tests.yml` and lets `actions/checkout` default to the dispatched ref. **Scope: this one 3-line change only** (+3 / −7); branched off current `main` so the diff is exactly the ref-input removal.

> Replaces #730, which was accidentally built on an orphaned base (#729 was squash-merged, so #730's diff spuriously re-included the whole rework). This PR has the correct minimal diff.

## Why

The custom `ref` input duplicated GitHub's built-in **"Use workflow from"** ref selector for the normal "build this branch" flow. It was also inconsistent with the E2E consumer: `tools/fetch-pr-apk.sh --e2e` matches dispatch runs by `head_branch` (the dispatched ref, which the API exposes) — `workflow_dispatch` *input* values are not exposed by the GitHub API at all. Removing the input makes producer and consumer consistent by construction.

Trade-off: bare-commit-SHA targeting via the input is dropped. Branch/tag selection (UI selector or `gh workflow run --ref <branch>`) still works and covers the merge-ready-PR and release-tag cases.

## Verification

- Diff vs `main` is exactly +3 / −7 in `e2e-tests.yml` (ref input + `ref:` line + comment).
- YAML parses; `permissions: contents: read` and the dummy-config E2E build (`com.pocketpalai.e2e`, dummy keystore, `E2E_BUILD=true ./gradlew assembleE2eReleaseE2e`) unchanged.
- Safety grep clean: no `secrets.*` / `vars.*` / AWS / dorny / iOS / leftover `inputs.ref`.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)