### PR TITLE
chore(deps): upgrade llama.rn to 0.12.4

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.3):
+  - llama-rn (0.12.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3751,7 +3751,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 2bb735f37117cb87233e4c7841e44e9f0c24b41c
+  llama-rn: 94584e5009b0d435dbc56f3cca4503da46829484
   onnxruntime-c: 4a1a1a81da2087869dc9b6357f182952db2df29c
   onnxruntime-react-native: 4451eff6b1aa60589186c6a8422d436fba6a9192
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
     "expr-eval": "^2.0.2",
-    "llama.rn": "0.12.3",
+    "llama.rn": "0.12.4",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6520,10 +6520,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.3.tgz#584dfe1412c077e2a29d829444eb295f730bd47e"
-  integrity sha512-SAMQ0Zj2CpngHNpqzxmIydo64tO3UYiOFeIHWwKc3yWMI5esjv4BJGvZj3Ca+rQWEoF7x+a/BjloiHp6+F141Q==
+llama.rn@0.12.4:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.4.tgz#3bb0fca305f1c2d03827359afc6ee04d65cf6818"
+  integrity sha512-53oQKv2rzYbsSfFMONcj+KnFfAJ9S5gO9l1FyRi35Zmh8PeLUa7Zzh0FUQ6/+LwZH5SYnCulMeA94GS+ls/y7w==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

Bumps `llama.rn` 0.12.3 → 0.12.4. Dependency-only upgrade (package.json + lockfiles). Native iOS + Android builds pass; targeted Jest suites green. Memory profile re-verification on iPhone 13 Pro + Pixel 9 is **PENDING** (must be run by human via memory-profile skill on physical devices before merge — see Verification below).

Effective llama.cpp range covered by this upgrade: **b9254 → b9309** (55 commits) plus one llama.rn-side packaging change.

## Changes

- `package.json` — `"llama.rn": "0.12.3"` → `"llama.rn": "0.12.4"`
- `yarn.lock` — regenerated (llama.rn block only, 4+/4-)
- `ios/Podfile.lock` — `llama-rn (0.12.3)` → `llama-rn (0.12.4)`, checksum `2bb735f3…` → `94584e50…`

3 files, 7 insertions / 7 deletions. No consumer code touched; the llama.rn Jest mock surface is version-agnostic.

## llama.cpp / llama.rn changelog (PocketPal-relevant)

Scoped to items that touch surfaces PocketPal actually ships. Dropped: server, CUDA, SYCL, Vulkan, WebGPU, ZenDNN, web UI, cmake/ci/docs, perplexity overflow fixes.

### Hexagon NPU (Snapdragon)

- hexagon: HMX quantized matmul rework (ggml-org/llama.cpp#23368) — direct successor to 0.12.0's Hexagon perf work
- hexagon: ssm-conv fix for large prompts (ggml-org/llama.cpp#23307)
- hexagon: apply repl optimization in flash-attn softmax (ggml-org/llama.cpp#23455)

### OpenCL / Adreno

- opencl: generalize Adreno MoE kernels on M (ggml-org/llama.cpp#23449) — follow-up to #23303 (q4_k/q5_k/q6_k MoE landed in 0.12.3)
- opencl: refactor backend initialization (ggml-org/llama.cpp#23318)
- opencl: batch profiling — speed + memory-leak fix (ggml-org/llama.cpp#23495)

### Metal (Apple)

- metal: optimize concat kernel + fix set kernel threads (ggml-org/llama.cpp#23411)

### Correctness / crash fixes

- common/speculative: fix nullptr crash in `get_devices_str` (ggml-org/llama.cpp#23386)
- llama-graph: fix null-buffer crash in `llm_graph_input_attn_kv_iswa` for SWA-only models — Gemma-3 stability (ggml-org/llama.cpp#23131)
- flash-attn: replace f32 with `kv_type` and `q_type` (quantized-cache correctness) (ggml-org/llama.cpp#23372)
- ggml: check correct iface method before fallback 2d-get (ggml-org/llama.cpp#23306, ggml-org/llama.cpp#23514)

### Speculative decoding (MTP) — refinements

- llama: move to backend sampling for MTP draft path (ggml-org/llama.cpp#23287)
- mtp: use `inp_out_ids` to skip logit computation (ggml-org/llama.cpp#23433)

### Multimodal

- mtmd: DeepSeek-OCR image processing fixes + `img_tool::resize` padding refactor (ggml-org/llama.cpp#23345)
- mtmd, model: merge HunyuanOCR into HunyuanVL, fix OCR vision precision (ggml-org/llama.cpp#23329)
- mtmd: add WAV MIME type variants, improve audio format detection (ggml-org/llama.cpp#23396)

### Vocab / tokenizer

- vocab: add Carbon-3B (HybridDNATokenizer) support + fix (ggml-org/llama.cpp#23410, ggml-org/llama.cpp#23466)

### llama.rn sync points

- iOS: embed ggml-metal source into framework binary (mybigday/llama.rn#349) — packaging change; ggml-metal `.metal` source now ships inside the framework binary. Transparent to PocketPal's build (verified during iOS Release build below).
- 0.12.4 syncs to llama.cpp b9297 (mybigday/llama.rn#347)
- 0.12.4 syncs to llama.cpp b9309 (mybigday/llama.rn#351)

## Verification

- [x] `yarn install` clean — `yarn.lock` change scoped to llama.rn block (4+/4-)
- [x] `pod install` clean — `Podfile.lock` change scoped to llama-rn pod + checksum
- [x] Targeted Jest suites pass — 32/32 suites, 749/749 tests pass (Node 22.21.0)
- [x] `yarn ios:build:release` succeeds (~171s, Build Succeeded, `PocketPal.app` produced; no new ggml-metal/metallib warnings — llama.rn#349 packaging change transparent)
- [x] `yarn build:android:release` succeeds (~3m 58s, BUILD SUCCESSFUL, `app-prod-release.aab` ~100 MB produced)
- [ ] **PENDING** — Memory profile re-verified on iPhone 13 Pro vs baseline (model qwen3-1.7b) — to be run by human via memory-profile skill on physical device
- [ ] **PENDING** — Memory profile re-verified on Pixel 9 vs baseline (model qwen3-1.7b) — to be run by human via memory-profile skill on physical device

Draft until both memory-profile runs complete and report PASS (regression threshold: >10% AND >200 MB, per `e2e/scripts/memory-profile.sh` convention).

## Risk

Dependency-only; mock surface (loadLlamaModelInfo, LlamaContext, completion, bench, getFormattedChat, initMultimodal) is unchanged. No wrapper or version-string edits required — confirms the `quick` classification held. Pattern follows prior llama.rn upgrade PRs: #722 (0.12.0 stable), #728 (0.12.1), #740 (0.12.3).

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)