### PR TITLE
[Bug]: pal card falls back to creator avatar when no thumbnail

### DIFF
--- a/src/screens/PalsScreen/components/SquarePalCard/SquarePalCard.tsx
+++ b/src/screens/PalsScreen/components/SquarePalCard/SquarePalCard.tsx
@@ -159,9 +159,6 @@ const PalThumbnail: React.FC<{
   const thumbnailUrl = pal.thumbnail_url
     ? getFullThumbnailUri(pal.thumbnail_url)
     : undefined;
-  const creatorAvatarUrl = isPalsHubPal(pal)
-    ? pal.creator?.avatar_url
-    : pal.creator_info?.avatar_url;
 
   // Get pal colors for gradient background (local pals only)
   const palColors = isLocalPal(pal) ? pal.color : null;
@@ -201,27 +198,15 @@ const PalThumbnail: React.FC<{
   return (
     <View style={thumbnailStyle}>
       {thumbnailUrl ? (
-        <>
-          <Image
-            source={{uri: thumbnailUrl}}
-            style={styles.thumbnailImage}
-            resizeMode="cover"
-          />
-        </>
-      ) : creatorAvatarUrl ? (
-        <>
-          <Image
-            source={{uri: creatorAvatarUrl}}
-            style={styles.thumbnailImage}
-            resizeMode="cover"
-          />
-        </>
+        <Image
+          source={{uri: thumbnailUrl}}
+          style={styles.thumbnailImage}
+          resizeMode="cover"
+        />
       ) : (
-        <>
-          <Text style={[styles.thumbnailText, {color: textColor}]}>
-            {firstLetter}
-          </Text>
-        </>
+        <Text style={[styles.thumbnailText, {color: textColor}]}>
+          {firstLetter}
+        </Text>
       )}
 
       {/* Chat Navigation Button (only for downloaded/local pals) */}


### PR DESCRIPTION
## Summary
- Pal cards (`SquarePalCard`) without a `thumbnail_url` were falling back to the creator's `avatar_url`. For pals you authored yourself (locally or via PalsHub), the creator avatar is your own profile picture — so blank-thumbnail pals looked like they were branded with your face.
- Drop the creator-avatar branch and fall straight through to the first-letter placeholder, matching the behavior already used by `PalDetailSheet` (neutral placeholder, never the creator avatar).
- Server-side data is correct; this was purely a client-side rendering choice introduced with the original PalsHub integration.

## Test plan
- [x] `yarn test src/screens/PalsScreen/components/SquarePalCard` — 28/28 pass
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint src/screens/PalsScreen/components/SquarePalCard/SquarePalCard.tsx` — 0 errors
- [ ] Manual: load a self-authored pal with no thumbnail → expect first-letter placeholder, not profile pic

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)