### PR TITLE
chore(deps): upgrade llama.rn to 0.12.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.1):
+  - llama-rn (0.12.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3751,7 +3751,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 30cce807803745c870de7878dfd62f8b89836330
+  llama-rn: 2bb735f37117cb87233e4c7841e44e9f0c24b41c
   onnxruntime-c: 4a1a1a81da2087869dc9b6357f182952db2df29c
   onnxruntime-react-native: 4451eff6b1aa60589186c6a8422d436fba6a9192
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
     "expr-eval": "^2.0.2",
-    "llama.rn": "0.12.1",
+    "llama.rn": "0.12.3",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6520,10 +6520,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.1.tgz#1e9c5d6ae24edffc5bafa5902b403af99b7b9122"
-  integrity sha512-oJG/2e8AHskcpVcenPx8riMq2Gc/hQx9Q6OdVi73gYKyF3/c32zZbaeWP+wfkBtSf4jO1VFFhcecaUz/29CvBw==
+llama.rn@0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.3.tgz#584dfe1412c077e2a29d829444eb295f730bd47e"
+  integrity sha512-SAMQ0Zj2CpngHNpqzxmIydo64tO3UYiOFeIHWwKc3yWMI5esjv4BJGvZj3Ca+rQWEoF7x+a/BjloiHp6+F141Q==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

Bumps `llama.rn` 0.12.1 → 0.12.3. Dependency-only upgrade (package.json + lockfiles). Native iOS + Android builds pass; targeted Jest suites green. Memory profile re-verification on iPhone 13 Pro + Pixel 9 is **PENDING** (must be run by human via memory-profile skill on physical devices before merge — see Verification below).

Effective llama.cpp range covered by this upgrade: **b9204 → b9254** (50 commits) plus llama.rn-level additions.

## Changes

- `package.json` — `"llama.rn": "0.12.1"` → `"llama.rn": "0.12.3"`
- `yarn.lock` — regenerated (llama.rn block only, 4+/4-)
- `ios/Podfile.lock` — `llama-rn (0.12.1)` → `llama-rn (0.12.3)`, checksum `30cce807…` → `2bb735f3…`

3 files, 7 insertions / 7 deletions. No consumer code touched; the llama.rn Jest mock surface is version-agnostic.

## llama.cpp / llama.rn changelog (PocketPal-relevant)

Scoped to items that touch surfaces PocketPal actually ships. Dropped: server, web-UI, CUDA, SYCL, WebGPU, conversion-only items.

### Speculative decoding (MTP)

- llama: MTP clean-up (ggml-org/llama.cpp#23269)
- model: clarify MTP layer comment in `qwen35.cpp` (ggml-org/llama.cpp#23338)
- convert: update mtp related help (ggml-org/llama.cpp#23334)
- llama.rn: MTP speculative decoding support (mybigday/llama.rn#343, shipped in 0.12.2)
- llama.rn: MTP support for parallel API (mybigday/llama.rn#345, shipped in 0.12.3)

### Hexagon NPU (Snapdragon)

- ggml-hexagon: add PAD op HVX kernel (ggml-org/llama.cpp#23078)
- hexagon: add support for TRI op (ggml-org/llama.cpp#22822)
- hexagon: enable support for NORM op (ggml-org/llama.cpp#23319)
- hexagon: add MROPE and IMROPE support in HTP rope op (ggml-org/llama.cpp#23317)
- snapdragon: update toolchain to v0.6 (ggml-org/llama.cpp#23369)

### OpenCL / Adreno

- opencl: add MoE support for q4_k, q5_k, q6_k on Adreno (ggml-org/llama.cpp#23303) — ties to TASK-20260421-1416 / PR #699 (Adreno large-buffer for A7X/A8X)

### Metal (Apple)

- metal: optimize pad + cpy (ggml-org/llama.cpp#23354)

### Multimodal

- mtmd: `fit_params` now takes mmproj into account (ggml-org/llama.cpp#21489)

### Core model

- llama: initialize pre-norm embedding mask flag (ggml-org/llama.cpp#23256)

### llama.rn sync points

- 0.12.2 syncs to llama.cpp b9222 + b9243 (mybigday/llama.rn#342, #344)
- 0.12.3 syncs to llama.cpp b9254 (mybigday/llama.rn#346)

## Verification

- [x] `yarn install` clean — `yarn.lock` change scoped to llama.rn block (4+/4-)
- [x] `pod install` clean — `Podfile.lock` change scoped to llama-rn pod + checksum
- [x] Targeted Jest suites pass — 10/10 suites, 246/246 tests pass (Node 22.21.0)
- [x] `yarn ios:build:release` succeeds (~182s, Build Succeeded, `PocketPal.app` produced)
- [x] `yarn build:android:release` succeeds (~4m, BUILD SUCCESSFUL, `app-prod-release.aab` ~100 MB produced)
- [x] **PENDING** — Memory profile re-verified on iPhone 13 Pro vs baseline (model qwen3-1.7b) — to be run by human via memory-profile skill on physical device
- [ ] **PENDING** — Memory profile re-verified on Pixel 9 vs baseline (model qwen3-1.7b) — to be run by human via memory-profile skill on physical device

Draft until both memory-profile runs complete and report PASS (regression threshold: >10% AND >200 MB, per `e2e/scripts/memory-profile.sh` convention).

## Risk

Dependency-only; mock surface (loadLlamaModelInfo, LlamaContext, completion, bench, getFormattedChat, initMultimodal) is unchanged. No `LlamaContextWrapper.mm` or `src/utils/*Versions.ts` edits required — confirms the `quick` classification held. Pattern follows prior llama.rn upgrade PRs: #722 (0.12.0 stable), #728 (0.12.1).

Story: TASK-20260524-2036

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)