### PR TITLE
fix(chat): tighten WebView JS surface + interrupted turn UX

### DIFF
--- a/src/components/AssistantTurnFooter/AssistantTurnFooter.tsx
+++ b/src/components/AssistantTurnFooter/AssistantTurnFooter.tsx
@@ -26,11 +26,14 @@ interface AssistantTurnFooterProps {
 }
 
 /**
- * Turn-level chrome (timing + copy) rendered once per assistant row,
- * below all step blocks. Each slot is gated only by field presence:
+ * Turn-level chrome (timing + copy + interrupt status) rendered once per
+ * assistant row, below all step blocks. Each slot is gated only by field
+ * presence:
  *
- *   - `metadata.timings` present → render the timing line
- *   - `metadata.copyable` true   → render the copy button
+ *   - `metadata.timings` present       → render the timing line
+ *   - `metadata.copyable` true         → render the copy button
+ *   - `metadata.interrupted` true      → render the interrupted status
+ *   - `metadata.truncationLikely` true → upgrade status to "cut off"
  *
  * On a turn aborted mid-stream with partial content, `copyable` is true
  * but `timings` is absent — the footer renders the copy button alone.
@@ -41,9 +44,10 @@ export const AssistantTurnFooter: React.FC<AssistantTurnFooterProps> = ({
 }) => {
   const theme = useTheme();
   const l10n = useContext(L10nContext);
-  const {copyable, timings} = message.metadata || {};
+  const {copyable, timings, interrupted, truncationLikely} =
+    message.metadata || {};
 
-  if (!timings && !copyable) {
+  if (!timings && !copyable && !interrupted) {
     return null;
   }
 
@@ -98,6 +102,15 @@ export const AssistantTurnFooter: React.FC<AssistantTurnFooterProps> = ({
       {timings && fullTimingsString ? (
         <Text style={componentStyles.timing} testID="footer-timing">
           {fullTimingsString}
+        </Text>
+      ) : null}
+      {interrupted ? (
+        <Text
+          style={componentStyles.interruptedStatus}
+          testID="footer-interrupted-status">
+          {truncationLikely
+            ? l10n.components.bubble.truncated
+            : l10n.components.bubble.interrupted}
         </Text>
       ) : null}
     </View>

--- a/src/components/AssistantTurnFooter/__tests__/AssistantTurnFooter.test.tsx
+++ b/src/components/AssistantTurnFooter/__tests__/AssistantTurnFooter.test.tsx
@@ -123,4 +123,37 @@ describe('AssistantTurnFooter', () => {
     expect(queryByTestId('footer-timing')).toBeNull();
     expect(queryByTestId('footer-copy')).toBeTruthy();
   });
+
+  it('renders "Interrupted" status when metadata.interrupted is set', () => {
+    const message = baseTurn({
+      metadata: {copyable: true, interrupted: true},
+    });
+    const {getByTestId, getByText} = render(
+      <AssistantTurnFooter message={message} />,
+    );
+    expect(getByTestId('footer-interrupted-status')).toBeTruthy();
+    expect(getByText('Interrupted')).toBeTruthy();
+  });
+
+  it('upgrades the status to "Cut off — likely context full" when truncationLikely is set', () => {
+    const message = baseTurn({
+      metadata: {copyable: true, interrupted: true, truncationLikely: true},
+    });
+    const {getByTestId, getByText} = render(
+      <AssistantTurnFooter message={message} />,
+    );
+    expect(getByTestId('footer-interrupted-status')).toBeTruthy();
+    expect(getByText('Cut off — likely context full')).toBeTruthy();
+  });
+
+  it('renders the footer for interrupted-only turns (no copyable, no timings)', () => {
+    // Defensive: the footer should still surface the failure even if
+    // the rollback path forgot to set `copyable`.
+    const message = baseTurn({metadata: {interrupted: true}});
+    const {queryByTestId} = render(<AssistantTurnFooter message={message} />);
+    expect(queryByTestId('assistant-turn-footer')).toBeTruthy();
+    expect(queryByTestId('footer-interrupted-status')).toBeTruthy();
+    expect(queryByTestId('footer-copy')).toBeNull();
+    expect(queryByTestId('footer-timing')).toBeNull();
+  });
 });

--- a/src/components/AssistantTurnFooter/styles.ts
+++ b/src/components/AssistantTurnFooter/styles.ts
@@ -14,4 +14,8 @@ export const styles = ({theme}: {theme: Theme}) =>
       color: theme.colors.textSecondary,
       fontSize: 10,
     },
+    interruptedStatus: {
+      color: theme.colors.error,
+      fontSize: 10,
+    },
   });

--- a/src/components/HtmlPreviewBubble/HtmlPreviewBubble.tsx
+++ b/src/components/HtmlPreviewBubble/HtmlPreviewBubble.tsx
@@ -1,7 +1,14 @@
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import {Modal, ScrollView, Text, TouchableOpacity, View} from 'react-native';
 import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 import {WebView} from 'react-native-webview';
+import {useIsFocused} from '@react-navigation/native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import CodeHighlighter from 'react-native-code-highlighter';
@@ -29,10 +36,13 @@ interface HtmlPreviewBubbleProps {
   title?: string;
 }
 
-// NOTE: v1.1 spike — JS enabled for game/interactive testing. Keeps strict
-// default-src 'none' so network/external resources are still blocked.
-// `'unsafe-inline'` + `'unsafe-eval'` on script-src because model-generated
-// games often use eval-like patterns (Function, setTimeout(string)).
+// JS is enabled only in the fullscreen modal (user-activated); the in-row
+// preview keeps `javaScriptEnabled={false}` so chat history scrolling
+// cannot pin CPU or drain battery on model-generated `while(true)` /
+// `setInterval` loops. Strict CSP (default-src 'none') blocks network
+// exfiltration regardless. `'unsafe-inline'` + `'unsafe-eval'` on
+// script-src are needed in the fullscreen path so model-generated games
+// can use eval-like patterns (Function, setTimeout(string)).
 const CSP =
   "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline' 'unsafe-eval'; img-src data:; font-src data:";
 
@@ -67,10 +77,14 @@ const FRAGMENT_STYLES = `<style>
  * Renders model-supplied HTML inside an isolated WebView. Security envelope:
  *  - originWhitelist + onShouldStartLoadWithRequest pin navigation to about:blank
  *  - CSP default-src 'none' blocks all external resource loads
- *  - script-src 'unsafe-inline' 'unsafe-eval' (deliberate v1.1 tradeoff for games)
  *  - no onMessage / injectedJavaScript → no native bridge surface
- * Residual risk: model-generated JS can pin CPU / drain battery via infinite
- * loops; cannot exfiltrate data over the network or escape the WebView origin.
+ *  - in-row preview has `javaScriptEnabled={false}` so scrolling chat
+ *    history cannot trigger model-generated JS; only the fullscreen modal
+ *    (opened on explicit user tap) mounts a JS-enabled WebView, and that
+ *    modal auto-closes when the chat screen loses focus.
+ * Residual risk: while the fullscreen modal is open, model-generated JS
+ * can still pin CPU / drain battery via infinite loops, but cannot
+ * exfiltrate data over the network or escape the WebView origin.
  *
  * Handles two shapes the model can emit:
  *   1. Full document (<!doctype ...><html>...) — inject CSP + viewport into
@@ -120,8 +134,18 @@ export const HtmlPreviewBubble: React.FC<HtmlPreviewBubbleProps> = ({
 }) => {
   const theme = useTheme();
   const l10n = useContext(L10nContext);
+  const isFocused = useIsFocused();
   const [fullscreen, setFullscreen] = useState(false);
   const [showCode, setShowCode] = useState(false);
+
+  // Auto-dismiss the JS-enabled fullscreen modal when the user navigates
+  // away from the chat screen so model-generated JS cannot keep running
+  // off-screen. The collapsed in-row preview is already JS-disabled.
+  useEffect(() => {
+    if (!isFocused && fullscreen) {
+      setFullscreen(false);
+    }
+  }, [isFocused, fullscreen]);
 
   const styles = useMemo(
     () =>
@@ -225,7 +249,9 @@ export const HtmlPreviewBubble: React.FC<HtmlPreviewBubbleProps> = ({
         ) : (
           <WebView
             source={{html: wrappedHtml, baseUrl: 'about:blank'}}
-            javaScriptEnabled={true}
+            // JS off in the in-row preview — see file-level doc. Layout +
+            // CSS still render; interactive content waits for fullscreen.
+            javaScriptEnabled={false}
             originWhitelist={['about:blank']}
             onShouldStartLoadWithRequest={req => req.url === 'about:blank'}
             scrollEnabled={true}

--- a/src/components/HtmlPreviewBubble/__tests__/HtmlPreviewBubble.test.tsx
+++ b/src/components/HtmlPreviewBubble/__tests__/HtmlPreviewBubble.test.tsx
@@ -10,6 +10,7 @@ describe('HtmlPreviewBubble', () => {
   it('renders the collapsed bubble with the provided title', () => {
     const {getByText, getByTestId} = render(
       <HtmlPreviewBubble html={html} title="My Preview" />,
+      {withNavigation: true},
     );
     expect(getByTestId('html-preview-bubble')).toBeTruthy();
     expect(getByTestId('html-preview-bubble-collapsed')).toBeTruthy();
@@ -17,16 +18,19 @@ describe('HtmlPreviewBubble', () => {
   });
 
   it('falls back to "Preview" when title is missing or empty', () => {
-    const {getByText, rerender} = render(<HtmlPreviewBubble html={html} />);
+    const {getByText, rerender} = render(<HtmlPreviewBubble html={html} />, {
+      withNavigation: true,
+    });
     expect(getByText('Preview')).toBeTruthy();
 
     rerender(<HtmlPreviewBubble html={html} title="" />);
     expect(getByText('Preview')).toBeTruthy();
   });
 
-  it('wraps html inside a full document with CSP meta tag and JS enabled', () => {
+  it('wraps html inside a full document with CSP meta tag and JS disabled in the in-row preview', () => {
     const {getByTestId} = render(
       <HtmlPreviewBubble html={html} title="CSP Test" />,
+      {withNavigation: true},
     );
     const webview = getByTestId('html-preview-webview');
     // The mock WebView (see __mocks__/external/react-native-webview.ts) forwards
@@ -38,7 +42,9 @@ describe('HtmlPreviewBubble', () => {
     expect(source.html).toContain("default-src 'none'");
     expect(source.html).toContain('img-src data:');
     expect(source.html).toContain(html);
-    expect(webview.props.javaScriptEnabled).toBe(true);
+    // In-row preview is intentionally JS-disabled so chat history
+    // scrolling cannot trigger model-generated CPU-pinning JS.
+    expect(webview.props.javaScriptEnabled).toBe(false);
     expect(webview.props.originWhitelist).toEqual(['about:blank']);
     // Initial about:blank load is allowed; any other navigation is blocked.
     expect(
@@ -53,6 +59,7 @@ describe('HtmlPreviewBubble', () => {
     // In the jest RN mock, <Modal> renders its children only while visible.
     const {getByTestId, queryByTestId} = render(
       <HtmlPreviewBubble html={html} title="Modal Test" />,
+      {withNavigation: true},
     );
 
     // Modal content is not visible initially.
@@ -75,6 +82,7 @@ describe('HtmlPreviewBubble', () => {
     const setStringSpy = jest.spyOn(Clipboard, 'setString');
     const {getByTestId} = render(
       <HtmlPreviewBubble html={html} title="Copy Test" />,
+      {withNavigation: true},
     );
 
     // Collapsed-header copy button
@@ -93,6 +101,7 @@ describe('HtmlPreviewBubble', () => {
   it('toggles between rendered preview and raw HTML code', () => {
     const {getByTestId, queryByTestId} = render(
       <HtmlPreviewBubble html={html} title="Toggle Test" />,
+      {withNavigation: true},
     );
 
     // Preview is shown by default.

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -192,28 +192,98 @@ describe('useChatSession — AssistantTurn integration', () => {
       await result.current.handleSendPress(textMessage);
     });
 
-    // Rollback path: updateMessage called with {interrupted: true} —
-    // unless the partial-content check decided to delete the empty
-    // turn instead. Either branch is acceptable; this test exercises
-    // the FIRST branch by ensuring there is partial step content
-    // present at rollback time.
+    // Rollback path: updateMessage called with {interrupted: true,
+    // copyable: true}. Seed includes partial step content so the
+    // preserve branch (not the delete-empty branch) must run.
     const updateMessageCalls = (chatSessionStore.updateMessage as jest.Mock)
       .mock.calls;
     const interruptedCall = updateMessageCalls.find(
       c => c[2]?.metadata?.interrupted === true,
     );
-    // Either the interrupted-write branch fired (partial content present)
-    // or the delete-empty branch fired (no partial content). Both are
-    // valid; the contract is "no crash and no silent no-op".
-    if (interruptedCall) {
-      expect(interruptedCall[2].metadata.copyable).toBe(true);
-    }
-    // `addSystemMessage` always fires on a failed run — system message
-    // gets added to surface the error.
+    expect(interruptedCall).toBeDefined();
+    expect(interruptedCall![2].metadata.copyable).toBe(true);
+    // Generic engine failure (not a tool-arg parse error), so
+    // truncationLikely should NOT be set.
+    expect(interruptedCall![2].metadata.truncationLikely).toBeUndefined();
+    // When the turn carries the failure context via its own metadata,
+    // the legacy `Completion failed: …` system-message dump is
+    // suppressed to avoid duplicating the same signal in two places.
     const sysCall = (
       chatSessionStore.addMessageToCurrentSession as jest.Mock
     ).mock.calls.find(c => c[0]?.metadata?.system === true);
-    expect(sysCall).toBeDefined();
+    expect(sysCall).toBeUndefined();
+
+    errSpy.mockRestore();
+  });
+
+  it('#3b run_failed with tool-args parse error → metadata.truncationLikely set; no system message', async () => {
+    // llama.cpp's native tool-call parser throws when the model emits
+    // a malformed tool_calls arguments string — typically because it
+    // ran out of context mid-args (very common for `render_html` with
+    // long HTML). The catch block detects this shape and writes
+    // {truncationLikely: true} on the turn so the footer can surface
+    // a more actionable hint instead of dumping the multi-KB native
+    // error string into chat.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    if (modelStore.context) {
+      modelStore.context.completion = jest
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            'Failed to parse tool call arguments as JSON: [json.exception.parse_error.101] parse error',
+          ),
+        );
+    }
+    const ref: {
+      current: {createdAt: number; id: string; sessionId: string} | null;
+    } = {current: null};
+    const {result} = renderHook(() =>
+      useChatSession(ref, textMessage.author, mockAssistant),
+    );
+
+    const turnId = 'turn-truncation-test';
+    chatSessionStore.sessions = [
+      {
+        id: 'session-1',
+        title: '',
+        date: '',
+        messages: [
+          {
+            id: turnId,
+            type: 'assistant_turn',
+            author: assistant,
+            createdAt: Date.now(),
+            steps: [{content: 'partial'}],
+            metadata: {copyable: true},
+          } as MessageType.AssistantTurn,
+        ],
+        completionSettings: {},
+        settingsSource: 'pal',
+      },
+    ] as any;
+    (
+      chatSessionStore.addMessageToCurrentSession as jest.Mock
+    ).mockImplementation(async (msg: any) => {
+      msg.id = turnId;
+    });
+
+    await act(async () => {
+      await result.current.handleSendPress(textMessage);
+    });
+
+    const updateMessageCalls = (chatSessionStore.updateMessage as jest.Mock)
+      .mock.calls;
+    const interruptedCall = updateMessageCalls.find(
+      c => c[2]?.metadata?.interrupted === true,
+    );
+    expect(interruptedCall).toBeDefined();
+    expect(interruptedCall![2].metadata.truncationLikely).toBe(true);
+    expect(interruptedCall![2].metadata.copyable).toBe(true);
+
+    const sysCall = (
+      chatSessionStore.addMessageToCurrentSession as jest.Mock
+    ).mock.calls.find(c => c[0]?.metadata?.system === true);
+    expect(sysCall).toBeUndefined();
 
     errSpy.mockRestore();
   });

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -633,11 +633,22 @@ export const useChatSession = (
         console.warn('[useChatSession] TTS stop on error failed:', ttsErr);
       });
 
+      const errorMessage = (error as Error).message;
+      // Native tool-call parser throws on truncated JSON when the model
+      // ran out of context mid-args (most often `render_html` with a
+      // long string). Detect by error shape and route through the
+      // turn's metadata so the footer can show a friendlier hint
+      // instead of a multi-KB raw error dump.
+      const isToolArgsParseError =
+        /Failed to parse tool call arguments as JSON/i.test(errorMessage);
+
       // Error rollback path. The empty/in-flight AssistantTurn row
       // already exists; preserve any partial steps and tag with
-      // {interrupted, copyable}. The store widening from step 2
-      // ensures this metadata write does not silently no-op on
-      // assistant_turn rows and does not clobber metadata.steps.
+      // {interrupted, copyable} (plus {truncationLikely} on the
+      // tool-call parse case). The store widening from step 2 ensures
+      // this metadata write does not silently no-op on assistant_turn
+      // rows and does not clobber metadata.steps.
+      let turnAbsorbedError = false;
       if (currentMessageInfo.current) {
         const session = chatSessionStore.sessions.find(
           s => s.id === currentMessageInfo.current!.sessionId,
@@ -664,9 +675,13 @@ export const useChatSession = (
               metadata: {
                 interrupted: true,
                 copyable: true,
+                ...(isToolArgsParseError ? {truncationLikely: true} : {}),
               },
             },
           );
+          // The turn now carries the failure context; suppress the
+          // duplicate `Completion failed: …` system message dump.
+          turnAbsorbedError = true;
         } else {
           try {
             await chatSessionRepository.deleteMessage(
@@ -688,9 +703,15 @@ export const useChatSession = (
         }
       }
 
-      const errorMessage = (error as Error).message;
-      if (errorMessage.includes('network')) {
+      if (turnAbsorbedError) {
+        // Footer already surfaces interrupted / truncationLikely; nothing
+        // more to add to chat.
+      } else if (errorMessage.includes('network')) {
         await addSystemMessage(l10n.common.networkError);
+      } else if (isToolArgsParseError) {
+        // No turn content to attach the hint to — fall back to a
+        // friendly system message instead of the raw native error dump.
+        await addSystemMessage(l10n.chat.toolCallTruncated);
       } else {
         await addSystemMessage(`${l10n.chat.completionFailed}${errorMessage}`);
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -497,7 +497,9 @@
     "bubble": {
       "msPerToken": "{{value}}ms/token",
       "tokensPerSec": "{{value}} tokens/sec",
-      "ttft": "{{value}}ms TTFT"
+      "ttft": "{{value}}ms TTFT",
+      "interrupted": "Interrupted",
+      "truncated": "Cut off — likely context full"
     },
     "exportUtils": {
       "fileSaved": "File Saved",
@@ -1080,6 +1082,7 @@
     "conversationReset": "Conversation reset!",
     "modelNotLoaded": "Model not loaded. Please initialize the model.",
     "completionFailed": "Completion failed: ",
+    "toolCallTruncated": "Tool call cut off — the model likely ran out of room. Try a larger context or a smaller request.",
     "loadingModel": "Loading model ...",
     "typeYourMessage": "Type your message here",
     "load": "Load",


### PR DESCRIPTION
Follow-up to #709 (already merged). Two pieces of post-merge review feedback that landed too late to make the squash.

## Summary

- **WebView lockdown (HtmlPreviewBubble).** In-row `render_html` preview now sets `javaScriptEnabled={false}`, so scrolling chat history cannot trigger model-generated `while(true)` / `setInterval` CPU drain. The user-activated fullscreen modal keeps JS enabled and auto-closes via `useIsFocused` when the chat screen blurs, so leaving the chat unmounts the JS-running WebView instead of letting it burn cycles off-screen. CSP `default-src 'none'` continues to block all network exfiltration.

- **Failure UX (useChatSession + AssistantTurnFooter).** When the native tool-call parser rejects a truncated JSON args string (typically the model running out of context mid-args on a long `render_html` payload), the error is routed through the turn's own metadata (`interrupted`, `truncationLikely`) instead of being dumped as a multi-KB native error string in a chat system message. The footer surfaces "Interrupted" or "Cut off — likely context full". When there's no partial content on the turn, a friendly `chat.toolCallTruncated` message stands in for the raw error.

- **L10n.** Adds `bubble.interrupted`, `bubble.truncated`, `chat.toolCallTruncated`.

## Why now

Reviewer report for #709 flagged the WebView JS surface as a CONCERN: model-generated HTML can pin CPU just by being visible in chat history. The original spike comment explicitly accepted that residual risk — this PR closes it for the common case (chat history scrolling) while preserving the games-/interactive-HTML use case via the fullscreen modal.

The interrupted-turn UX fix is independent in origin but discovered while testing the WebView change: when a tool-call fails to parse natively, the raw `[json.exception.parse_error.101]` dump that previously landed in chat was awful UX. Surfacing the failure on the turn itself is the right resting place.

(Supersedes #736, which was opened from the squash-merged feature branch and inflated by GitHub's merge-base computation.)

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn test` on affected suites: `HtmlPreviewBubble`, `AssistantTurnFooter`, `useChatSession.test.ts`, `useChatSession.assistantTurn.test.ts`, `locales`, `talents/*` — 353 passing, 0 failures
- [x] Manual: opened in-row HTML preview, confirmed CSS/layout still renders without JS; tap to expand → JS animations run in fullscreen; swipe to drawer → modal auto-dismisses, JS context unmounts
- [x] Manual: reproduce a "context full mid-tool-call" failure and verify the footer shows "Cut off — likely context full" with no chat system-message dump

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)