### PR TITLE
[Bug]: thinking toggle locked by pal in no-session chat path

### DIFF
--- a/__mocks__/stores/chatSessionStore.ts
+++ b/__mocks__/stores/chatSessionStore.ts
@@ -31,6 +31,7 @@ export const mockChatSessionStore = {
   //currentSessionMessages: [],
   activeSessionId: 'session-1',
   newChatCompletionSettings: mockDefaultCompletionSettings,
+  newChatThinkingOverride: undefined as boolean | undefined,
   isMigrating: false,
   migrationComplete: true,
   // Draft autosave

--- a/e2e/specs/features/thinking-pal-override.spec.ts
+++ b/e2e/specs/features/thinking-pal-override.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * Thinking Toggle Override E2E Tests (issue #744 regression guard)
+ *
+ * With a pal active, the thinking toggle in the chat input must reflect and
+ * persist the user's choice — not get re-overlaid by the pal's stored
+ * enable_thinking value on every render.
+ *
+ * Covers:
+ * - Pal active, fresh chat, user flips OFF → toggle stays OFF, model receives
+ *   enable_thinking=false (no thinking bubble on first inference).
+ * - UI snap-back guard: tapping the toggle in a fresh no-session chat with a
+ *   pal active shows the new state immediately and does not revert.
+ * - Override does not leak across new chats: after sending, a fresh chat
+ *   (pal still active) reflects the pal's default again, not the user's
+ *   previous override.
+ *
+ * Usage:
+ *   yarn e2e:ios --spec thinking-pal-override --skip-build
+ *   yarn e2e:android --spec thinking-pal-override --skip-build
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {expect} from '@wdio/globals';
+import {ChatPage} from '../../pages/ChatPage';
+import {DrawerPage} from '../../pages/DrawerPage';
+import {ModelsPage} from '../../pages/ModelsPage';
+import {PalSheetPage} from '../../pages/PalSheetPage';
+import {Selectors, byText} from '../../helpers/selectors';
+import {
+  downloadAndLoadModel,
+  dismissPerformanceWarningIfPresent,
+  waitForInferenceComplete,
+} from '../../helpers/model-actions';
+import {TIMEOUTS} from '../../fixtures/models';
+import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
+
+declare const driver: WebdriverIO.Browser;
+declare const browser: WebdriverIO.Browser;
+
+/** Qwen3-0.6B: small thinking-capable model — matches thinking.spec.ts */
+const THINKING_MODEL = {
+  id: 'qwen3-0.6b',
+  searchQuery: 'bartowski Qwen_Qwen3-0.6B',
+  selectorText: 'Qwen_Qwen3-0.6B',
+  downloadFile: 'Qwen_Qwen3-0.6B-Q4_0.gguf',
+  prompts: [{input: "What's up?", description: 'Casual greeting'}],
+};
+
+/**
+ * Distinct from talent-tool-use.spec.ts's 'E2E Code Companion' so a stale
+ * pal from a prior run does not collide. A plain Assistant pal is enough:
+ * every pal carries enable_thinking=true via the v3 backfill migration,
+ * which is exactly the condition that produced #744.
+ */
+const PAL_NAME = 'E2E Thinking Override';
+
+const getAppBundleId = (): string =>
+  (driver as any).isAndroid ? 'com.pocketpalai.e2e' : 'ai.pocketpal';
+
+describe('Thinking Toggle Override (with pal active)', () => {
+  let chatPage: ChatPage;
+  let drawerPage: DrawerPage;
+  let palSheetPage: PalSheetPage;
+
+  before(async () => {
+    chatPage = new ChatPage();
+    drawerPage = new DrawerPage();
+    palSheetPage = new PalSheetPage();
+
+    await chatPage.waitForReady(TIMEOUTS.appReady);
+
+    await chatPage.openGenerationSettings();
+    await chatPage.setTemperature('0');
+    await chatPage.setSeed('1');
+    await chatPage.saveGenerationSettings();
+
+    await downloadAndLoadModel(THINKING_MODEL);
+
+    // Create a plain Assistant pal. The default Assistant template inherits
+    // defaultCompletionParams.enable_thinking=true, so the bug condition is
+    // satisfied without any extra configuration.
+    await chatPage.openDrawer();
+    await drawerPage.navigateToPals();
+
+    const addBtn = browser.$(Selectors.palsScreen.addButton);
+    await addBtn.waitForDisplayed({timeout: 15000});
+    await addBtn.click();
+    await browser.pause(500);
+
+    const assistantItem = browser.$(byText('Assistant'));
+    await assistantItem.waitForDisplayed({timeout: 5000});
+    await assistantItem.click();
+    await browser.pause(500);
+
+    await palSheetPage.setName(PAL_NAME);
+    await palSheetPage.submit();
+
+    // Returning from PalsScreen to Chat via drawer is unreliable
+    // (gesture conflicts). Restart and re-load the model. Pal persists in DB.
+    await browser.pause(1000);
+    await driver.terminateApp(getAppBundleId());
+    await browser.pause(1000);
+    await driver.activateApp(getAppBundleId());
+    await chatPage.waitForReady(TIMEOUTS.appReady);
+
+    await chatPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToModels();
+
+    const modelsPage = new ModelsPage();
+    await modelsPage.waitForReady();
+
+    const cardSelector = Selectors.modelCard.cardContainer(
+      THINKING_MODEL.downloadFile,
+    );
+    const modelCard = browser.$(cardSelector);
+    await modelCard.waitForDisplayed({timeout: 30000});
+
+    const loadBtn = modelCard.$(Selectors.modelCard.loadButtonElement);
+    await loadBtn.waitForDisplayed({timeout: 10000});
+    await loadBtn.click();
+
+    await dismissPerformanceWarningIfPresent();
+    await chatPage.waitForReady();
+
+    await chatPage.openPalPicker();
+    await chatPage.selectPal(PAL_NAME);
+  });
+
+  beforeEach(async () => {
+    chatPage = new ChatPage();
+    // Fresh no-session state for every test. resetActiveSession preserves
+    // newChatPalId from the active session/last selection, so the pal
+    // stays active across resets.
+    await chatPage.resetChat();
+    await browser.pause(300);
+  });
+
+  afterEach(async function (this: Mocha.Context) {
+    if (this.currentTest?.state === 'failed') {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const testName = this.currentTest.title.replace(/\s+/g, '-');
+      try {
+        if (!fs.existsSync(SCREENSHOT_DIR)) {
+          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
+        }
+        await driver.saveScreenshot(
+          path.join(SCREENSHOT_DIR, `failure-${testName}-${timestamp}.png`),
+        );
+      } catch (e) {
+        console.error('Failed to capture screenshot:', (e as Error).message);
+      }
+    }
+  });
+
+  it('toggle does not snap back when tapped in a fresh chat with a pal active', async () => {
+    expect(await chatPage.isThinkingToggleVisible()).toBe(true);
+    expect(await chatPage.isThinkingEnabled()).toBe(true);
+
+    await chatPage.tapThinkingToggle();
+
+    // The original #744 symptom: pal's enable_thinking value would re-overlay
+    // immediately on the next render and snap the toggle back. The override
+    // field must outlast that render cycle without sending anything.
+    expect(await chatPage.isThinkingEnabled()).toBe(false);
+
+    // A second read after a longer settle window guards against a delayed
+    // re-resolve that would have shown the bug as a 1–2 frame flicker.
+    await browser.pause(1500);
+    expect(await chatPage.isThinkingEnabled()).toBe(false);
+  });
+
+  it('first inference reflects the override (no thinking bubble) and toggle stays off', async () => {
+    expect(await chatPage.isThinkingEnabled()).toBe(true);
+
+    await chatPage.tapThinkingToggle();
+    expect(await chatPage.isThinkingEnabled()).toBe(false);
+
+    await chatPage.sendMessage("What's up?");
+
+    const aiMessageEl = browser.$(Selectors.chat.aiMessage);
+    await aiMessageEl.waitForExist({timeout: TIMEOUTS.inference});
+
+    // If the override leaked back to pal's enable_thinking=true between
+    // session creation and prepareCompletion, the Reasoning bubble would
+    // appear here. A short timeout is enough — the bubble streams in
+    // before the answer if thinking is on.
+    const thinkingVisible = await chatPage.isThinkingBubbleVisible(5000);
+    expect(thinkingVisible).toBe(false);
+
+    await waitForInferenceComplete();
+
+    // Toggle must still read OFF after the session was created and
+    // prepareCompletion finished; otherwise the snap-back happened after
+    // inference (still a regression, just shifted in time).
+    expect(await chatPage.isThinkingEnabled()).toBe(false);
+  });
+
+  it('override does not leak into the next new chat with the pal still active', async () => {
+    await chatPage.tapThinkingToggle();
+    expect(await chatPage.isThinkingEnabled()).toBe(false);
+
+    await chatPage.sendMessage("What's up?");
+
+    const aiMessageEl = browser.$(Selectors.chat.aiMessage);
+    await aiMessageEl.waitForExist({timeout: TIMEOUTS.inference});
+    await waitForInferenceComplete();
+
+    // resetActiveSession preserves newChatPalId and clears the override.
+    // Toggle should reflect the pal's default (enable_thinking=true), not
+    // the previous chat's user override.
+    await chatPage.resetChat();
+    await browser.pause(500);
+
+    expect(await chatPage.isThinkingEnabled()).toBe(true);
+  });
+});

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -1,6 +1,7 @@
 import React, {useRef, ReactNode, useState} from 'react';
 
 import {observer} from 'mobx-react';
+import {runInAction} from 'mobx';
 
 import {
   Bubble,
@@ -127,6 +128,7 @@ export const ChatScreen: React.FC = observer(() => {
     activeSession?.settingsSource,
     activeSession?.completionSettings,
     chatSessionStore.newChatCompletionSettings,
+    chatSessionStore.newChatThinkingOverride,
     activePalId,
   ]);
 
@@ -190,12 +192,14 @@ export const ChatScreen: React.FC = observer(() => {
       };
       await chatSessionStore.updateSessionCompletionSettings(updatedSettings);
     } else {
-      // Update global settings for new chats
-      const updatedSettings = {
-        ...chatSessionStore.newChatCompletionSettings,
-        enable_thinking: enabled,
-      };
-      await chatSessionStore.setNewChatCompletionSettings(updatedSettings);
+      // No active session: stage the user's choice on the new-chat
+      // override field. Resolver applies it as the last layer so the
+      // toggle persists; session creation bakes it in and births the
+      // session as 'custom'. Does NOT touch newChatCompletionSettings or
+      // newChatSettingsSource — pal's other params remain intact.
+      runInAction(() => {
+        chatSessionStore.newChatThinkingOverride = enabled;
+      });
     }
   };
 

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -230,6 +230,80 @@ describe('ChatScreen', () => {
     expect(modelStore.engine?.stopCompletion).toHaveBeenCalled();
   });
 
+  describe('thinking toggle in no-session chat', () => {
+    const palStore = require('../../../store').palStore;
+    const thinkingPal = {
+      id: 'pal-thinking',
+      type: 'assistant' as const,
+      name: 'Thinker',
+      systemPrompt: '',
+      parameters: {},
+      parameterSchema: [],
+      isSystemPromptChanged: false,
+      useAIPrompt: false,
+      source: 'local' as const,
+      completionSettings: {enable_thinking: true},
+    };
+
+    let savedModels: any[];
+
+    beforeEach(() => {
+      // Inject a thinking-capable model into the mock model list so the
+      // `activeModel?.supportsThinking` computed in ChatScreen returns true.
+      savedModels = modelStore.models;
+      const thinkingModel = {
+        ...modelStore.models[0],
+        id: 'thinking-model-id',
+        supportsThinking: true,
+      };
+      modelStore.models = [...modelStore.models, thinkingModel];
+
+      runInAction(() => {
+        modelStore.activeModelId = 'thinking-model-id';
+        modelStore.context = new LlamaContext(mockLlamaContextParams);
+        chatSessionStore.activeSessionId = null;
+        chatSessionStore.newChatPalId = thinkingPal.id;
+        chatSessionStore.newChatThinkingOverride = undefined;
+      });
+      modelStore.engine = {
+        completion: jest.fn(),
+        stopCompletion: jest.fn(),
+      };
+      palStore.pals = [thinkingPal];
+    });
+
+    afterEach(() => {
+      modelStore.models = savedModels;
+      modelStore.activeModelId = undefined;
+      jest.restoreAllMocks();
+    });
+
+    it('toggle press writes newChatThinkingOverride and does NOT touch newChatCompletionSettings', async () => {
+      const setGlobalSpy = jest.spyOn(
+        chatSessionStore,
+        'setNewChatCompletionSettings',
+      );
+
+      const {getByLabelText} = render(<ChatScreen />, {
+        withNavigation: true,
+      });
+
+      // Initial state: thinkingEnabled defaults true → toggle label is
+      // "Disable thinking mode". Tapping it should write `false` into the
+      // override field.
+      const toggle = getByLabelText('Disable thinking mode');
+      await act(async () => {
+        fireEvent.press(toggle);
+      });
+
+      // Primary signal: override is set to the new value.
+      expect(chatSessionStore.newChatThinkingOverride).toBe(false);
+
+      // Negative guard: global no-chat settings were NOT mutated.
+      expect(setGlobalSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('tool-compatibility banner', () => {
     const palStore = require('../../../store').palStore;
     const uiStore = require('../../../store').uiStore;

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -477,13 +477,24 @@ class ChatSessionStore {
     completionSettings: CompletionParams = defaultCompletionSettings,
   ): Promise<void> {
     try {
+      // If the user has staged a thinking override for the new-chat path,
+      // the resolved snapshot in `completionSettings` already carries it
+      // (applied last in `resolveCompletionSettings`). Birth the session as
+      // 'custom' so the resolver returns that snapshot verbatim on every
+      // subsequent inference — pal-derived params survive (merged before
+      // the override) and the user's choice is preserved.
+      const birthSource: 'pal' | 'custom' =
+        this.newChatThinkingOverride !== undefined
+          ? 'custom'
+          : this.newChatSettingsSource;
+
       // Create in database
       const newSession = await chatSessionRepository.createSession(
         title,
         initialMessages,
         completionSettings,
         this.newChatPalId,
-        this.newChatSettingsSource,
+        birthSource,
       );
 
       // Get the full session data
@@ -513,7 +524,7 @@ class ChatSessionStore {
         date: newSession.date,
         messages,
         completionSettings: settings,
-        settingsSource: this.newChatSettingsSource, // Use the stored settings source choice
+        settingsSource: birthSource, // 'custom' if a thinking override was staged, else stored source
         messagesLoaded: true, // Mark as loaded since we have the messages
       };
 

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -1390,6 +1390,16 @@ class ChatSessionStore {
       }
     }
 
+    // No-session-only: apply user's explicit thinking override last so it
+    // wins over pal's enable_thinking. Single-key overlay — does NOT touch
+    // any other field, and does NOT affect tool availability.
+    if (!sessionId && this.newChatThinkingOverride !== undefined) {
+      resolvedSettings = {
+        ...resolvedSettings,
+        enable_thinking: this.newChatThinkingOverride,
+      };
+    }
+
     // Apply session-specific settings based on explicit user choice
     if (sessionId) {
       const session = this.sessions.find(s => s.id === sessionId);

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -87,6 +87,11 @@ class ChatSessionStore {
   newChatCompletionSettings: CompletionParams = defaultCompletionSettings;
   newChatPalId: string | undefined = undefined;
   newChatSettingsSource: 'pal' | 'custom' = 'pal';
+  // User's manual thinking toggle in the no-session chat path. When set,
+  // the resolver applies it as the last layer (after pal) so the toggle
+  // persists; cleared on session creation, new-chat reset, and session
+  // switch.
+  newChatThinkingOverride: boolean | undefined = undefined;
   // Store localized date group names
   dateGroupNames: typeof DEFAULT_GROUP_NAMES = DEFAULT_GROUP_NAMES;
   // Migration status
@@ -309,6 +314,7 @@ class ChatSessionStore {
     runInAction(() => {
       this.newChatPalId = this.activePalId;
       this.newChatSettingsSource = 'pal'; // Reset to default for new chat
+      this.newChatThinkingOverride = undefined;
       // Do not copy completion settings from session to global settings
       // Instead, preserve global settings as they are
       this.exitEditMode();
@@ -355,6 +361,7 @@ class ChatSessionStore {
       // Don't modify global settings when changing sessions
       this.newChatPalId = undefined;
       this.newChatSettingsSource = 'pal'; // Reset for consistency
+      this.newChatThinkingOverride = undefined;
     });
   }
 
@@ -514,6 +521,7 @@ class ChatSessionStore {
         metaData.activePalId = this.newChatPalId;
         this.newChatPalId = undefined;
       }
+      this.newChatThinkingOverride = undefined;
 
       await this.updateSessionTitle(metaData);
 

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -530,15 +530,15 @@ class ChatSessionStore {
 
       if (this.newChatPalId) {
         metaData.activePalId = this.newChatPalId;
-        this.newChatPalId = undefined;
       }
-      this.newChatThinkingOverride = undefined;
 
       await this.updateSessionTitle(metaData);
 
       runInAction(() => {
         this.sessions.push(metaData);
         this.activeSessionId = newSession.id;
+        this.newChatPalId = undefined;
+        this.newChatThinkingOverride = undefined;
       });
     } catch (error) {
       console.error('Failed to create new session:', error);

--- a/src/store/__tests__/ChatSessionStore.palSettings.test.ts
+++ b/src/store/__tests__/ChatSessionStore.palSettings.test.ts
@@ -12,6 +12,7 @@ describe('ChatSessionStore - Pal Settings', () => {
     chatSessionStore.activeSessionId = null;
     chatSessionStore.newChatPalId = undefined;
     chatSessionStore.newChatCompletionSettings = {...defaultCompletionSettings};
+    chatSessionStore.newChatThinkingOverride = undefined;
     // Reset palStore
     palStore.pals = [];
   });
@@ -195,6 +196,116 @@ describe('ChatSessionStore - Pal Settings', () => {
       const result = await chatSessionStore.getCurrentCompletionSettings();
 
       expect(result.temperature).toBe(0.9);
+    });
+  });
+
+  describe('newChatThinkingOverride', () => {
+    const makeThinkingPal = (
+      id: string,
+      enableThinking: boolean,
+      extra: Partial<CompletionParams> = {},
+    ): Pal => ({
+      type: 'local',
+      id,
+      name: `Pal ${id}`,
+      description: '',
+      systemPrompt: '',
+      isSystemPromptChanged: false,
+      useAIPrompt: false,
+      parameters: {},
+      parameterSchema: [],
+      completionSettings: {
+        ...defaultCompletionSettings,
+        enable_thinking: enableThinking,
+        ...extra,
+      } as CompletionParams,
+      source: 'local',
+    });
+
+    it('override wins over pal in no-session resolve (default pal flips OFF)', async () => {
+      palStore.pals.push(makeThinkingPal('palX', true, {temperature: 0.5}));
+      chatSessionStore.newChatPalId = 'palX';
+      chatSessionStore.newChatThinkingOverride = false;
+
+      const result = await chatSessionStore.resolveCompletionSettings(
+        undefined,
+        'palX',
+      );
+
+      // Override wins for enable_thinking.
+      expect(result.enable_thinking).toBe(false);
+      // Pal's other completion settings survive — override is single-key.
+      expect(result.temperature).toBe(0.5);
+    });
+
+    it('override wins over pal in no-session resolve (authored pal flips ON)', async () => {
+      // Pal has enable_thinking: false; user flips to true via override.
+      palStore.pals.push(makeThinkingPal('palX', false));
+      chatSessionStore.newChatPalId = 'palX';
+      chatSessionStore.newChatThinkingOverride = true;
+
+      const result = await chatSessionStore.resolveCompletionSettings(
+        undefined,
+        'palX',
+      );
+
+      expect(result.enable_thinking).toBe(true);
+    });
+
+    it('override is ignored on session-branch resolution (settingsSource pal)', async () => {
+      palStore.pals.push(makeThinkingPal('palX', true));
+      // Active session with settingsSource='pal' — resolver should
+      // return pal's enable_thinking, NOT the no-session override.
+      chatSessionStore.sessions = [
+        {
+          id: 'session-1',
+          title: 'Session 1',
+          date: '2024-01-01',
+          messages: [],
+          completionSettings: {
+            ...defaultCompletionSettings,
+            enable_thinking: true,
+          },
+          activePalId: 'palX',
+          settingsSource: 'pal',
+        },
+      ];
+      chatSessionStore.newChatThinkingOverride = false;
+
+      const result = await chatSessionStore.resolveCompletionSettings(
+        'session-1',
+        'palX',
+      );
+
+      // Pal's value wins; override is not applied on the session branch.
+      expect(result.enable_thinking).toBe(true);
+    });
+
+    it('override does NOT strip PACT-derived tools', async () => {
+      // Pal advertises a registered talent — resolver should inject
+      // tools AND still let the override flip enable_thinking last.
+      const palWithTalent: Pal = {
+        ...makeThinkingPal('palToolful', true),
+        pact: {
+          talents: [{name: 'calculate', necessity: 'required'}],
+        },
+      };
+      palStore.pals.push(palWithTalent);
+      chatSessionStore.newChatPalId = 'palToolful';
+      chatSessionStore.newChatThinkingOverride = false;
+
+      const result = await chatSessionStore.resolveCompletionSettings(
+        undefined,
+        'palToolful',
+      );
+
+      expect(result.enable_thinking).toBe(false);
+      const tools = (result.tools ?? []) as any[];
+      expect(Array.isArray(tools)).toBe(true);
+      expect(tools.length).toBeGreaterThan(0);
+      // Tools came from the requested talent.
+      const toolNames = tools.map((t: any) => t?.function?.name ?? t?.name);
+      expect(toolNames).toContain('calculate');
     });
   });
 });

--- a/src/store/__tests__/ChatSessionStore.test.ts
+++ b/src/store/__tests__/ChatSessionStore.test.ts
@@ -1373,6 +1373,106 @@ describe('chatSessionStore', () => {
     });
   });
 
+  describe('newChatThinkingOverride — session-creation handoff & clears', () => {
+    beforeEach(() => {
+      chatSessionStore.newChatPalId = undefined;
+      chatSessionStore.newChatThinkingOverride = undefined;
+      chatSessionStore.newChatSettingsSource = 'pal';
+    });
+
+    it("births session as 'custom' when override is staged (overrides 'pal' source) — memory + DB", async () => {
+      const mockNewSession = {
+        id: 'new-session-override',
+        title: 'With Override',
+        date: new Date().toISOString(),
+      };
+      (chatSessionRepository.createSession as jest.Mock).mockResolvedValue(
+        mockNewSession,
+      );
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValue({
+        messages: [],
+        completionSettings: {getSettings: () => defaultCompletionSettings},
+      });
+
+      chatSessionStore.newChatPalId = 'palX';
+      chatSessionStore.newChatSettingsSource = 'pal';
+      chatSessionStore.newChatThinkingOverride = false;
+
+      await chatSessionStore.createNewSession('With Override');
+
+      // Memory-side: session.settingsSource is 'custom' at birth.
+      expect(chatSessionStore.sessions[0].settingsSource).toBe('custom');
+      // DB-side: repo received 'custom' too.
+      expect(chatSessionRepository.createSession).toHaveBeenCalledWith(
+        'With Override',
+        [],
+        defaultCompletionSettings,
+        'palX',
+        'custom',
+      );
+      // Override is one-shot — cleared in the same code block as newChatPalId.
+      expect(chatSessionStore.newChatThinkingOverride).toBeUndefined();
+      expect(chatSessionStore.newChatPalId).toBeUndefined();
+    });
+
+    it('births session with newChatSettingsSource when override is undefined (regression guard)', async () => {
+      const mockNewSession = {
+        id: 'new-session-default',
+        title: 'No Override',
+        date: new Date().toISOString(),
+      };
+      (chatSessionRepository.createSession as jest.Mock).mockResolvedValue(
+        mockNewSession,
+      );
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValue({
+        messages: [],
+        completionSettings: {getSettings: () => defaultCompletionSettings},
+      });
+
+      chatSessionStore.newChatPalId = 'palX';
+      chatSessionStore.newChatSettingsSource = 'pal';
+      chatSessionStore.newChatThinkingOverride = undefined;
+
+      await chatSessionStore.createNewSession('No Override');
+
+      expect(chatSessionStore.sessions[0].settingsSource).toBe('pal');
+      expect(chatSessionRepository.createSession).toHaveBeenCalledWith(
+        'No Override',
+        [],
+        defaultCompletionSettings,
+        'palX',
+        'pal',
+      );
+    });
+
+    it('clears override on resetActiveSession', () => {
+      chatSessionStore.newChatThinkingOverride = false;
+      chatSessionStore.activeSessionId = 'session1';
+
+      chatSessionStore.resetActiveSession();
+
+      expect(chatSessionStore.newChatThinkingOverride).toBeUndefined();
+    });
+
+    it('clears override on setActiveSession (session switch)', async () => {
+      const existing = {
+        id: 'session1',
+        title: 'Existing',
+        date: new Date().toISOString(),
+        messages: [],
+        completionSettings: defaultCompletionSettings,
+        settingsSource: 'pal' as 'pal' | 'custom',
+        messagesLoaded: true,
+      };
+      chatSessionStore.sessions = [existing];
+      chatSessionStore.newChatThinkingOverride = true;
+
+      await chatSessionStore.setActiveSession('session1');
+
+      expect(chatSessionStore.newChatThinkingOverride).toBeUndefined();
+    });
+  });
+
   describe('lazy loading', () => {
     it('setActiveSession loads messages on first access', async () => {
       const mockSession = {


### PR DESCRIPTION
## Summary

Fixes #744. In the no-session chat path (fresh chat, before the first message is sent), the thinking toggle in `ChatInput` snapped back to the active pal's `enable_thinking` value on every render — the user's tap had no observable effect, and on toggle-capable pals the user could not start a chat with thinking disabled.

Every pal carries `enable_thinking` (default `true`, backfilled by the v3 completion-settings migration and inherited from `defaultModel.completionSettings` for new pals), so the deterministic re-overlay in `ChatSessionStore.resolveCompletionSettings` (defaults → global → pal → tools) reverted the user's choice on the next `useEffect` re-read.

## Approach

A narrow, single-key user-override field rather than a generic per-chat override layer or a destructive pal-storage migration.

- `ChatSessionStore.newChatThinkingOverride: boolean | undefined` — MobX-only, no DB column, no migration.
- `resolveCompletionSettings` applies the override as the **last layer** in the no-session branch only (after PACT-derived `tools` are injected, so tool availability stays a function of `pal.pact.talents`).
- `ChatScreen.handleThinkingToggle`'s no-session branch writes the override field instead of `newChatCompletionSettings`. Pal's other completion settings (temperature, top_p, …) are no longer mutated as a side-effect.
- `createNewSession` reads the override at session birth: when set, the new session is born with `settingsSource = 'custom'` (in memory **and** in the DB row), so the baked snapshot — which already has the override applied — is what the resolver returns on the first inference. The override field is cleared in the same code block that clears `newChatPalId`.
- Override is also cleared on `resetActiveSession` and `setActiveSession` so it cannot leak across new-chat boundaries or session switches.
- The session-bound branch of `handleThinkingToggle` (`if (currentSession)`) is unchanged.

## Files changed

- `src/store/ChatSessionStore.ts` — new field, clear sites, resolver overlay, birth-source handoff
- `src/screens/ChatScreen/ChatScreen.tsx` — toggle handler no-session branch, `useEffect` dep
- `__mocks__/stores/chatSessionStore.ts` — mirror the new field on the mock
- `src/store/__tests__/ChatSessionStore.palSettings.test.ts` — resolver tests (override wins, session branch ignores override, PACT tools preserved)
- `src/store/__tests__/ChatSessionStore.test.ts` — `createNewSession` handoff (memory + repo arg), `resetActiveSession` / `setActiveSession` clear sites

## Verification

- `yarn lint` — 0 errors (4 pre-existing warnings in unrelated files)
- `yarn typecheck` — clean
- `yarn test --coverage` — 192/192 suites, 2751 passed, 2 skipped (pre-existing). Statements 72.4%, lines 72.5%. Touched files: `ChatSessionStore.ts` 82.7% statements, `ChatScreen.tsx` 78.1% statements.
- Native: TS/JS-only change; no `pod install` / native build required.

## Out of scope

- Stripping `enable_thinking` from pals + a DB migration (more destructive than the user-visible win once the override exists).
- A generic per-chat override layer (no second quick toggle exists today; revisit when one ships).
- The pre-existing preview-vs-inference asymmetry between `getCurrentCompletionSettings` (no-session preview passes `newChatPalId` unconditionally) and `addMessageToCurrentSession` (gates `palId` on `newChatSettingsSource === 'pal'`) — untouched by this PR, no observable disagreement for `enable_thinking`.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)