### PR TITLE
[Feat]: non-touch autostart deep link for bench E2E matrix

### DIFF
--- a/e2e/helpers/bench-runner.ts
+++ b/e2e/helpers/bench-runner.ts
@@ -71,8 +71,13 @@ export function pushConfig(
 }
 
 export async function deepLinkLaunch(): Promise<void> {
+  // `?autostart=1` makes the runner screen self-start its matrix run with no
+  // injected tap. This is the fix for HyperOS / MediaTek devices, where the
+  // OS silently drops `adb shell input tap` (and WDIO's analogous .click()),
+  // so a tap-driven start never fired onPress. The screen now invokes the
+  // exact same start handler the button does.
   await driver.execute('mobile: deepLink', {
-    url: 'pocketpal://e2e/benchmark',
+    url: 'pocketpal://e2e/benchmark?autostart=1',
     package: PACKAGE,
   });
 }

--- a/e2e/specs/benchmark-matrix.spec.ts
+++ b/e2e/specs/benchmark-matrix.spec.ts
@@ -65,20 +65,49 @@ describe('Benchmark Matrix', () => {
     const status = await driver.$(byTestId('bench-runner-screen-status'));
     await status.waitForDisplayed({timeout: 30_000});
 
+    const readStatus = async (): Promise<string | null> =>
+      (await status.getAttribute('content-desc').catch(() => null)) ??
+      (await status.getText().catch(() => null));
+
+    // Fast-fail diagnostic: with autostart=1 the screen must leave `idle`
+    // within seconds of mount. If it doesn't, the autostart param never
+    // reached the screen — fail in 30s with that specific signal instead
+    // of burning the full BENCH_MAX_WAIT_MIN on a silent timeout.
+    let lastObserved: string | null = await readStatus();
+    try {
+      await browser.waitUntil(
+        async () => {
+          lastObserved = await readStatus();
+          return typeof lastObserved === 'string' && lastObserved !== 'idle';
+        },
+        {timeout: 30_000, interval: 1_000},
+      );
+    } catch {
+      // Rethrow with the actual last-observed status interpolated. (WDIO's
+      // own timeoutMsg is a static string built before the wait starts, so
+      // it cannot include the value of `lastObserved` at timeout time.)
+      throw new Error(
+        `autostart did not leave 'idle' within 30s (last status=${lastObserved ?? 'null'}). The screen mounted but the autostart deep-link param never triggered onRun — likely a regression in the deep-link param plumbing or the screen's once-per-mount effect.`,
+      );
+    }
+
     const deadline = Date.now() + MAX_WAIT_MS;
     let terminal: string | null = null;
     while (Date.now() < deadline) {
       await browser.pause(POLL_MS);
-      const s =
-        (await status.getAttribute('content-desc').catch(() => null)) ??
-        (await status.getText().catch(() => null));
+      const s = await readStatus();
+      if (typeof s === 'string') {
+        lastObserved = s;
+      }
       if (s === 'complete' || (typeof s === 'string' && s.startsWith('error:'))) {
         terminal = s;
         break;
       }
     }
     if (!terminal) {
-      throw new Error(`No terminal state within ${MAX_WAIT_MS / 60_000} min`);
+      throw new Error(
+        `No terminal state within ${MAX_WAIT_MS / 60_000} min (last status=${lastObserved ?? 'null'}).`,
+      );
     }
 
     const localFile = pullLatestReport(outDir, udid);

--- a/e2e/specs/benchmark-matrix.spec.ts
+++ b/e2e/specs/benchmark-matrix.spec.ts
@@ -4,7 +4,8 @@
  * Drives the in-app BenchmarkRunnerScreen across {models} x {quants} x
  * {backends}. The screen owns the matrix loop, downloads, init/release,
  * peak-memory tracking, and JSON writing. This spec just pushes a config,
- * deep-links the screen, taps Run, polls status, and pulls the JSON.
+ * deep-links the screen with `?autostart=1` (which self-starts the run, no
+ * tap), polls status, and pulls the JSON.
  *
  *   yarn e2e --platform android --spec benchmark-matrix --skip-build
  *   BENCH_MODELS=qwen3-1.7b BENCH_QUANTS=q4_0 BENCH_BACKENDS=gpu yarn e2e ...
@@ -57,12 +58,13 @@ describe('Benchmark Matrix', () => {
   it('runs the matrix and writes a JSON report', async function (this: Mocha.Context) {
     this.timeout(MAX_WAIT_MS + 60_000);
 
-    const runBtn = await driver.$(byTestId('bench-run-button'));
-    await runBtn.waitForDisplayed({timeout: 30_000});
-
-    await runBtn.click();
-
+    // No tap: the deep link carried `?autostart=1`, so the screen self-starts
+    // the matrix once it mounts (the fix for HyperOS / MediaTek dropping
+    // injected taps). We just wait for the status element to appear, then
+    // poll it for a terminal state — no `bench-run-button` interaction.
     const status = await driver.$(byTestId('bench-runner-screen-status'));
+    await status.waitForDisplayed({timeout: 30_000});
+
     const deadline = Date.now() + MAX_WAIT_MS;
     let terminal: string | null = null;
     while (Date.now() < deadline) {

--- a/src/__automation__/__tests__/benchmarkRoute.test.ts
+++ b/src/__automation__/__tests__/benchmarkRoute.test.ts
@@ -1,9 +1,6 @@
-import {
-  isBenchmarkRunnerUrl,
-  parseBenchmarkAutostart,
-} from '../navigationConstants';
+import {isBenchmarkRunnerUrl, parseBenchmarkAutostart} from '../benchmarkRoute';
 
-describe('navigationConstants', () => {
+describe('benchmarkRoute', () => {
   describe('isBenchmarkRunnerUrl', () => {
     it('matches the bare bench URL', () => {
       expect(isBenchmarkRunnerUrl('pocketpal://e2e/benchmark')).toBe(true);

--- a/src/__automation__/__tests__/deepLink.test.ts
+++ b/src/__automation__/__tests__/deepLink.test.ts
@@ -99,7 +99,7 @@ describe('dispatchAutomationDeepLink', () => {
   });
 
   describe('bench host', () => {
-    it('navigates to BenchmarkRunner for pocketpal://e2e/benchmark', async () => {
+    it('navigates to BenchmarkRunner with autostart:false for pocketpal://e2e/benchmark', async () => {
       const navigate = jest.fn();
       const handled = await dispatchAutomationDeepLink(
         makeParams({
@@ -110,7 +110,42 @@ describe('dispatchAutomationDeepLink', () => {
       );
 
       expect(handled).toBe(true);
-      expect(navigate).toHaveBeenCalledWith('BenchmarkRunner');
+      // Bare URL still routes; autostart false keeps the screen idle.
+      expect(navigate).toHaveBeenCalledWith('BenchmarkRunner', {
+        autostart: false,
+      });
+    });
+
+    it('navigates with autostart:true for pocketpal://e2e/benchmark?autostart=1', async () => {
+      const navigate = jest.fn();
+      const handled = await dispatchAutomationDeepLink(
+        makeParams({
+          url: 'pocketpal://e2e/benchmark?autostart=1',
+          host: 'e2e',
+        }),
+        {navigate},
+      );
+
+      expect(handled).toBe(true);
+      expect(navigate).toHaveBeenCalledWith('BenchmarkRunner', {
+        autostart: true,
+      });
+    });
+
+    it('navigates with autostart:false for pocketpal://e2e/benchmark?autostart=0', async () => {
+      const navigate = jest.fn();
+      const handled = await dispatchAutomationDeepLink(
+        makeParams({
+          url: 'pocketpal://e2e/benchmark?autostart=0',
+          host: 'e2e',
+        }),
+        {navigate},
+      );
+
+      expect(handled).toBe(true);
+      expect(navigate).toHaveBeenCalledWith('BenchmarkRunner', {
+        autostart: false,
+      });
     });
 
     it('returns true even when no navigation is supplied (cold-launch path handles nav itself)', async () => {

--- a/src/__automation__/benchmarkRoute.ts
+++ b/src/__automation__/benchmarkRoute.ts
@@ -1,0 +1,58 @@
+// Deep-link protocol surface for the E2E benchmark runner. Owns the URL
+// prefix, the prefix matcher, and the autostart query parser — i.e. every
+// shape-bound piece of the `pocketpal://e2e/benchmark[...]` contract.
+//
+// Lives under src/__automation__/ so the automation protocol stays inside
+// the same boundary as the runner screen and the dispatch helpers. The two
+// allow-listed prod-reachable mount points (App.tsx and src/hooks/
+// useDeepLinking.ts; see the no-restricted-imports allow-list in .eslintrc)
+// are the only places outside this folder that may import from here.
+//
+// Pure module: no side effects, no logging, no navigation. The helpers
+// never throw — malformed inputs yield `false`. This keeps the import safe
+// even if a future call site lands outside an `__E2E__` branch.
+
+// Canonical deep-link URL that routes to the benchmark runner screen.
+// Used by both the useDeepLinking warm/cold-launch Linking effect (raw-URL
+// match) and the dispatchAutomationDeepLink router (DeepLinkParams match).
+export const BENCHMARK_RUNNER_URL_PREFIX = 'pocketpal://e2e/benchmark';
+
+export function isBenchmarkRunnerUrl(url: string | null | undefined): boolean {
+  return typeof url === 'string' && url.startsWith(BENCHMARK_RUNNER_URL_PREFIX);
+}
+
+// Resolve the autostart signal from a bench deep-link URL. Returns true iff
+// the URL carries `?autostart=` with a value of exactly "1" or "true"
+// (case-insensitive); any other value, or absence, is false. The narrow
+// allowlist avoids an "autostart=0 still starts" foot-gun and keeps the
+// contract trivially scriptable from adb / WDIO.
+//
+// This is the SINGLE place the truthiness rule lives — both deep-link
+// delivery sites call it, so the two routing paths cannot drift. It is NOT
+// the routing gate: isBenchmarkRunnerUrl stays the sole matcher; this
+// helper is consulted only once a URL has already matched.
+//
+// Parses the query substring directly rather than relying on host parsing
+// of the custom scheme.
+export function parseBenchmarkAutostart(
+  url: string | null | undefined,
+): boolean {
+  if (typeof url !== 'string') {
+    return false;
+  }
+  try {
+    const queryIndex = url.indexOf('?');
+    if (queryIndex === -1) {
+      return false;
+    }
+    const params = new URLSearchParams(url.slice(queryIndex + 1));
+    const value = params.get('autostart');
+    if (value === null) {
+      return false;
+    }
+    const normalized = value.toLowerCase();
+    return normalized === '1' || normalized === 'true';
+  } catch {
+    return false;
+  }
+}

--- a/src/__automation__/deepLink.ts
+++ b/src/__automation__/deepLink.ts
@@ -10,11 +10,8 @@
  *                                doesn't deliver the URL via DeepLinkService)
  */
 import type {DeepLinkParams} from '../services/DeepLinkService';
-import {
-  ROUTES,
-  isBenchmarkRunnerUrl,
-  parseBenchmarkAutostart,
-} from '../utils/navigationConstants';
+import {ROUTES} from '../utils/navigationConstants';
+import {isBenchmarkRunnerUrl, parseBenchmarkAutostart} from './benchmarkRoute';
 
 interface NavigationLike {
   navigate: (route: string, params?: Record<string, unknown>) => void;

--- a/src/__automation__/deepLink.ts
+++ b/src/__automation__/deepLink.ts
@@ -10,10 +10,14 @@
  *                                doesn't deliver the URL via DeepLinkService)
  */
 import type {DeepLinkParams} from '../services/DeepLinkService';
-import {ROUTES, isBenchmarkRunnerUrl} from '../utils/navigationConstants';
+import {
+  ROUTES,
+  isBenchmarkRunnerUrl,
+  parseBenchmarkAutostart,
+} from '../utils/navigationConstants';
 
 interface NavigationLike {
-  navigate: (route: string) => void;
+  navigate: (route: string, params?: Record<string, unknown>) => void;
 }
 
 /** Returns true if handled; false if caller should fall through. */
@@ -39,7 +43,12 @@ export async function dispatchAutomationDeepLink(
   // the shared helper so both deep-link sites (this dispatcher and the
   // useDeepLinking cold/warm-launch effect) accept the exact same shape.
   if (isBenchmarkRunnerUrl(params.url)) {
-    navigation?.navigate(ROUTES.BENCHMARK_RUNNER);
+    // Resolve autostart from the same raw URL string via the shared helper —
+    // NOT from params.queryParams — so the iOS/DeepLinkService origin and the
+    // Android/Linking origin cannot diverge in truthiness.
+    navigation?.navigate(ROUTES.BENCHMARK_RUNNER, {
+      autostart: parseBenchmarkAutostart(params.url),
+    });
     return true;
   }
   return false;

--- a/src/__automation__/screens/BenchmarkRunnerScreen.tsx
+++ b/src/__automation__/screens/BenchmarkRunnerScreen.tsx
@@ -1044,14 +1044,10 @@ interface BenchmarkRunnerScreenProps {
   // matrix. Production code never passes this prop.
   __runner?: typeof runMatrix;
   __loadConfig?: typeof loadConfig;
-  // Test-only seam: lets unit tests drive the autostart trigger without
-  // registering a navigator route. When provided it wins over route params;
-  // the production path always reads route.params.autostart.
-  __autostart?: boolean;
 }
 
 export const BenchmarkRunnerScreen: React.FC<BenchmarkRunnerScreenProps> =
-  observer(({__runner, __loadConfig, __autostart}) => {
+  observer(({__runner, __loadConfig}) => {
     const [status, setStatus] = useState<Status>('idle');
     const [lastCell, setLastCell] = useState<{
       pp?: number;
@@ -1060,20 +1056,15 @@ export const BenchmarkRunnerScreen: React.FC<BenchmarkRunnerScreenProps> =
     }>({});
     const runningRef = useRef(false);
 
-    // Resolve the autostart navigation param. This is an E2E-only route
-    // (registered only under __E2E__), so route params are the production
-    // source of truth. `useRoute` throws when there is no navigator in the
-    // tree (unit tests render the screen bare), so the read is contained;
-    // the `__autostart` seam covers those tests. The two deep-link delivery
-    // sites set this param via the shared parseBenchmarkAutostart helper.
-    let routeAutostart: boolean | undefined;
-    try {
-      routeAutostart = (useRoute().params as {autostart?: boolean} | undefined)
-        ?.autostart;
-    } catch {
-      routeAutostart = undefined;
-    }
-    const autostart = __autostart ?? routeAutostart;
+    // Autostart trigger source: the two deep-link delivery sites set
+    // `autostart` on the navigation route params via parseBenchmarkAutostart;
+    // we just read it here. Tests mock @react-navigation/native's useRoute
+    // to inject the desired params (the codebase's existing per-file
+    // navigation-mock pattern; see SquarePalCard / ModelCard / useDeepLinking
+    // test files).
+    const route = useRoute();
+    const autostart = (route.params as {autostart?: boolean} | undefined)
+      ?.autostart;
 
     const onRun = useCallback(async () => {
       // Single-flight: ignore taps while a run is in progress.

--- a/src/__automation__/screens/BenchmarkRunnerScreen.tsx
+++ b/src/__automation__/screens/BenchmarkRunnerScreen.tsx
@@ -1,5 +1,6 @@
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Button, ScrollView, StyleSheet, Text, View} from 'react-native';
+import {useRoute} from '@react-navigation/native';
 import RNDeviceInfo from 'react-native-device-info';
 import {
   addNativeLogListener,
@@ -1043,10 +1044,14 @@ interface BenchmarkRunnerScreenProps {
   // matrix. Production code never passes this prop.
   __runner?: typeof runMatrix;
   __loadConfig?: typeof loadConfig;
+  // Test-only seam: lets unit tests drive the autostart trigger without
+  // registering a navigator route. When provided it wins over route params;
+  // the production path always reads route.params.autostart.
+  __autostart?: boolean;
 }
 
 export const BenchmarkRunnerScreen: React.FC<BenchmarkRunnerScreenProps> =
-  observer(({__runner, __loadConfig}) => {
+  observer(({__runner, __loadConfig, __autostart}) => {
     const [status, setStatus] = useState<Status>('idle');
     const [lastCell, setLastCell] = useState<{
       pp?: number;
@@ -1054,6 +1059,21 @@ export const BenchmarkRunnerScreen: React.FC<BenchmarkRunnerScreenProps> =
       cells?: number;
     }>({});
     const runningRef = useRef(false);
+
+    // Resolve the autostart navigation param. This is an E2E-only route
+    // (registered only under __E2E__), so route params are the production
+    // source of truth. `useRoute` throws when there is no navigator in the
+    // tree (unit tests render the screen bare), so the read is contained;
+    // the `__autostart` seam covers those tests. The two deep-link delivery
+    // sites set this param via the shared parseBenchmarkAutostart helper.
+    let routeAutostart: boolean | undefined;
+    try {
+      routeAutostart = (useRoute().params as {autostart?: boolean} | undefined)
+        ?.autostart;
+    } catch {
+      routeAutostart = undefined;
+    }
+    const autostart = __autostart ?? routeAutostart;
 
     const onRun = useCallback(async () => {
       // Single-flight: ignore taps while a run is in progress.
@@ -1090,6 +1110,23 @@ export const BenchmarkRunnerScreen: React.FC<BenchmarkRunnerScreenProps> =
       setStatus('idle');
       setLastCell({});
     }, []);
+
+    // Autostart: when the route carries autostart=true, invoke the SAME
+    // onRun the button uses — no second start path, same use of the
+    // already-pushed bench-config.json. Fired at most once per mount via the
+    // ref latch, so MobX-observer re-renders (this is an `observer`) cannot
+    // re-trigger it; onRun's single-flight gate (runningRef + status guard)
+    // remains the authoritative backstop. A falsey/absent autostart leaves
+    // the screen idle, waiting for a tap, exactly as before.
+    const autostartFiredRef = useRef(false);
+    useEffect(() => {
+      if (autostart && !autostartFiredRef.current) {
+        autostartFiredRef.current = true;
+        // onRun owns its own try/catch (it sets status='error:...' on
+        // failure), so the catch here is only a floating-promise guard.
+        onRun().catch(() => undefined);
+      }
+    }, [autostart, onRun]);
 
     return (
       <ScrollView

--- a/src/__automation__/screens/__tests__/BenchmarkRunnerScreen.test.tsx
+++ b/src/__automation__/screens/__tests__/BenchmarkRunnerScreen.test.tsx
@@ -5,6 +5,22 @@ import {fireEvent, render, waitFor} from '../../../../jest/test-utils';
 
 import {modelStore} from '../../../store';
 
+// Mock @react-navigation/native's useRoute so the screen can read route
+// params without a real navigator in the tree. The default return covers
+// every non-autostart test; the autostart suite overrides per-test. This
+// mirrors the per-file navigation mock pattern used in SquarePalCard,
+// ModelCard, ModelNotLoadedMessage, and useDeepLinking tests.
+jest.mock('@react-navigation/native', () => ({
+  useRoute: jest.fn(() => ({
+    key: 'bench',
+    name: 'BenchmarkRunner',
+    params: {},
+  })),
+}));
+const {useRoute} = require('@react-navigation/native') as {
+  useRoute: jest.Mock;
+};
+
 // Mock RNFS at the module path the screen imports.
 jest.mock('@dr.pogodin/react-native-fs', () => ({
   ExternalDirectoryPath: '/mock/external',
@@ -91,6 +107,12 @@ function makeMockContext(overrides?: {bench?: jest.Mock; release?: jest.Mock}) {
 describe('BenchmarkRunnerScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default useRoute → no autostart. Autostart tests override this.
+    useRoute.mockReturnValue({
+      key: 'bench',
+      name: 'BenchmarkRunner',
+      params: {},
+    });
     RNFS.exists.mockResolvedValue(true);
     RNFS.readFile.mockResolvedValue(JSON.stringify(VALID_CONFIG));
     RNFS.writeFile.mockResolvedValue(undefined);
@@ -210,16 +232,22 @@ describe('BenchmarkRunnerScreen', () => {
   });
 
   describe('autostart', () => {
+    // Helper: configure useRoute to return params {autostart: <value>}. The
+    // production read path is `route.params.autostart` — this mirrors what
+    // the two deep-link delivery sites set via parseBenchmarkAutostart.
+    const setRouteAutostart = (autostart: boolean | undefined) => {
+      useRoute.mockReturnValue({
+        key: 'bench',
+        name: 'BenchmarkRunner',
+        params: autostart === undefined ? {} : {autostart},
+      });
+    };
+
     it('fires the runner exactly once after mount when autostart is true (no tap)', async () => {
+      setRouteAutostart(true);
       const runner = jest.fn().mockResolvedValue(undefined);
       const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
-      render(
-        <BenchmarkRunnerScreen
-          __runner={runner}
-          __loadConfig={loader}
-          __autostart={true}
-        />,
-      );
+      render(<BenchmarkRunnerScreen __runner={runner} __loadConfig={loader} />);
       // Same start path the button uses: loadConfig then runMatrix, once.
       await waitFor(() => {
         expect(loader).toHaveBeenCalledTimes(1);
@@ -228,6 +256,7 @@ describe('BenchmarkRunnerScreen', () => {
     });
 
     it('does NOT fire the runner and stays idle when autostart is absent', async () => {
+      // beforeEach default: route.params === {} → autostart undefined.
       const runner = jest.fn().mockResolvedValue(undefined);
       const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
       const {getByTestId} = render(
@@ -244,14 +273,11 @@ describe('BenchmarkRunnerScreen', () => {
     });
 
     it('does NOT fire the runner and stays idle when autostart is false', async () => {
+      setRouteAutostart(false);
       const runner = jest.fn().mockResolvedValue(undefined);
       const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
       const {getByTestId} = render(
-        <BenchmarkRunnerScreen
-          __runner={runner}
-          __loadConfig={loader}
-          __autostart={false}
-        />,
+        <BenchmarkRunnerScreen __runner={runner} __loadConfig={loader} />,
       );
       await act(async () => {
         await Promise.resolve();
@@ -263,6 +289,7 @@ describe('BenchmarkRunnerScreen', () => {
     });
 
     it('autostart then a redundant tap mid-run still invokes the runner exactly once (single-flight)', async () => {
+      setRouteAutostart(true);
       let resolveRunner: () => void = () => {};
       const runner = jest.fn(
         () =>
@@ -272,11 +299,7 @@ describe('BenchmarkRunnerScreen', () => {
       );
       const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
       const {getByTestId} = render(
-        <BenchmarkRunnerScreen
-          __runner={runner}
-          __loadConfig={loader}
-          __autostart={true}
-        />,
+        <BenchmarkRunnerScreen __runner={runner} __loadConfig={loader} />,
       );
       // Autostart kicks off the run.
       await waitFor(() => {
@@ -294,14 +317,11 @@ describe('BenchmarkRunnerScreen', () => {
     });
 
     it('does not re-fire the runner on re-render after autostart fired (once per mount)', async () => {
+      setRouteAutostart(true);
       const runner = jest.fn().mockResolvedValue(undefined);
       const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
       const {rerender} = render(
-        <BenchmarkRunnerScreen
-          __runner={runner}
-          __loadConfig={loader}
-          __autostart={true}
-        />,
+        <BenchmarkRunnerScreen __runner={runner} __loadConfig={loader} />,
       );
       await waitFor(() => {
         expect(runner).toHaveBeenCalledTimes(1);
@@ -310,11 +330,7 @@ describe('BenchmarkRunnerScreen', () => {
       // run from firing again.
       await act(async () => {
         rerender(
-          <BenchmarkRunnerScreen
-            __runner={runner}
-            __loadConfig={loader}
-            __autostart={true}
-          />,
+          <BenchmarkRunnerScreen __runner={runner} __loadConfig={loader} />,
         );
       });
       expect(runner).toHaveBeenCalledTimes(1);

--- a/src/__automation__/screens/__tests__/BenchmarkRunnerScreen.test.tsx
+++ b/src/__automation__/screens/__tests__/BenchmarkRunnerScreen.test.tsx
@@ -471,7 +471,7 @@ describe('BenchmarkRunnerScreen', () => {
       const [paramsArg] = (initLlama as jest.Mock).mock.calls[0];
       expect(paramsArg.devices).toEqual(['CPU']);
       // Pinned to 0 so ggml does not route layers through other registered
-      // backends (Bug-2 — verified on Snapdragon 8 Elite Gen 5).
+      // backends (verified on Snapdragon 8 Elite Gen 5).
       expect(paramsArg.n_gpu_layers).toBe(0);
     });
 

--- a/src/__automation__/screens/__tests__/BenchmarkRunnerScreen.test.tsx
+++ b/src/__automation__/screens/__tests__/BenchmarkRunnerScreen.test.tsx
@@ -209,6 +209,118 @@ describe('BenchmarkRunnerScreen', () => {
     });
   });
 
+  describe('autostart', () => {
+    it('fires the runner exactly once after mount when autostart is true (no tap)', async () => {
+      const runner = jest.fn().mockResolvedValue(undefined);
+      const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
+      render(
+        <BenchmarkRunnerScreen
+          __runner={runner}
+          __loadConfig={loader}
+          __autostart={true}
+        />,
+      );
+      // Same start path the button uses: loadConfig then runMatrix, once.
+      await waitFor(() => {
+        expect(loader).toHaveBeenCalledTimes(1);
+        expect(runner).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('does NOT fire the runner and stays idle when autostart is absent', async () => {
+      const runner = jest.fn().mockResolvedValue(undefined);
+      const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
+      const {getByTestId} = render(
+        <BenchmarkRunnerScreen __runner={runner} __loadConfig={loader} />,
+      );
+      // Flush mount effects so a (wrongly) scheduled autostart would surface.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(runner).not.toHaveBeenCalled();
+      expect(
+        getByTestId('bench-runner-screen-status').props.accessibilityLabel,
+      ).toBe('idle');
+    });
+
+    it('does NOT fire the runner and stays idle when autostart is false', async () => {
+      const runner = jest.fn().mockResolvedValue(undefined);
+      const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
+      const {getByTestId} = render(
+        <BenchmarkRunnerScreen
+          __runner={runner}
+          __loadConfig={loader}
+          __autostart={false}
+        />,
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(runner).not.toHaveBeenCalled();
+      expect(
+        getByTestId('bench-runner-screen-status').props.accessibilityLabel,
+      ).toBe('idle');
+    });
+
+    it('autostart then a redundant tap mid-run still invokes the runner exactly once (single-flight)', async () => {
+      let resolveRunner: () => void = () => {};
+      const runner = jest.fn(
+        () =>
+          new Promise<void>(r => {
+            resolveRunner = r;
+          }),
+      );
+      const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
+      const {getByTestId} = render(
+        <BenchmarkRunnerScreen
+          __runner={runner}
+          __loadConfig={loader}
+          __autostart={true}
+        />,
+      );
+      // Autostart kicks off the run.
+      await waitFor(() => {
+        expect(runner).toHaveBeenCalledTimes(1);
+      });
+      // A later tap arrives while the run is in flight — single-flight gate
+      // rejects it.
+      await act(async () => {
+        fireEvent.press(getByTestId('bench-run-button'));
+      });
+      expect(runner).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        resolveRunner();
+      });
+    });
+
+    it('does not re-fire the runner on re-render after autostart fired (once per mount)', async () => {
+      const runner = jest.fn().mockResolvedValue(undefined);
+      const loader = jest.fn().mockResolvedValue(VALID_CONFIG);
+      const {rerender} = render(
+        <BenchmarkRunnerScreen
+          __runner={runner}
+          __loadConfig={loader}
+          __autostart={true}
+        />,
+      );
+      await waitFor(() => {
+        expect(runner).toHaveBeenCalledTimes(1);
+      });
+      // Force a re-render with stable autostart — the ref latch must keep the
+      // run from firing again.
+      await act(async () => {
+        rerender(
+          <BenchmarkRunnerScreen
+            __runner={runner}
+            __loadConfig={loader}
+            __autostart={true}
+          />,
+        );
+      });
+      expect(runner).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('runMatrix', () => {
     const setStatus = jest.fn();
     const setLastCell = jest.fn();

--- a/src/hooks/__tests__/useDeepLinking.test.ts
+++ b/src/hooks/__tests__/useDeepLinking.test.ts
@@ -63,7 +63,7 @@ describe('useDeepLinking — cold-launch routing', () => {
     getInitialURLSpy.mockRestore();
   });
 
-  it('navigates to BenchmarkRunner when __E2E__=true and getInitialURL returns the bench URL', async () => {
+  it('navigates to BenchmarkRunner with autostart:false for the bare bench URL on cold launch', async () => {
     getInitialURLSpy.mockResolvedValue('pocketpal://e2e/benchmark');
 
     renderHook(() => useDeepLinking());
@@ -73,7 +73,24 @@ describe('useDeepLinking — cold-launch routing', () => {
     await Promise.resolve();
 
     expect(getInitialURLSpy).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.BENCHMARK_RUNNER);
+    // Bare URL still routes; autostart resolves false so the screen stays
+    // idle and waits for a tap — current behaviour preserved.
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.BENCHMARK_RUNNER, {
+      autostart: false,
+    });
+  });
+
+  it('navigates with autostart:true for the autostart bench URL on cold launch', async () => {
+    getInitialURLSpy.mockResolvedValue('pocketpal://e2e/benchmark?autostart=1');
+
+    renderHook(() => useDeepLinking());
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.BENCHMARK_RUNNER, {
+      autostart: true,
+    });
   });
 
   it('does NOT navigate when __E2E__=false (cold-launch effect short-circuits)', async () => {
@@ -157,7 +174,65 @@ describe('useDeepLinking — cold-launch routing', () => {
     // Simulate WDIO firing `mobile: deepLink` after the app started.
     expect(captured.handler).not.toBeNull();
     captured.handler!({url: 'pocketpal://e2e/benchmark'});
-    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.BENCHMARK_RUNNER);
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.BENCHMARK_RUNNER, {
+      autostart: false,
+    });
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  it('navigates with autostart:true on a warm-state autostart url event', async () => {
+    getInitialURLSpy.mockResolvedValue(null);
+
+    const captured: {handler: ((evt: {url: string}) => void) | null} = {
+      handler: null,
+    };
+    const addEventListenerSpy = jest
+      .spyOn(Linking, 'addEventListener')
+      .mockImplementation((event: string, cb: any) => {
+        if (event === 'url') {
+          captured.handler = cb;
+        }
+        return {remove: jest.fn()} as any;
+      });
+
+    renderHook(() => useDeepLinking());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(captured.handler).not.toBeNull();
+    captured.handler!({url: 'pocketpal://e2e/benchmark?autostart=1'});
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.BENCHMARK_RUNNER, {
+      autostart: true,
+    });
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  it('navigates with autostart:false for autostart=0 on a warm-state url event', async () => {
+    getInitialURLSpy.mockResolvedValue(null);
+
+    const captured: {handler: ((evt: {url: string}) => void) | null} = {
+      handler: null,
+    };
+    const addEventListenerSpy = jest
+      .spyOn(Linking, 'addEventListener')
+      .mockImplementation((event: string, cb: any) => {
+        if (event === 'url') {
+          captured.handler = cb;
+        }
+        return {remove: jest.fn()} as any;
+      });
+
+    renderHook(() => useDeepLinking());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(captured.handler).not.toBeNull();
+    captured.handler!({url: 'pocketpal://e2e/benchmark?autostart=0'});
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.BENCHMARK_RUNNER, {
+      autostart: false,
+    });
 
     addEventListenerSpy.mockRestore();
   });

--- a/src/hooks/__tests__/useDeepLinking.test.ts
+++ b/src/hooks/__tests__/useDeepLinking.test.ts
@@ -1,8 +1,8 @@
 /**
  * useDeepLinking — cold-launch routing tests
  *
- * Covers the SHOULD rows from the TASK-20260428-1532 Test Requirements
- * table for the new `__E2E__`-gated `useEffect` that reads
+ * Covers the SHOULD rows from the Test Requirements table for the
+ * `__E2E__`-gated `useEffect` that reads
  * `Linking.getInitialURL()` and routes to `BenchmarkRunner` when the
  * launching intent matches `pocketpal://e2e/benchmark`.
  *

--- a/src/hooks/useDeepLinking.ts
+++ b/src/hooks/useDeepLinking.ts
@@ -10,7 +10,11 @@ import {Alert, Linking} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {deepLinkService, DeepLinkParams} from '../services/DeepLinkService';
 import {chatSessionStore, palStore, deepLinkStore} from '../store';
-import {ROUTES, isBenchmarkRunnerUrl} from '../utils/navigationConstants';
+import {
+  ROUTES,
+  isBenchmarkRunnerUrl,
+  parseBenchmarkAutostart,
+} from '../utils/navigationConstants';
 
 /**
  * Hook for handling deep link navigation
@@ -104,7 +108,14 @@ export const useDeepLinking = () => {
     }
     const routeIfBench = (url: string | null) => {
       if (isBenchmarkRunnerUrl(url)) {
-        (navigation as any).navigate(ROUTES.BENCHMARK_RUNNER);
+        // Resolve autostart from the same raw URL the gate matched, via the
+        // shared helper, so cold-launch (getInitialURL) and warm-launch
+        // ('url' event) deliveries — and the iOS dispatchAutomationDeepLink
+        // path — cannot diverge in truthiness. A bare bench URL resolves
+        // false, so the screen stays idle exactly as before.
+        (navigation as any).navigate(ROUTES.BENCHMARK_RUNNER, {
+          autostart: parseBenchmarkAutostart(url),
+        });
       }
     };
     Linking.getInitialURL()

--- a/src/hooks/useDeepLinking.ts
+++ b/src/hooks/useDeepLinking.ts
@@ -10,11 +10,11 @@ import {Alert, Linking} from 'react-native';
 import {useNavigation} from '@react-navigation/native';
 import {deepLinkService, DeepLinkParams} from '../services/DeepLinkService';
 import {chatSessionStore, palStore, deepLinkStore} from '../store';
+import {ROUTES} from '../utils/navigationConstants';
 import {
-  ROUTES,
   isBenchmarkRunnerUrl,
   parseBenchmarkAutostart,
-} from '../utils/navigationConstants';
+} from '../__automation__/benchmarkRoute';
 
 /**
  * Hook for handling deep link navigation

--- a/src/utils/__tests__/navigationConstants.test.ts
+++ b/src/utils/__tests__/navigationConstants.test.ts
@@ -1,0 +1,115 @@
+import {
+  isBenchmarkRunnerUrl,
+  parseBenchmarkAutostart,
+} from '../navigationConstants';
+
+describe('navigationConstants', () => {
+  describe('isBenchmarkRunnerUrl', () => {
+    it('matches the bare bench URL', () => {
+      expect(isBenchmarkRunnerUrl('pocketpal://e2e/benchmark')).toBe(true);
+    });
+
+    it('matches the bench URL with a query string (prefix tolerates query)', () => {
+      expect(
+        isBenchmarkRunnerUrl('pocketpal://e2e/benchmark?autostart=1'),
+      ).toBe(true);
+    });
+
+    it('does not match unrelated URLs', () => {
+      expect(isBenchmarkRunnerUrl('pocketpal://chat?palId=foo')).toBe(false);
+      expect(isBenchmarkRunnerUrl('pocketpal://e2e/other')).toBe(false);
+    });
+
+    it('does not match null / undefined', () => {
+      expect(isBenchmarkRunnerUrl(null)).toBe(false);
+      expect(isBenchmarkRunnerUrl(undefined)).toBe(false);
+    });
+  });
+
+  describe('parseBenchmarkAutostart', () => {
+    it('returns true for autostart=1', () => {
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=1'),
+      ).toBe(true);
+    });
+
+    it('returns true for autostart=true (case-insensitive)', () => {
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=true'),
+      ).toBe(true);
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=TRUE'),
+      ).toBe(true);
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=True'),
+      ).toBe(true);
+    });
+
+    it('returns true when autostart sits alongside other query params', () => {
+      expect(
+        parseBenchmarkAutostart(
+          'pocketpal://e2e/benchmark?foo=bar&autostart=1',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for autostart=0', () => {
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=0'),
+      ).toBe(false);
+    });
+
+    it('returns false for autostart=false', () => {
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=false'),
+      ).toBe(false);
+    });
+
+    it('returns false for an unrecognized value (garbage)', () => {
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=banana'),
+      ).toBe(false);
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart='),
+      ).toBe(false);
+      expect(
+        parseBenchmarkAutostart('pocketpal://e2e/benchmark?autostart=11'),
+      ).toBe(false);
+    });
+
+    it('returns false for the bare URL (no query)', () => {
+      expect(parseBenchmarkAutostart('pocketpal://e2e/benchmark')).toBe(false);
+    });
+
+    it('returns false when the query has no autostart key', () => {
+      expect(parseBenchmarkAutostart('pocketpal://e2e/benchmark?foo=bar')).toBe(
+        false,
+      );
+    });
+
+    it('returns false for null / undefined / non-string without throwing', () => {
+      expect(parseBenchmarkAutostart(null)).toBe(false);
+      expect(parseBenchmarkAutostart(undefined)).toBe(false);
+      // Defends against a non-string slipping past the type contract.
+      expect(parseBenchmarkAutostart(42 as unknown as string)).toBe(false);
+    });
+
+    it('returns false for a malformed/garbage string without throwing', () => {
+      expect(() => parseBenchmarkAutostart('not a url at all')).not.toThrow();
+      expect(parseBenchmarkAutostart('not a url at all')).toBe(false);
+      expect(parseBenchmarkAutostart('???')).toBe(false);
+    });
+
+    it('iOS-origin and Android-origin parity: same raw URL resolves identically', () => {
+      // Both delivery sites resolve from the same raw URL via this one
+      // helper, so an iOS (DeepLinkService) launch and an Android (Linking)
+      // launch of the same URL cannot diverge in truthiness. This is the
+      // unit-level parity guarantee that the two routing paths share.
+      const url = 'pocketpal://e2e/benchmark?autostart=1';
+      const androidOrigin = parseBenchmarkAutostart(url);
+      const iosOrigin = parseBenchmarkAutostart(url);
+      expect(androidOrigin).toBe(iosOrigin);
+      expect(androidOrigin).toBe(true);
+    });
+  });
+});

--- a/src/utils/navigationConstants.ts
+++ b/src/utils/navigationConstants.ts
@@ -13,55 +13,8 @@ export const ROUTES = {
 
   // E2E-only deep-link-driven matrix runner. Hidden from drawer sidebar via
   // drawerItemStyle:{display:'none'}; reachable only by the deep link
-  // pocketpal://e2e/benchmark in the e2e flavor build.
+  // pocketpal://e2e/benchmark in the e2e flavor build. The URL prefix,
+  // matcher, and autostart parser live in src/__automation__/benchmarkRoute
+  // so the automation protocol stays inside the __automation__ boundary.
   BENCHMARK_RUNNER: 'BenchmarkRunner',
 };
-
-// Canonical deep-link URL that routes to BENCHMARK_RUNNER. Used by both the
-// useDeepLinking warm/cold-launch effect (raw-URL match) and the
-// dispatchAutomationDeepLink router (DeepLinkParams match).
-export const BENCHMARK_RUNNER_URL_PREFIX = 'pocketpal://e2e/benchmark';
-
-export function isBenchmarkRunnerUrl(url: string | null | undefined): boolean {
-  return typeof url === 'string' && url.startsWith(BENCHMARK_RUNNER_URL_PREFIX);
-}
-
-// Resolve the autostart signal from a bench deep-link URL. Returns true iff
-// the URL carries `?autostart=` with a value of exactly "1" or "true"
-// (case-insensitive); any other value, or absence, is false. The narrow
-// allowlist avoids an "autostart=0 still starts" foot-gun and keeps the
-// contract trivially scriptable from adb / WDIO.
-//
-// This is the SINGLE place the truthiness rule lives — both deep-link
-// delivery sites (the useDeepLinking cold/warm-launch Linking effect and the
-// dispatchAutomationDeepLink router) call it, so the two routing paths cannot
-// drift. It is NOT the routing gate: isBenchmarkRunnerUrl stays the sole
-// matcher; this helper is consulted only once a URL has already matched.
-//
-// Pure and side-effect-free: it does not navigate, mutate state, log, or
-// throw (a malformed URL yields false). Parses the query substring directly
-// rather than relying on host parsing of the custom scheme, so it ships
-// harmlessly in prod even though navigationConstants.ts is prod-reachable —
-// it introduces no new automation marker string.
-export function parseBenchmarkAutostart(
-  url: string | null | undefined,
-): boolean {
-  if (typeof url !== 'string') {
-    return false;
-  }
-  try {
-    const queryIndex = url.indexOf('?');
-    if (queryIndex === -1) {
-      return false;
-    }
-    const params = new URLSearchParams(url.slice(queryIndex + 1));
-    const value = params.get('autostart');
-    if (value === null) {
-      return false;
-    }
-    const normalized = value.toLowerCase();
-    return normalized === '1' || normalized === 'true';
-  } catch {
-    return false;
-  }
-}

--- a/src/utils/navigationConstants.ts
+++ b/src/utils/navigationConstants.ts
@@ -25,3 +25,43 @@ export const BENCHMARK_RUNNER_URL_PREFIX = 'pocketpal://e2e/benchmark';
 export function isBenchmarkRunnerUrl(url: string | null | undefined): boolean {
   return typeof url === 'string' && url.startsWith(BENCHMARK_RUNNER_URL_PREFIX);
 }
+
+// Resolve the autostart signal from a bench deep-link URL. Returns true iff
+// the URL carries `?autostart=` with a value of exactly "1" or "true"
+// (case-insensitive); any other value, or absence, is false. The narrow
+// allowlist avoids an "autostart=0 still starts" foot-gun and keeps the
+// contract trivially scriptable from adb / WDIO.
+//
+// This is the SINGLE place the truthiness rule lives — both deep-link
+// delivery sites (the useDeepLinking cold/warm-launch Linking effect and the
+// dispatchAutomationDeepLink router) call it, so the two routing paths cannot
+// drift. It is NOT the routing gate: isBenchmarkRunnerUrl stays the sole
+// matcher; this helper is consulted only once a URL has already matched.
+//
+// Pure and side-effect-free: it does not navigate, mutate state, log, or
+// throw (a malformed URL yields false). Parses the query substring directly
+// rather than relying on host parsing of the custom scheme, so it ships
+// harmlessly in prod even though navigationConstants.ts is prod-reachable —
+// it introduces no new automation marker string.
+export function parseBenchmarkAutostart(
+  url: string | null | undefined,
+): boolean {
+  if (typeof url !== 'string') {
+    return false;
+  }
+  try {
+    const queryIndex = url.indexOf('?');
+    if (queryIndex === -1) {
+      return false;
+    }
+    const params = new URLSearchParams(url.slice(queryIndex + 1));
+    const value = params.get('autostart');
+    if (value === null) {
+      return false;
+    }
+    const normalized = value.toLowerCase();
+    return normalized === '1' || normalized === 'true';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Why

The bench E2E matrix is driven entirely over adb except one step: starting the run, which required a UI tap on **RUN BENCHMARK MATRIX**. That tap goes through Android's synthetic-input layer (`adb shell input tap`), and on **HyperOS** (POCO F7 Ultra) and **MediaTek** (POCO X7 Pro) the OS silently drops the injected tap — `onPress` never fires and the matrix never starts. A real finger tap works, so the wiring is correct; the OS just rejects injected touches. The existing fallback chain (swipe → monkey → long-hold → off-center taps) didn't reliably break through, so every config on every device needed a manual human tap (~10–15 per PR validation), blocking unattended runs.

## What

Adds a non-touch trigger that invokes the **exact same** start path the button does. The E2E-only deep link now honors an `autostart` query param:

```
pocketpal://e2e/benchmark?autostart=1
```

When present, the `BenchmarkRunnerScreen` calls its existing `onRun` once after mount, loading the already-pushed `bench-config.json` — same code path, same single-flight gating, **no change to what is measured**.

- `parseBenchmarkAutostart` — pure query-only helper (truthy allowlist `1`/`true` case-insensitive; returns `false` on anything else or any parse error). Does not touch routing; `isBenchmarkRunnerUrl` remains the sole routing gate.
- Both deep-link delivery sites (`useDeepLinking` Linking effect + `dispatchAutomationDeepLink`) thread `{autostart}` from the raw URL via that one helper.
- Screen reads `route.params.autostart` and fires `onRun` once per mount via a `useRef` latch (independent of MobX-observer re-renders); single-flight remains the backstop.
- WDIO spec/helper updated: `deepLinkLaunch` sends `?autostart=1` and the spec drops the `.click()` (and the now-dead button wait), polling `bench-runner-screen-status` directly.

No native changes — the `pocketpal://` scheme is already registered in the e2e `AndroidManifest.xml`. No new DCE marker introduced, so the prod bundle-grep contract is unchanged.

## Testing

**Unit:** full suite green — 2268 passed / 2 skipped, global coverage gate PASS. Covers the canonical scenarios: autostart starts a run, bare URL stays `idle` (regression guard), autostart+tap race yields one run, `autostart=0`/garbage → false, and iOS/Android helper parity.

**On-device (the two devices that drop injected taps):** built the e2e APK, pushed a single-cell config, cold-launched the deep link with **zero taps**:

| Device | `pocketpal://e2e/benchmark` (bare) | `...?autostart=1` (no tap) |
| --- | --- | --- |
| POCO F7 Ultra (HyperOS) | `idle` ✓ | `running → complete` ✓ |
| POCO X7 Pro (MediaTek) | `idle` ✓ | `running → complete` ✓ |

The matrix started and ran to completion with no human touch on both devices; the bare URL correctly stays idle.

---
Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
