### PR TITLE
Support alternative model sources and split GGUF downloads

### DIFF
--- a/__mocks__/external/@dr.pogodin/react-native-fs.js
+++ b/__mocks__/external/@dr.pogodin/react-native-fs.js
@@ -40,6 +40,7 @@ export const writeFile = jest.fn(() => {
   return Promise.resolve();
 });
 export const downloadFile = jest.fn();
+export const moveFile = jest.fn().mockResolvedValue(true);
 // Make DocumentDirectoryPath configurable for tests
 let documentDirectoryPath = '/path/to/documents';
 export const DocumentDirectoryPath = documentDirectoryPath;
@@ -73,6 +74,7 @@ const RNFS = {
   readFile,
   writeFile,
   downloadFile,
+  moveFile,
   DocumentDirectoryPath,
   LibraryDirectoryPath,
   MainBundlePath,

--- a/__mocks__/external/@dr.pogodin/react-native-fs.js
+++ b/__mocks__/external/@dr.pogodin/react-native-fs.js
@@ -1,6 +1,6 @@
 // Track deleted files for stateful behavior in tests
 const deletedFiles = new Set();
-export const stat = jest.fn();
+export const stat = jest.fn(() => Promise.resolve({size: 2 * 10 ** 9}));
 export const mkdir = jest.fn();
 export const unlink = jest.fn().mockImplementation(path => {
   deletedFiles.add(path);

--- a/__mocks__/stores/hfStore.ts
+++ b/__mocks__/stores/hfStore.ts
@@ -4,6 +4,7 @@ export const mockHFStore = {
   models: [mockHFModel1, mockHFModel2],
   isLoading: false,
   error: '',
+  modelDetailsLoading: false,
   nextPageLink: null,
   searchQuery: '',
   queryFilter: 'gguf',

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,6 +50,9 @@ react {
     //   A list of extra flags to pass to the 'bundle' commands.
     //   See https://github.com/react-native-community/cli/blob/main/docs/commands.md#bundle
     // extraPackagerArgs = []
+    if (project.hasProperty("metroMaxWorkers")) {
+        extraPackagerArgs = ["--max-workers", project.property("metroMaxWorkers").toString()]
+    }
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
@@ -240,6 +243,9 @@ dependencies {
 
     // OkHttp for DownloadModule (network requests)
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
+    // WatermelonDB JSI is not autolinked by the package's default Android config.
+    implementation project(':watermelondb-jsi')
 }
 
 project.ext.vectoricons = [

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,6 +80,11 @@ def enableProguardInReleaseBuilds = false
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["arm64-v8a", "x86_64"]
+}
+
 android {
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -93,7 +98,7 @@ android {
         versionCode 140
         versionName "1.15.1"
         ndk {
-            abiFilters "arm64-v8a", "x86_64"
+            abiFilters (*reactNativeArchitectures())
         }
     }
     externalNativeBuild {
@@ -103,6 +108,11 @@ android {
             // shim) into libappmodules.so. The replacement file must
             // include ReactNative-application.cmake — see jni/CMakeLists.txt.
             path file("src/main/jni/CMakeLists.txt")
+        }
+    }
+    packaging {
+        jniLibs {
+            pickFirsts += ['lib/**/libworklets.so']
         }
     }
     signingConfigs {
@@ -237,4 +247,3 @@ project.ext.vectoricons = [
 ]
 
 apply from: file("../../node_modules/react-native-vector-icons/fonts.gradle")
-

--- a/android/app/src/main/java/com/pocketpalai/download/DownloadDao.kt
+++ b/android/app/src/main/java/com/pocketpalai/download/DownloadDao.kt
@@ -25,4 +25,7 @@ interface DownloadDao {
 
     @Query("UPDATE downloads SET status = :status, error = :error WHERE id = :downloadId")
     suspend fun updateStatus(downloadId: String, status: DownloadStatus, error: String? = null)
-} 
+
+    @Query("UPDATE downloads SET authToken = NULL, requestHeaders = NULL WHERE id = :downloadId")
+    suspend fun clearSensitiveHeaders(downloadId: String)
+}

--- a/android/app/src/main/java/com/pocketpalai/download/DownloadDatabase.kt
+++ b/android/app/src/main/java/com/pocketpalai/download/DownloadDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [DownloadEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 abstract class DownloadDatabase : RoomDatabase() {
@@ -24,6 +24,12 @@ abstract class DownloadDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE downloads ADD COLUMN requestHeaders TEXT")
+            }
+        }
+
         @Volatile
         private var INSTANCE: DownloadDatabase? = null
 
@@ -34,10 +40,10 @@ abstract class DownloadDatabase : RoomDatabase() {
                     DownloadDatabase::class.java,
                     DATABASE_NAME
                 )
-                .addMigrations(MIGRATION_1_2)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                 .build()
                 .also { INSTANCE = it }
             }
         }
     }
-} 
+}

--- a/android/app/src/main/java/com/pocketpalai/download/DownloadEntity.kt
+++ b/android/app/src/main/java/com/pocketpalai/download/DownloadEntity.kt
@@ -16,7 +16,8 @@ data class DownloadEntity(
     val networkType: NetworkType,
     val createdAt: Long,
     val error: String? = null,
-    val authToken: String? = null
+    val authToken: String? = null,
+    val requestHeaders: String? = null
 )
 
 enum class DownloadStatus {
@@ -25,4 +26,4 @@ enum class DownloadStatus {
 
 enum class NetworkType {
     ANY, WIFI
-} 
+}

--- a/android/app/src/main/java/com/pocketpalai/download/DownloadModule.kt
+++ b/android/app/src/main/java/com/pocketpalai/download/DownloadModule.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.first
 import java.io.File
 import java.util.*
 import androidx.concurrent.futures.await
+import org.json.JSONObject
 
 @ReactModule(name = NativeDownloadModuleSpec.NAME)
 class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModuleSpec(reactContext) {
@@ -54,8 +55,26 @@ class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModu
         }
     }
 
+    private fun readableHeadersToJson(headers: ReadableMap?): String? {
+        if (headers == null) {
+            return null
+        }
+
+        val json = JSONObject()
+        val iterator = headers.keySetIterator()
+        while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            val value = headers.getString(key)
+            if (value != null) {
+                json.put(key, value)
+            }
+        }
+
+        return if (json.length() > 0) json.toString() else null
+    }
+
     override fun startDownload(url: String, config: ReadableMap, promise: Promise) {
-        Log.d(TAG, "Starting download with config: $config")
+        Log.d(TAG, "Starting download")
         scope.launch {
             try {
                 val downloadId = UUID.randomUUID().toString()
@@ -69,6 +88,11 @@ class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModu
                 val authToken = if (config.hasKey("authToken")) config.getString("authToken") else null
                 if (authToken != null) {
                     Log.d(TAG, "Authorization token provided for download")
+                }
+                val requestHeaders = if (config.hasKey("headers")) {
+                    readableHeadersToJson(config.getMap("headers"))
+                } else {
+                    null
                 }
 
                 val networkType = when (config.getString("networkType")) {
@@ -98,11 +122,15 @@ class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModu
                     priority = priority,
                     networkType = networkType,
                     createdAt = System.currentTimeMillis(),
-                    authToken = authToken
+                    authToken = authToken,
+                    requestHeaders = requestHeaders
                 )
 
                 withContext(Dispatchers.IO) {
-                    Log.d(TAG, "Inserting download into database: $download")
+                    Log.d(
+                        TAG,
+                        "Inserting download into database: id=$downloadId, destination=$destination, networkType=$networkType, hasAuthToken=${authToken != null}, hasHeaders=${requestHeaders != null}"
+                    )
                     downloadDao.insertDownload(download)
                 }
 
@@ -293,6 +321,7 @@ class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModu
                     if (download != null) {
                         Log.d(TAG, "Updating status to CANCELLED for download: $downloadId")
                         downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled by user")
+                        downloadDao.clearSensitiveHeaders(downloadId)
                         
                         // Clean up the partial download file
                         val file = File(download.destination)
@@ -470,6 +499,7 @@ class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModu
                         if (downloadInfo != null) {
                             Log.e(TAG, "Error details for ID $downloadId: ${downloadInfo.error}")
                             sendFailureEvent(downloadId, downloadInfo.error ?: "Unknown error")
+                            downloadDao.clearSensitiveHeaders(downloadId)
                         } else {
                             Log.w(TAG, "Download info not found for failed download: $downloadId")
                         }
@@ -485,6 +515,7 @@ class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModu
                     
                     // Log final database state after cancellation
                     scope.launch {
+                        downloadDao.clearSensitiveHeaders(downloadId)
                         logEntireDownloadDatabase()
                         removeWorkObserver(downloadId)
                     }
@@ -516,4 +547,4 @@ class DownloadModule(reactContext: ReactApplicationContext) : NativeDownloadModu
         private const val TAG = "DownloadModule"
         private fun getWorkName(downloadId: String) = "download_$downloadId"
     }
-} 
+}

--- a/android/app/src/main/java/com/pocketpalai/download/DownloadWorker.kt
+++ b/android/app/src/main/java/com/pocketpalai/download/DownloadWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.*
+import org.json.JSONObject
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -34,6 +35,46 @@ class DownloadWorker(
         currentCall?.cancel()
     }
 
+    private fun applyStoredHeaders(
+        requestBuilder: Request.Builder,
+        requestHeaders: String?
+    ): Boolean {
+        if (requestHeaders.isNullOrBlank()) {
+            return false
+        }
+
+        var hasAuthorization = false
+        try {
+            val json = JSONObject(requestHeaders)
+            val keys = json.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                val value = json.optString(key)
+                if (value.isNotBlank()) {
+                    requestBuilder.header(key, value)
+                    if (key.equals("Authorization", ignoreCase = true)) {
+                        hasAuthorization = true
+                    }
+                }
+            }
+        } catch (error: Exception) {
+            Log.w(TAG, "Ignoring invalid stored request headers", error)
+        }
+
+        return hasAuthorization
+    }
+
+    private suspend fun clearSensitiveHeaders(downloadId: String) {
+        downloadDao.clearSensitiveHeaders(downloadId)
+    }
+
+    private fun deletePartialFile(file: File, reason: String) {
+        if (file.exists()) {
+            Log.d(TAG, "Deleting partial download file after $reason: ${file.absolutePath}")
+            file.delete()
+        }
+    }
+
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         try {
             val downloadId = inputData.getString(KEY_DOWNLOAD_ID) ?: return@withContext Result.failure()
@@ -43,6 +84,7 @@ class DownloadWorker(
                 Log.d(TAG, "Work was cancelled before starting for ID: $downloadId")
                 handleStopped()
                 downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
+                clearSensitiveHeaders(downloadId)
                 return@withContext Result.failure()
             }
 
@@ -50,7 +92,10 @@ class DownloadWorker(
             Log.d(TAG, "Progress update interval: $progressInterval ms")
 
             val download = downloadDao.getDownload(downloadId) ?: return@withContext Result.failure()
-            Log.d(TAG, "Retrieved download info: $download")
+            Log.d(
+                TAG,
+                "Retrieved download info: id=${download.id}, status=${download.status}, progress=${download.downloadedBytes}/${download.totalBytes}"
+            )
 
             if (download.status == DownloadStatus.PAUSED) {
                 Log.d(TAG, "Download is paused, returning retry for ID: $downloadId")
@@ -69,7 +114,10 @@ class DownloadWorker(
                     // Reload download info after update
                     val updatedDownload = downloadDao.getDownload(downloadId)
                     if (updatedDownload != null) {
-                        Log.d(TAG, "Updated download info: $updatedDownload")
+                        Log.d(
+                            TAG,
+                            "Updated download info: id=${updatedDownload.id}, status=${updatedDownload.status}, progress=${updatedDownload.downloadedBytes}/${updatedDownload.totalBytes}"
+                        )
                     }
                 }
             }
@@ -77,16 +125,18 @@ class DownloadWorker(
             val request = Request.Builder()
                 .url(download.url)
                 .apply {
+                    val hasAuthorizationHeader = applyStoredHeaders(this, download.requestHeaders)
+
                     if (file.exists() && file.length() > 0) {
                         val range = "bytes=${file.length()}-"
                         Log.d(TAG, "Resuming download from byte ${file.length()}")
-                        addHeader("Range", range)
+                        header("Range", range)
                     }
                     
                     // Add authorization header if token is available
-                    download.authToken?.let { token ->
+                    download.authToken?.takeIf { !hasAuthorizationHeader }?.let { token ->
                         Log.d(TAG, "Adding Authorization header for authenticated download")
-                        addHeader("Authorization", "Bearer $token")
+                        header("Authorization", "Bearer $token")
                     }
                 }
                 .build()
@@ -127,23 +177,23 @@ class DownloadWorker(
                     416 -> {
                         Log.e(TAG, "Server rejected the range request for ID: $downloadId")
                         
-                        if (file.exists()) {
-                            Log.d(TAG, "Deleting invalid partial file: ${file.absolutePath}")
-                            file.delete()
-                        }
+                        deletePartialFile(file, "range rejection")
                         
                         downloadDao.updateStatus(
                             downloadId,
                             DownloadStatus.FAILED,
                             "Download failed: The partial download was invalid or the file on server has changed"
                         )
+                        clearSensitiveHeaders(downloadId)
                         
                         return@withContext Result.failure()
                     }
                     in 400..499 -> {
                         val error = "Client error: ${response.code}"
                         Log.e(TAG, error)
+                        deletePartialFile(file, "client error")
                         downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, error)
+                        clearSensitiveHeaders(downloadId)
                         return@withContext Result.failure()
                     }
                     in 500..599 -> {
@@ -155,7 +205,9 @@ class DownloadWorker(
                     else -> {
                         val error = "Unexpected response: ${response.code}"
                         Log.e(TAG, error)
+                        deletePartialFile(file, "unexpected response")
                         downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, error)
+                        clearSensitiveHeaders(downloadId)
                         return@withContext Result.failure()
                     }
                 }
@@ -209,6 +261,7 @@ class DownloadWorker(
                             if (isStopped) {
                                 Log.d(TAG, "Download cancelled during transfer for ID: $downloadId")
                                 downloadDao.updateStatus(downloadId, DownloadStatus.CANCELLED, "Download cancelled")
+                                clearSensitiveHeaders(downloadId)
                                 if (file.exists()) {
                                     file.delete()
                                     Log.d(TAG, "Deleted partial download file: ${file.absolutePath}")
@@ -244,17 +297,34 @@ class DownloadWorker(
 
                 Log.d(TAG, "Download completed successfully for ID: $downloadId")
                 downloadDao.updateProgress(downloadId, bytesWritten, totalBytes, DownloadStatus.COMPLETED)
+                clearSensitiveHeaders(downloadId)
                 return@withContext Result.success()
             }
 
             Log.e(TAG, "No response body for ID: $downloadId")
+            deletePartialFile(file, "empty response body")
+            downloadDao.updateStatus(downloadId, DownloadStatus.FAILED, "Download failed: Empty response body")
+            clearSensitiveHeaders(downloadId)
             return@withContext Result.failure()
         } catch (e: Exception) {
             Log.e(TAG, "Download failed", e)
             val downloadId = inputData.getString(KEY_DOWNLOAD_ID)
             downloadId?.let {
                 Log.e(TAG, "Updating status to FAILED for ID: $it")
+                val download = downloadDao.getDownload(it)
+                if (download?.status == DownloadStatus.CANCELLED) {
+                    clearSensitiveHeaders(it)
+                    return@withContext Result.failure()
+                }
+                if (download?.status == DownloadStatus.PAUSED) {
+                    return@withContext Result.retry()
+                }
+
+                download?.destination?.let { destination ->
+                    deletePartialFile(File(destination), "download failure")
+                }
                 downloadDao.updateStatus(it, DownloadStatus.FAILED, e.message)
+                clearSensitiveHeaders(it)
             }
             return@withContext Result.failure()
         }
@@ -299,4 +369,4 @@ class ProgressInterceptor : Interceptor {
             .body(if (originalBody != null) ProgressResponseBody(originalBody) else null)
             .build()
     }
-} 
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,8 @@ buildscript {
         kotlinVersion = "2.1.20"
     }
     repositories {
+        maven { url 'https://mirrors.cloud.tencent.com/nexus/repository/maven-public/' }
+        maven { url 'https://mirrors.cloud.tencent.com/nexus/repository/google/' }
         google()
         mavenCentral()
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
-networkTimeout=10000
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-9.0.0-bin.zip
+networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,24 @@
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
+pluginManagement {
+    includeBuild("../node_modules/@react-native/gradle-plugin")
+    repositories {
+        maven { url 'https://mirrors.cloud.tencent.com/nexus/repository/maven-public/' }
+        maven { url 'https://mirrors.cloud.tencent.com/nexus/repository/google/' }
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        maven { url 'https://mirrors.cloud.tencent.com/nexus/repository/maven-public/' }
+        maven { url 'https://mirrors.cloud.tencent.com/nexus/repository/google/' }
+        google()
+        mavenCentral()
+    }
+}
 rootProject.name = 'PocketPal'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,10 @@ module.exports = {
     '!**/ImageView.ios.ts',
     '!**/ImageView.tsx',
   ],
-  coveragePathIgnorePatterns: ['/src/screens/DevToolsScreen/'],
+  coveragePathIgnorePatterns: [
+    '/src/screens/DevToolsScreen/',
+    '<rootDir>/pr-work/',
+  ],
   coverageThreshold: {
     global: {
       branches: 60,
@@ -30,7 +33,8 @@ module.exports = {
     '**/__tests__/**/*.test.[jt]s?(x)',
     '**/?(*.)+(spec|test).[jt]s?(x)',
   ],
-  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/', '<rootDir>/pr-work/'],
+  modulePathIgnorePatterns: ['<rootDir>/pr-work/'],
   moduleNameMapper: {
     '@react-native-async-storage/async-storage':
       '<rootDir>/__mocks__/external/@react-native-async-storage/async-storage.js',

--- a/src/api/__tests__/hf.test.ts
+++ b/src/api/__tests__/hf.test.ts
@@ -21,7 +21,12 @@ describe('fetchModels', () => {
       }),
     );
     expect(result).toEqual({
-      models: [{id: 'model1'}],
+      models: [
+        expect.objectContaining({
+          id: 'model1',
+          source: 'huggingface',
+        }),
+      ],
       nextLink: 'next-page-link',
     });
   });

--- a/src/api/hf.ts
+++ b/src/api/hf.ts
@@ -1,13 +1,19 @@
 import axios from 'axios';
 
 import {urls} from '../config';
-
 import {
   GGUFSpecs,
   HuggingFaceModel,
   HuggingFaceModelsResponse,
   ModelFileDetails,
 } from '../utils/types';
+import {
+  fetchGGUFSpecsFromSource,
+  fetchModelFilesDetailsFromSource,
+  fetchModelsFromSource,
+} from './modelSources';
+
+const REQUEST_TIMEOUT_MS = 20000;
 
 /**
  * Get information from all models in the Hub.
@@ -47,45 +53,19 @@ export async function fetchModels({
   nextPageUrl?: string;
   authToken?: string | null;
 }): Promise<HuggingFaceModelsResponse> {
-  try {
-    const headers: Record<string, string> = {};
-
-    if (authToken) {
-      headers.Authorization = `Bearer ${authToken}`;
-    }
-
-    const response = await axios.get(nextPageUrl || urls.modelsList(), {
-      params: {
-        search,
-        author,
-        filter,
-        sort,
-        direction,
-        limit,
-        full,
-        config,
-      },
-      headers,
-    });
-
-    const linkHeader = response.headers.link;
-    let nextLink = null;
-
-    if (linkHeader) {
-      const match = linkHeader.match(/<([^>]*)>/);
-      if (match) {
-        nextLink = match[1];
-      }
-    }
-
-    return {
-      models: response.data as HuggingFaceModel[],
-      nextLink,
-    };
-  } catch (error) {
-    console.error('Error fetching models:', error);
-    throw error;
-  }
+  return fetchModelsFromSource({
+    source: 'huggingface',
+    search,
+    author,
+    filter,
+    sort,
+    direction,
+    limit,
+    full,
+    config,
+    nextPageUrl,
+    authToken,
+  });
 }
 
 /**
@@ -98,26 +78,11 @@ export const fetchModelFilesDetails = async (
   modelId: string,
   authToken?: string | null,
 ): Promise<ModelFileDetails[]> => {
-  const url = `${urls.modelTree(modelId)}?recursive=true`;
-
-  try {
-    const headers: Record<string, string> = {};
-    if (authToken) {
-      headers.Authorization = `Bearer ${authToken}`;
-    }
-
-    const response = await fetch(url, {headers});
-
-    if (!response.ok) {
-      throw new Error(`Error fetching model files: ${response.statusText}`);
-    }
-
-    const data: ModelFileDetails[] = await response.json();
-    return data;
-  } catch (error) {
-    console.error('Failed to fetch model files:', error);
-    throw error;
-  }
+  return fetchModelFilesDetailsFromSource({
+    source: 'huggingface',
+    modelId,
+    authToken,
+  });
 };
 
 /**
@@ -130,26 +95,11 @@ export const fetchGGUFSpecs = async (
   modelId: string,
   authToken?: string | null,
 ): Promise<GGUFSpecs> => {
-  const url = `${urls.modelSpecs(modelId)}?expand[]=gguf`;
-
-  try {
-    const headers: Record<string, string> = {};
-    if (authToken) {
-      headers.Authorization = `Bearer ${authToken}`;
-    }
-
-    const response = await fetch(url, {headers});
-
-    if (!response.ok) {
-      throw new Error(`Error fetching GGUF specs: ${response.statusText}`);
-    }
-
-    const data: GGUFSpecs = await response.json();
-    return data;
-  } catch (error) {
-    console.error('Failed to fetch GGUF specs:', error);
-    throw error;
-  }
+  return fetchGGUFSpecsFromSource({
+    source: 'huggingface',
+    modelId,
+    authToken,
+  });
 };
 
 /**
@@ -189,6 +139,7 @@ export async function fetchModelInfo({
         full,
       },
       headers,
+      timeout: REQUEST_TIMEOUT_MS,
     });
 
     const modelData: Partial<HuggingFaceModel> = {...response.data};
@@ -201,16 +152,13 @@ export async function fetchModelInfo({
     // Convert GGUF field to specs format for compatibility with existing code
     // The API returns: { "gguf": { "total": 123, "architecture": "llama", ... } }
     // But our code expects: { "specs": { "gguf": { "total": 123, ... } } }
-    // TODO: at some point this needs to be migrated to be compatible with HF datastructure.
     if (response.data.gguf) {
       modelData.specs = {
         _id: response.data._id || '',
         id: response.data.id || repoId,
         gguf: response.data.gguf,
-        // Include other fields that might be in the original specs format
         ...modelData.specs,
       };
-      // Remove the original gguf field since we've moved it to specs.gguf
       delete (modelData as any).gguf;
     }
 

--- a/src/api/modelSources/__tests__/modelSources.test.ts
+++ b/src/api/modelSources/__tests__/modelSources.test.ts
@@ -1,0 +1,347 @@
+import axios from 'axios';
+
+import {
+  fetchGGUFSpecsFromSource,
+  fetchModelFilesDetailsFromSource,
+  fetchModelsFromSource,
+} from '..';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('model source adapters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses hf-mirror as a Hugging Face compatible endpoint', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'owner/repo-GGUF',
+          author: 'owner',
+          siblings: [{rfilename: 'model.Q4_K_M.gguf'}],
+        },
+      ],
+      headers: {link: '<https://huggingface.co/api/models?cursor=next>'},
+    });
+
+    const result = await fetchModelsFromSource({
+      source: 'hf_mirror',
+      search: 'repo',
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://hf-mirror.com/api/models',
+      expect.objectContaining({
+        params: expect.objectContaining({search: 'repo'}),
+      }),
+    );
+    expect(result.models[0].source).toBe('hf_mirror');
+    expect(result.models[0].url).toBe('https://hf-mirror.com/owner/repo-GGUF');
+    expect(result.models[0].siblings[0].url).toBe(
+      'https://hf-mirror.com/owner/repo-GGUF/resolve/main/model.Q4_K_M.gguf',
+    );
+    expect(result.nextLink).toBe('https://hf-mirror.com/api/models?cursor=next');
+  });
+
+  it('normalizes ModelScope search results into GGUF-compatible models', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        Data: {
+          Models: [
+            {
+              ModelId: 'qwen/Qwen2.5-GGUF',
+              Owner: 'qwen',
+              Organization: {
+                Avatar: 'https://modelscope.cn/avatar/qwen.png',
+              },
+              Description: 'Qwen GGUF model',
+              Downloads: 10,
+              params: 1500000000,
+              file_size: 2048,
+              Stars: 2,
+              tags: ['library:gguf'],
+              Files: [
+                {Path: 'qwen.Q4_K_M.gguf', Size: 1024, Oid: 'abc'},
+                {Path: 'README.md', Size: 64},
+              ],
+            },
+          ],
+          total_count: 120,
+          page_number: 1,
+          page_size: 50,
+        },
+      },
+      headers: {},
+    });
+
+    const result = await fetchModelsFromSource({
+      source: 'modelscope',
+      search: 'qwen',
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://modelscope.cn/openapi/v1/models',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          search: 'qwen gguf',
+          page: 1,
+          page_size: 50,
+        }),
+      }),
+    );
+    expect(result.nextLink).toBe(
+      'https://modelscope.cn/openapi/v1/models?search=qwen%20gguf&page=2&page_size=50',
+    );
+    expect(result.models[0]).toEqual(
+      expect.objectContaining({
+        id: 'qwen/Qwen2.5-GGUF',
+        author: 'qwen',
+        source: 'modelscope',
+        description: 'Qwen GGUF model',
+        avatarUrl: 'https://modelscope.cn/avatar/qwen.png',
+        modelSize: 2048,
+        library_name: 'gguf',
+        url: 'https://modelscope.cn/models/qwen/Qwen2.5-GGUF',
+        specs: expect.objectContaining({
+          gguf: expect.objectContaining({total: 1500000000}),
+        }),
+      }),
+    );
+    expect(result.models[0].siblings).toHaveLength(1);
+    expect(result.models[0].siblings[0]).toEqual(
+      expect.objectContaining({
+        rfilename: 'qwen.Q4_K_M.gguf',
+        size: 1024,
+        oid: 'abc',
+      }),
+    );
+  });
+
+  it('loads additional ModelScope pages from the next page URL', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        data: {
+          models: [
+            {
+              id: 'qwen/Qwen3-GGUF',
+              author: 'qwen',
+              tags: ['library:gguf'],
+              files: [{path: 'qwen3.Q4_K_M.gguf', size: 1024}],
+            },
+          ],
+          total_count: 51,
+          page_number: 2,
+          page_size: 50,
+        },
+      },
+      headers: {},
+    });
+
+    const result = await fetchModelsFromSource({
+      source: 'modelscope',
+      nextPageUrl:
+        'https://modelscope.cn/openapi/v1/models?search=qwen%20gguf&page=2&page_size=50',
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://modelscope.cn/openapi/v1/models?search=qwen%20gguf&page=2&page_size=50',
+      expect.objectContaining({
+        params: undefined,
+      }),
+    );
+    expect(result.models[0].id).toBe('qwen/Qwen3-GGUF');
+    expect(result.nextLink).toBeNull();
+  });
+
+  it('keeps ModelScope GGUF repositories even when search results omit file lists', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        Data: {
+          Models: [
+            {
+              ModelId: 'deepseek/DeepSeek-R1-GGUF',
+              Owner: 'deepseek',
+              Description: 'Quantized GGUF models',
+              Downloads: 20,
+              Stars: 5,
+              tags: ['nlp'],
+            },
+            {
+              ModelId: 'deepseek/DeepSeek-R1',
+              Owner: 'deepseek',
+              Description: 'Original weights',
+              tags: ['nlp'],
+            },
+          ],
+          total_count: 2,
+          page_number: 1,
+          page_size: 50,
+        },
+      },
+      headers: {},
+    });
+
+    const result = await fetchModelsFromSource({
+      source: 'modelscope',
+      search: 'deepseek',
+    });
+
+    expect(result.models.map(model => model.id)).toEqual([
+      'deepseek/DeepSeek-R1-GGUF',
+    ]);
+  });
+
+  it('loads a ModelScope repository directly when search is owner/repo', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        Code: 200,
+        Data: {
+          ModelId: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+          Path: 'Qwen',
+          Name: 'Qwen2.5-0.5B-Instruct-GGUF',
+          Avatar: 'https://example.com/avatar.png',
+          Downloads: 10,
+          Stars: 2,
+          ModelInfos: {
+            gguf: {
+              model_size: 630167424,
+              architecture: 'qwen2',
+              gguf_file_list: [
+                {
+                  file_info: [
+                    {
+                      name: 'qwen2.5-0.5b-instruct-q4_k_m.gguf',
+                      size: 491400032,
+                      sha256: 'sha-1',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        Success: true,
+      },
+    });
+
+    const result = await fetchModelsFromSource({
+      source: 'modelscope',
+      search: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+      authToken: 'ms-token',
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://modelscope.cn/api/v1/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+      expect.objectContaining({
+        headers: {Authorization: 'Bearer ms-token'},
+      }),
+    );
+    expect(result.models[0]).toEqual(
+      expect.objectContaining({
+        id: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+        source: 'modelscope',
+        modelSize: 630167424,
+      }),
+    );
+    expect(result.models[0].siblings[0]).toEqual(
+      expect.objectContaining({
+        rfilename: 'qwen2.5-0.5b-instruct-q4_k_m.gguf',
+        size: 491400032,
+        oid: 'sha-1',
+      }),
+    );
+  });
+
+  it('returns ModelScope file details from the repo files endpoint', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        data: {Code: 200, Data: {}, Success: true},
+      })
+      .mockResolvedValueOnce({
+        data: {
+          Code: 200,
+          Data: {
+            Files: [
+              {
+                Path: 'qwen2.5-0.5b-instruct-q4_k_m.gguf',
+                Size: 491400032,
+                Sha256: 'sha-1',
+              },
+              {Path: 'README.md', Size: 1000},
+            ],
+          },
+          Success: true,
+        },
+      });
+
+    const details = await fetchModelFilesDetailsFromSource({
+      source: 'modelscope',
+      modelId: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+      authToken: 'ms-token',
+    });
+
+    expect(details).toEqual([
+      expect.objectContaining({
+        path: 'qwen2.5-0.5b-instruct-q4_k_m.gguf',
+        size: 491400032,
+        oid: 'sha-1',
+      }),
+    ]);
+  });
+
+  it('throws a clear ModelScope error when no GGUF files are found', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        data: {Code: 200, Data: {}, Success: true},
+      })
+      .mockResolvedValueOnce({
+        data: {
+          Code: 200,
+          Data: {Files: [{Path: 'README.md', Size: 1000}]},
+          Success: true,
+        },
+      });
+
+    await expect(
+      fetchModelFilesDetailsFromSource({
+        source: 'modelscope',
+        modelId: 'Qwen/No-GGUF',
+      }),
+    ).rejects.toThrow('No GGUF files found for ModelScope model: Qwen/No-GGUF');
+  });
+
+  it('extracts GGUF specs from ModelScope detail metadata', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        Code: 200,
+        Data: {
+          ModelId: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+          ModelInfos: {
+            gguf: {
+              model_size: 630167424,
+              architecture: 'qwen2',
+              context_length: 32768,
+            },
+          },
+        },
+        Success: true,
+      },
+    });
+
+    const specs = await fetchGGUFSpecsFromSource({
+      source: 'modelscope',
+      modelId: 'Qwen/Qwen2.5-0.5B-Instruct-GGUF',
+    });
+
+    expect(specs.gguf).toEqual(
+      expect.objectContaining({
+        total: 630167424,
+        architecture: 'qwen2',
+        context_length: 32768,
+      }),
+    );
+  });
+});

--- a/src/api/modelSources/__tests__/network.test.ts
+++ b/src/api/modelSources/__tests__/network.test.ts
@@ -1,0 +1,32 @@
+import {fetchWithTimeout} from '../network';
+
+describe('model source network helpers', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('aborts fetch requests after the timeout', async () => {
+    jest.spyOn(global, 'fetch').mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('aborted'), {name: 'AbortError'}));
+          });
+        }) as Promise<Response>,
+    );
+
+    const request = fetchWithTimeout('https://example.com/model', {}, 100);
+    const timeoutExpectation = expect(request).rejects.toThrow(
+      'Network timeout: request exceeded 100ms',
+    );
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    await timeoutExpectation;
+  });
+});

--- a/src/api/modelSources/hfCompatible.ts
+++ b/src/api/modelSources/hfCompatible.ts
@@ -1,0 +1,141 @@
+import axios from 'axios';
+
+import {urls} from '../../config';
+import {
+  GGUFSpecs,
+  HuggingFaceModel,
+  HuggingFaceModelsResponse,
+  ModelFileDetails,
+} from '../../utils/types';
+import {processHFSearchResults} from '../../utils/hf';
+import {ModelSourceConfig} from './types';
+import {
+  fetchWithTimeout,
+  MODEL_SOURCE_REQUEST_TIMEOUT_MS,
+} from './network';
+
+const REQUEST_TIMEOUT_MS = MODEL_SOURCE_REQUEST_TIMEOUT_MS;
+
+function getAuthHeaders(authToken?: string | null): Record<string, string> {
+  return authToken ? {Authorization: `Bearer ${authToken}`} : {};
+}
+
+function getNextLink(linkHeader?: string, domain?: string): string | null {
+  if (!linkHeader) {
+    return null;
+  }
+
+  const match = linkHeader.match(/<([^>]*)>/);
+  if (!match) {
+    return null;
+  }
+
+  const nextLink = match[1];
+  if (!domain) {
+    return nextLink;
+  }
+
+  return nextLink.replace(/^https:\/\/huggingface\.co/, domain);
+}
+
+export async function fetchHFCompatibleModels({
+  sourceConfig,
+  search,
+  author,
+  filter,
+  sort,
+  direction,
+  limit,
+  full,
+  config,
+  nextPageUrl,
+  authToken,
+}: {
+  sourceConfig: ModelSourceConfig;
+  search?: string;
+  author?: string;
+  filter?: string;
+  sort?: string;
+  direction?: string;
+  limit?: number;
+  full?: boolean;
+  config?: boolean;
+  nextPageUrl?: string;
+  authToken?: string | null;
+}): Promise<HuggingFaceModelsResponse> {
+  const response = await axios.get(
+    nextPageUrl || urls.hfCompatibleModelsList(sourceConfig.domain),
+    {
+      params: {
+        search,
+        author,
+        filter,
+        sort,
+        direction,
+        limit,
+        full,
+        config,
+      },
+      headers: getAuthHeaders(authToken),
+      timeout: REQUEST_TIMEOUT_MS,
+    },
+  );
+
+  return {
+    models: processHFSearchResults(response.data as HuggingFaceModel[], {
+      source: sourceConfig.id,
+      domain: sourceConfig.domain,
+    }),
+    nextLink: getNextLink(response.headers.link, sourceConfig.domain),
+  };
+}
+
+export const fetchHFCompatibleModelFilesDetails = async ({
+  sourceConfig,
+  modelId,
+  authToken,
+}: {
+  sourceConfig: ModelSourceConfig;
+  modelId: string;
+  authToken?: string | null;
+}): Promise<ModelFileDetails[]> => {
+  const url = `${urls.hfCompatibleModelTree(
+    sourceConfig.domain,
+    modelId,
+  )}?recursive=true`;
+
+  const response = await fetchWithTimeout(url, {
+    headers: getAuthHeaders(authToken),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error fetching model files: ${response.statusText}`);
+  }
+
+  return response.json() as Promise<ModelFileDetails[]>;
+};
+
+export const fetchHFCompatibleGGUFSpecs = async ({
+  sourceConfig,
+  modelId,
+  authToken,
+}: {
+  sourceConfig: ModelSourceConfig;
+  modelId: string;
+  authToken?: string | null;
+}): Promise<GGUFSpecs> => {
+  const url = `${urls.hfCompatibleModelSpecs(
+    sourceConfig.domain,
+    modelId,
+  )}?expand[]=gguf`;
+
+  const response = await fetchWithTimeout(url, {
+    headers: getAuthHeaders(authToken),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error fetching GGUF specs: ${response.statusText}`);
+  }
+
+  return response.json() as Promise<GGUFSpecs>;
+};

--- a/src/api/modelSources/index.ts
+++ b/src/api/modelSources/index.ts
@@ -1,0 +1,105 @@
+import {
+  GGUFSpecs,
+  HuggingFaceModelsResponse,
+  ModelFileDetails,
+  ModelSourceId,
+} from '../../utils/types';
+import {stripSourceScope} from '../../utils/modelSources';
+import {
+  fetchHFCompatibleGGUFSpecs,
+  fetchHFCompatibleModelFilesDetails,
+  fetchHFCompatibleModels,
+} from './hfCompatible';
+import {
+  fetchModelScopeGGUFSpecs,
+  fetchModelScopeModelFilesDetails,
+  fetchModelScopeModels,
+} from './modelscope';
+import {getModelSourceConfig, isHFCompatibleSource} from './registry';
+import {
+  FetchGGUFSpecsParams,
+  FetchModelFilesParams,
+  FetchSourceModelsParams,
+} from './types';
+
+function normalizeModelId(source: ModelSourceId, modelId: string): string {
+  return source === 'huggingface' ? modelId : stripSourceScope(modelId);
+}
+
+export async function fetchModelsFromSource({
+  source,
+  ...params
+}: FetchSourceModelsParams): Promise<HuggingFaceModelsResponse> {
+  const sourceConfig = getModelSourceConfig(source);
+
+  if (isHFCompatibleSource(source)) {
+    return fetchHFCompatibleModels({
+      sourceConfig,
+      ...params,
+    });
+  }
+
+  return fetchModelScopeModels({
+    sourceConfig,
+    search: params.search,
+    author: params.author,
+    sort: params.sort,
+    limit: params.limit,
+    nextPageUrl: params.nextPageUrl,
+    authToken: params.authToken,
+  });
+}
+
+export async function fetchModelFilesDetailsFromSource({
+  source,
+  modelId,
+  authToken,
+}: FetchModelFilesParams): Promise<ModelFileDetails[]> {
+  const sourceConfig = getModelSourceConfig(source);
+  const normalizedModelId = normalizeModelId(source, modelId);
+
+  if (isHFCompatibleSource(source)) {
+    return fetchHFCompatibleModelFilesDetails({
+      sourceConfig,
+      modelId: normalizedModelId,
+      authToken,
+    });
+  }
+
+  return fetchModelScopeModelFilesDetails({
+    sourceConfig,
+    modelId: normalizedModelId,
+    authToken,
+  });
+}
+
+export async function fetchGGUFSpecsFromSource({
+  source,
+  modelId,
+  authToken,
+}: FetchGGUFSpecsParams): Promise<GGUFSpecs> {
+  const sourceConfig = getModelSourceConfig(source);
+  const normalizedModelId = normalizeModelId(source, modelId);
+
+  if (isHFCompatibleSource(source)) {
+    return fetchHFCompatibleGGUFSpecs({
+      sourceConfig,
+      modelId: normalizedModelId,
+      authToken,
+    });
+  }
+
+  return fetchModelScopeGGUFSpecs({
+    sourceConfig,
+    modelId: normalizedModelId,
+    authToken,
+  });
+}
+
+export {getModelSourceConfig, isHFCompatibleSource};
+export type {
+  FetchGGUFSpecsParams,
+  FetchModelFilesParams,
+  FetchSourceModelsParams,
+  ModelSourceConfig,
+} from './types';

--- a/src/api/modelSources/modelscope.ts
+++ b/src/api/modelSources/modelscope.ts
@@ -1,0 +1,828 @@
+import axios from 'axios';
+
+import {urls} from '../../config';
+import {
+  GGUFSpecs,
+  HuggingFaceModel,
+  HuggingFaceModelsResponse,
+  ModelFile,
+  ModelFileDetails,
+} from '../../utils/types';
+import {filterValidGGUFFiles} from '../../utils/hf';
+import {ModelSourceConfig} from './types';
+import {MODEL_SOURCE_REQUEST_TIMEOUT_MS} from './network';
+
+const REQUEST_TIMEOUT_MS = MODEL_SOURCE_REQUEST_TIMEOUT_MS;
+const DEFAULT_REVISION = 'master';
+const DEFAULT_PAGE_SIZE = 50;
+
+class ModelScopeResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ModelScopeResponseError';
+  }
+}
+
+function asArray(value: any): any[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function firstDefined<T>(...values: T[]): T | undefined {
+  return values.find(value => value !== undefined && value !== null);
+}
+
+function getNested(obj: any, path: string[]): any {
+  return path.reduce((current, key) => current?.[key], obj);
+}
+
+function extractList(data: any): any[] {
+  const candidates = [
+    data?.Data?.Models,
+    data?.Data?.ModelList,
+    data?.Data?.Rows,
+    data?.Data?.List,
+    data?.Data?.data,
+    data?.Data,
+    data?.data?.Models,
+    data?.data?.ModelsList,
+    data?.data?.Rows,
+    data?.data?.List,
+    data?.data?.models,
+    data?.data?.list,
+    data?.data,
+    data?.models,
+    data?.ModelList,
+    data?.Models,
+  ];
+
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+  }
+
+  return [];
+}
+
+function getTotalCount(data: any): number {
+  return (
+    Number(
+      firstDefined(
+        data?.Data?.TotalCount,
+        data?.Data?.total_count,
+        data?.Data?.Total,
+        data?.Data?.total,
+        data?.data?.TotalCount,
+        data?.data?.total_count,
+        data?.data?.Total,
+        data?.data?.total,
+        data?.total_count,
+        data?.TotalCount,
+        data?.total,
+        data?.Total,
+        0,
+      ),
+    ) || 0
+  );
+}
+
+function getPageNumber(data: any, fallback: number): number {
+  return (
+    Number(
+      firstDefined(
+        data?.Data?.PageNumber,
+        data?.Data?.page_number,
+        data?.Data?.page,
+        data?.data?.PageNumber,
+        data?.data?.page_number,
+        data?.data?.page,
+        data?.page_number,
+        data?.PageNumber,
+        data?.page,
+        fallback,
+      ),
+    ) || fallback
+  );
+}
+
+function getPageSize(data: any, fallback: number): number {
+  return (
+    Number(
+      firstDefined(
+        data?.Data?.PageSize,
+        data?.Data?.page_size,
+        data?.data?.PageSize,
+        data?.data?.page_size,
+        data?.page_size,
+        data?.PageSize,
+        fallback,
+      ),
+    ) || fallback
+  );
+}
+
+function buildQueryString(params: Record<string, any>): string {
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+    )
+    .join('&');
+}
+
+function getQueryParam(url: string | undefined, key: string): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+
+  const query = url.split('?')[1]?.split('#')[0];
+  if (!query) {
+    return undefined;
+  }
+
+  for (const part of query.split('&')) {
+    const [rawKey, ...rawValueParts] = part.split('=');
+    if (decodeURIComponent(rawKey) === key) {
+      const value = rawValueParts.join('=').replace(/\+/g, ' ');
+      return value ? decodeURIComponent(value) : undefined;
+    }
+  }
+
+  return undefined;
+}
+
+function getNextPageLink({
+  data,
+  endpoint,
+  search,
+  author,
+  sort,
+  page,
+  pageSize,
+}: {
+  data: any;
+  endpoint: string;
+  search?: string;
+  author?: string;
+  sort?: string;
+  page: number;
+  pageSize: number;
+}): string | null {
+  const totalCount = getTotalCount(data);
+  const currentPage = getPageNumber(data, page);
+  const resolvedPageSize = getPageSize(data, pageSize);
+
+  if (!totalCount || currentPage * resolvedPageSize >= totalCount) {
+    return null;
+  }
+
+  const query = buildQueryString({
+    search,
+    owner: author,
+    sort,
+    page: currentPage + 1,
+    page_size: resolvedPageSize,
+  });
+
+  return `${endpoint}?${query}`;
+}
+
+function getString(value: any): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function getImageFromMarkdown(value: any): string | undefined {
+  const markdown = getString(value);
+  if (!markdown) {
+    return undefined;
+  }
+
+  const imageMatch = markdown.match(/!\[[^\]]*]\((https?:\/\/[^)\s]+)\)/i);
+  if (imageMatch?.[1]) {
+    return imageMatch[1];
+  }
+
+  const htmlMatch = markdown.match(/<img[^>]+src=["'](https?:\/\/[^"']+)["']/i);
+  return htmlMatch?.[1];
+}
+
+function getModelScopeAvatar(raw: any): string | undefined {
+  return getString(
+    firstDefined(
+      raw?.Avatar,
+      raw?.avatar,
+      raw?.AvatarUrl,
+      raw?.avatarUrl,
+      raw?.avatar_url,
+      raw?.OwnerAvatar,
+      raw?.ownerAvatar,
+      raw?.Organization?.Avatar,
+      raw?.organization?.avatar,
+      raw?.Org?.Avatar,
+      raw?.org?.avatar,
+      raw?.CoverImage,
+      raw?.coverImage,
+      raw?.CoverImages?.[0],
+      raw?.cover_images?.[0],
+      raw?.NEXA?.ModelCover,
+      raw?.nexa?.modelCover,
+      getImageFromMarkdown(raw?.ReadMeContent),
+      getImageFromMarkdown(raw?.README),
+      getImageFromMarkdown(raw?.readme),
+    ),
+  );
+}
+
+function normalizeRepoId(raw: any): string {
+  const cleanRepoId = (repoId: string) =>
+    repoId.replace(/^models\//, '').replace(/^\/+/, '');
+
+  const explicitRepoId = firstDefined(
+    raw?.ModelId,
+    raw?.model_id,
+    raw?.modelId,
+    raw?.id,
+    raw?.Id,
+  );
+  if (explicitRepoId) {
+    return cleanRepoId(String(explicitRepoId));
+  }
+
+  const path = String(firstDefined(raw?.Path, raw?.path, '') || '');
+  if (path.includes('/')) {
+    return cleanRepoId(path);
+  }
+
+  const name = String(
+    firstDefined(
+      raw?.Name,
+      raw?.name,
+      raw?.ModelName,
+      raw?.modelName,
+    ) || '',
+  );
+  if (path && name) {
+    return cleanRepoId(`${path}/${name}`);
+  }
+
+  return cleanRepoId(path || name);
+}
+
+function splitRepoId(repoId: string): {owner: string; name: string} {
+  const [owner = 'unknown', ...rest] = repoId.split('/');
+  return {
+    owner,
+    name: rest.join('/') || repoId,
+  };
+}
+
+function normalizeModelScopeFile(
+  repoId: string,
+  rawFile: any,
+): ModelFile | null {
+  const rfilename = String(
+    firstDefined(
+      rawFile?.rfilename,
+      rawFile?.path,
+      rawFile?.Path,
+      rawFile?.name,
+      rawFile?.Name,
+      rawFile?.file_name,
+      rawFile?.FileName,
+    ) || '',
+  );
+
+  if (!rfilename) {
+    return null;
+  }
+
+  const size = Number(
+    firstDefined(
+      rawFile?.size,
+      rawFile?.Size,
+      rawFile?.lfs?.size,
+      rawFile?.Lfs?.Size,
+      rawFile?.LFS?.Size,
+    ) || 0,
+  );
+  const oid = firstDefined(
+    rawFile?.oid,
+    rawFile?.Oid,
+    rawFile?.sha,
+    rawFile?.Sha,
+    rawFile?.sha256,
+    rawFile?.Sha256,
+    rawFile?.lfs?.oid,
+    rawFile?.Lfs?.Oid,
+  );
+  const url = firstDefined(
+    rawFile?.url,
+    rawFile?.Url,
+    rawFile?.download_url,
+    rawFile?.downloadUrl,
+    rawFile?.DownloadUrl,
+    urls.modelScopeDownloadFile(repoId, rfilename, DEFAULT_REVISION),
+  );
+
+  return {
+    rfilename,
+    size: size > 0 ? size : undefined,
+    oid: oid ? String(oid) : undefined,
+    url: String(url),
+    lfs: size > 0 && oid ? {oid: String(oid), size, pointerSize: 0} : undefined,
+  };
+}
+
+function extractFiles(repoId: string, data: any): ModelFile[] {
+  const ggufInfos = firstDefined(
+    getNested(data, ['Data', 'ModelInfos', 'gguf', 'gguf_file_list']),
+    getNested(data, ['Data', 'modelInfos', 'gguf', 'gguf_file_list']),
+    getNested(data, ['ModelInfos', 'gguf', 'gguf_file_list']),
+    getNested(data, ['modelInfos', 'gguf', 'gguf_file_list']),
+  );
+
+  if (Array.isArray(ggufInfos)) {
+    const files = ggufInfos
+      .flatMap(item => asArray(item?.file_info))
+      .map(file =>
+        normalizeModelScopeFile(repoId, {
+          ...file,
+          Path: file?.name,
+          Oid: file?.sha256,
+        }),
+      )
+      .filter((file): file is ModelFile => Boolean(file));
+    if (files.length > 0) {
+      return filterValidGGUFFiles(files) as ModelFile[];
+    }
+  }
+
+  const candidates = [
+    data?.Data?.Files,
+    data?.Data?.files,
+    data?.Data?.RepoFiles,
+    data?.Data?.ModelFiles,
+    data?.Data?.Siblings,
+    data?.data?.files,
+    data?.data?.Files,
+    data?.files,
+    data?.Files,
+    data?.siblings,
+    data?.Siblings,
+    getNested(data, ['Data', 'Model', 'Files']),
+    getNested(data, ['data', 'model', 'files']),
+  ];
+
+  for (const candidate of candidates) {
+    const files = asArray(candidate)
+      .map(file => normalizeModelScopeFile(repoId, file))
+      .filter((file): file is ModelFile => Boolean(file));
+    if (files.length > 0) {
+      return filterValidGGUFFiles(files) as ModelFile[];
+    }
+  }
+
+  return [];
+}
+
+function normalizeModelScopeModel(raw: any): HuggingFaceModel | null {
+  const repoId = normalizeRepoId(raw);
+  if (!repoId) {
+    return null;
+  }
+
+  const {owner} = splitRepoId(repoId);
+  const siblings = extractFiles(repoId, raw);
+  const lastModifiedRaw = firstDefined(
+    raw?.LastModified,
+    raw?.lastModified,
+    raw?.GmtModified,
+    raw?.gmtModified,
+    raw?.UpdatedAt,
+    raw?.updated_at,
+    raw?.ModifiedTime,
+    raw?.modifiedTime,
+    raw?.LastUpdatedTime,
+    raw?.lastUpdatedTime,
+    raw?.CreatedTime,
+    raw?.createdTime,
+    raw?.CreatedAt,
+    raw?.created_at,
+    new Date().toISOString(),
+  );
+  const lastModified = String(
+    typeof lastModifiedRaw === 'number'
+      ? new Date(lastModifiedRaw * 1000).toISOString()
+      : lastModifiedRaw,
+  );
+  const modelInfos = raw?.ModelInfos?.gguf || raw?.modelInfos?.gguf;
+  const modelSize = Number(
+    firstDefined(
+      raw?.ModelSize,
+      raw?.modelSize,
+      raw?.file_size,
+      raw?.FileSize,
+      modelInfos?.model_size,
+      0,
+    ),
+  );
+  const parameterCount = Number(
+    firstDefined(raw?.params, raw?.Params, raw?.Parameters, raw?.parameters, 0),
+  );
+  const libraryFromTags = asArray(raw?.tags).find((tag: string) =>
+    tag.startsWith('library:'),
+  );
+  const libraryName = firstDefined(
+    raw?.LibraryName,
+    raw?.library_name,
+    raw?.Libraries?.[0],
+    libraryFromTags?.split(':')[1],
+    siblings.length > 0 ? 'gguf' : '',
+  );
+
+  return {
+    _id: repoId,
+    id: repoId,
+    author: String(firstDefined(raw?.Owner, raw?.owner, raw?.author, owner)),
+    gated: Boolean(firstDefined(raw?.Gated, raw?.gated, false)),
+    inference: '',
+    lastModified,
+    likes: Number(firstDefined(raw?.Stars, raw?.stars, raw?.likes, 0)) || 0,
+    trendingScore:
+      Number(firstDefined(raw?.TrendingScore, raw?.trendingScore, 0)) || 0,
+    private: Boolean(firstDefined(raw?.Private, raw?.private, false)),
+    sha: String(firstDefined(raw?.Sha, raw?.sha, '')),
+    downloads:
+      Number(
+        firstDefined(
+          raw?.Downloads,
+          raw?.downloads,
+          raw?.DownloadCount,
+          raw?.downloadCount,
+          raw?.download_count,
+          0,
+        ),
+      ) || 0,
+    tags: asArray(firstDefined(raw?.Tags, raw?.tags, raw?.Tasks, raw?.tasks)),
+    library_name: String(libraryName),
+    createdAt: String(
+      firstDefined(raw?.CreatedAt, raw?.created_at, lastModified),
+    ),
+    model_id: repoId,
+    siblings,
+    url: urls.modelScopeWebPage(repoId),
+    source: 'modelscope',
+    sourceRepoId: repoId,
+    avatarUrl: getModelScopeAvatar(raw),
+    description: firstDefined(
+      raw?.Description,
+      raw?.description,
+      raw?.Summary,
+      raw?.summary,
+      raw?.Intro,
+      raw?.intro,
+      raw?.ChineseName,
+    ),
+    modelSize: modelSize > 0 ? modelSize : undefined,
+    specs:
+      parameterCount > 0
+        ? {
+            _id: repoId,
+            id: repoId,
+            gguf: {
+              total: parameterCount,
+              architecture: '',
+              context_length: 0,
+            },
+          }
+        : undefined,
+  };
+}
+
+function shouldKeepModelScopeSearchModel(model: HuggingFaceModel): boolean {
+  const tags = (model.tags || []).map(tag => tag.toLowerCase());
+  const searchableText = [
+    model.id,
+    model.model_id,
+    model.library_name,
+    model.description,
+    ...tags,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  return model.siblings.length > 0 || searchableText.includes('gguf');
+}
+
+function toFileDetails(files: ModelFile[]): ModelFileDetails[] {
+  return files.map(file => ({
+    type: 'file',
+    oid: file.oid || file.lfs?.oid || '',
+    size: file.size || file.lfs?.size || 0,
+    lfs: file.lfs,
+    path: file.rfilename,
+  }));
+}
+
+function getAuthHeaders(authToken?: string | null): Record<string, string> {
+  return authToken ? {Authorization: `Bearer ${authToken}`} : {};
+}
+
+function assertSuccessfulModelScopeResponse(data: any, endpoint: string) {
+  if (
+    data &&
+    typeof data === 'object' &&
+    data.Success === false &&
+    data.Code !== 200
+  ) {
+    throw new ModelScopeResponseError(
+      data.Message || `ModelScope request failed for ${endpoint}`,
+    );
+  }
+}
+
+function looksLikeRepoId(value?: string): boolean {
+  return Boolean(value && /^[^/\s]+\/[^/\s]+$/.test(value.trim()));
+}
+
+async function tryModelScopeGet(
+  url: string,
+  params?: Record<string, any>,
+  authToken?: string | null,
+) {
+  try {
+    const response = await axios.get(url, {
+      params,
+      headers: getAuthHeaders(authToken),
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+    if (!response?.data) {
+      return null;
+    }
+    assertSuccessfulModelScopeResponse(response.data, url);
+    return response;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function fetchModelScopeDetail(
+  sourceConfig: ModelSourceConfig,
+  repoId: string,
+  authToken?: string | null,
+): Promise<any | null> {
+  const {owner, name} = splitRepoId(repoId);
+  const ownerPath = `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  const encodedRepo = encodeURIComponent(repoId);
+
+  const urlsToTry = [
+    `${sourceConfig.apiBase}/models/${ownerPath}`,
+    `${sourceConfig.apiBase}/models/${encodedRepo}`,
+    `${sourceConfig.domain}/api/v1/models/${ownerPath}`,
+  ];
+
+  for (const detailUrl of urlsToTry) {
+    const response = await tryModelScopeGet(detailUrl, undefined, authToken);
+    if (response?.data) {
+      return response.data;
+    }
+  }
+
+  return null;
+}
+
+async function fetchModelScopeFiles(
+  sourceConfig: ModelSourceConfig,
+  repoId: string,
+  authToken?: string | null,
+): Promise<ModelFile[]> {
+  const {owner, name} = splitRepoId(repoId);
+  const ownerPath = `${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+  const fileEndpoints = [
+    `${sourceConfig.apiBase}/models/${ownerPath}/repo/files`,
+    `${sourceConfig.apiBase}/models/${ownerPath}/repo/tree`,
+    `${sourceConfig.apiBase}/models/${ownerPath}/files`,
+  ];
+
+  for (const endpoint of fileEndpoints) {
+    const response = await tryModelScopeGet(
+      endpoint,
+      {
+        Revision: DEFAULT_REVISION,
+        revision: DEFAULT_REVISION,
+        Recursive: true,
+        recursive: true,
+      },
+      authToken,
+    );
+    if (response?.data) {
+      const files = extractFiles(repoId, response.data);
+      if (files.length > 0) {
+        return files;
+      }
+    }
+  }
+
+  return [];
+}
+
+async function fetchModelScopeDirectModel(
+  sourceConfig: ModelSourceConfig,
+  repoId: string,
+  authToken?: string | null,
+): Promise<HuggingFaceModel> {
+  const detail = await fetchModelScopeDetail(sourceConfig, repoId, authToken);
+  if (!detail) {
+    throw new ModelScopeResponseError(`ModelScope model not found: ${repoId}`);
+  }
+
+  const rawModel = detail.Data || detail;
+  const normalized = normalizeModelScopeModel({
+    ...rawModel,
+    ModelId: repoId,
+  });
+  if (!normalized) {
+    throw new ModelScopeResponseError(
+      `ModelScope model response could not be parsed: ${repoId}`,
+    );
+  }
+
+  const files =
+    normalized.siblings.length > 0
+      ? normalized.siblings
+      : await fetchModelScopeFiles(sourceConfig, repoId, authToken);
+
+  return {
+    ...normalized,
+    siblings: files,
+  };
+}
+
+export async function fetchModelScopeModels({
+  sourceConfig,
+  search,
+  author,
+  sort,
+  limit,
+  authToken,
+  nextPageUrl,
+}: {
+  sourceConfig: ModelSourceConfig;
+  search?: string;
+  author?: string;
+  sort?: string;
+  limit?: number;
+  authToken?: string | null;
+  nextPageUrl?: string;
+}): Promise<HuggingFaceModelsResponse> {
+  if (looksLikeRepoId(search) && !nextPageUrl) {
+    const model = await fetchModelScopeDirectModel(
+      sourceConfig,
+      search!.trim(),
+      authToken,
+    );
+    return {models: [model], nextLink: null};
+  }
+
+  const pageSize = Math.max(limit || DEFAULT_PAGE_SIZE, DEFAULT_PAGE_SIZE);
+  const endpoint = `${sourceConfig.domain}/openapi/v1/models`;
+  const params = {
+    search: search ? `${search} gguf` : 'gguf',
+    owner: author,
+    sort,
+    page: 1,
+    page_size: pageSize,
+  };
+  const requestSearch = nextPageUrl
+    ? getQueryParam(nextPageUrl, 'search') || params.search
+    : params.search;
+  const requestAuthor = nextPageUrl
+    ? getQueryParam(nextPageUrl, 'owner') || author
+    : author;
+  const requestSort = nextPageUrl
+    ? getQueryParam(nextPageUrl, 'sort') || sort
+    : sort;
+  const response = await axios.get(nextPageUrl || endpoint, {
+    params: nextPageUrl ? undefined : params,
+    headers: getAuthHeaders(authToken),
+    timeout: REQUEST_TIMEOUT_MS,
+  });
+
+  assertSuccessfulModelScopeResponse(response.data, 'model search');
+  const currentPage = nextPageUrl
+    ? getPageNumber(response.data, 1)
+    : params.page;
+  const currentPageSize = getPageSize(response.data, pageSize);
+  const models = extractList(response.data)
+    .map(model => normalizeModelScopeModel(model))
+    .filter((model): model is HuggingFaceModel => Boolean(model))
+    .filter(shouldKeepModelScopeSearchModel);
+
+  return {
+    models,
+    nextLink: getNextPageLink({
+      data: response.data,
+      endpoint,
+      search: requestSearch,
+      author: requestAuthor,
+      sort: requestSort,
+      page: currentPage,
+      pageSize: currentPageSize,
+    }),
+  };
+}
+
+export async function fetchModelScopeModelFilesDetails({
+  sourceConfig,
+  modelId,
+  authToken,
+}: {
+  sourceConfig: ModelSourceConfig;
+  modelId: string;
+  authToken?: string | null;
+}): Promise<ModelFileDetails[]> {
+  const detail = await fetchModelScopeDetail(sourceConfig, modelId, authToken);
+  const detailFiles = detail ? extractFiles(modelId, detail) : [];
+  const files =
+    detailFiles.length > 0
+      ? detailFiles
+      : await fetchModelScopeFiles(sourceConfig, modelId, authToken);
+
+  if (files.length === 0) {
+    throw new ModelScopeResponseError(
+      `No GGUF files found for ModelScope model: ${modelId}`,
+    );
+  }
+
+  return toFileDetails(files);
+}
+
+export async function fetchModelScopeGGUFSpecs({
+  sourceConfig,
+  modelId,
+  authToken,
+}: {
+  sourceConfig: ModelSourceConfig;
+  modelId: string;
+  authToken?: string | null;
+}): Promise<GGUFSpecs> {
+  const detail = await fetchModelScopeDetail(sourceConfig, modelId, authToken);
+  const normalized = detail
+    ? normalizeModelScopeModel(detail.Data || detail)
+    : null;
+  if (!detail) {
+    throw new ModelScopeResponseError(`ModelScope model not found: ${modelId}`);
+  }
+  const modelInfos = detail?.Data?.ModelInfos?.gguf || detail?.ModelInfos?.gguf;
+
+  return {
+    _id: modelId,
+    id: modelId,
+    gguf: {
+      total: Number(
+        firstDefined(
+          detail?.Data?.Parameters,
+          detail?.Data?.parameterCount,
+          detail?.Data?.ModelSize,
+          detail?.Data?.model_size,
+          modelInfos?.model_size,
+          detail?.Parameters,
+          detail?.parameterCount,
+          normalized?.modelSize,
+          0,
+        ),
+      ),
+      architecture: String(
+        firstDefined(
+          detail?.Data?.Architecture,
+          detail?.Data?.architecture,
+          modelInfos?.architecture,
+          detail?.Architecture,
+          detail?.architecture,
+          '',
+        ),
+      ),
+      context_length:
+        Number(
+          firstDefined(
+            detail?.Data?.ContextLength,
+            detail?.Data?.context_length,
+            modelInfos?.context_length,
+            detail?.ContextLength,
+            detail?.context_length,
+            0,
+          ),
+        ) || 0,
+    },
+  };
+}

--- a/src/api/modelSources/modelscope.ts
+++ b/src/api/modelSources/modelscope.ts
@@ -123,7 +123,9 @@ function getPageSize(data: any, fallback: number): number {
 
 function buildQueryString(params: Record<string, any>): string {
   return Object.entries(params)
-    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .filter(
+      ([, value]) => value !== undefined && value !== null && value !== '',
+    )
     .map(
       ([key, value]) =>
         `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
@@ -131,7 +133,10 @@ function buildQueryString(params: Record<string, any>): string {
     .join('&');
 }
 
-function getQueryParam(url: string | undefined, key: string): string | undefined {
+function getQueryParam(
+  url: string | undefined,
+  key: string,
+): string | undefined {
   if (!url) {
     return undefined;
   }
@@ -260,12 +265,7 @@ function normalizeRepoId(raw: any): string {
   }
 
   const name = String(
-    firstDefined(
-      raw?.Name,
-      raw?.name,
-      raw?.ModelName,
-      raw?.modelName,
-    ) || '',
+    firstDefined(raw?.Name, raw?.name, raw?.ModelName, raw?.modelName) || '',
   );
   if (path && name) {
     return cleanRepoId(`${path}/${name}`);
@@ -358,8 +358,9 @@ function extractFiles(repoId: string, data: any): ModelFile[] {
         }),
       )
       .filter((file): file is ModelFile => Boolean(file));
-    if (files.length > 0) {
-      return filterValidGGUFFiles(files) as ModelFile[];
+    const validFiles = filterValidGGUFFiles(files) as ModelFile[];
+    if (validFiles.length > 0) {
+      return validFiles;
     }
   }
 
@@ -383,8 +384,9 @@ function extractFiles(repoId: string, data: any): ModelFile[] {
     const files = asArray(candidate)
       .map(file => normalizeModelScopeFile(repoId, file))
       .filter((file): file is ModelFile => Boolean(file));
-    if (files.length > 0) {
-      return filterValidGGUFFiles(files) as ModelFile[];
+    const validFiles = filterValidGGUFFiles(files) as ModelFile[];
+    if (validFiles.length > 0) {
+      return validFiles;
     }
   }
 
@@ -528,6 +530,7 @@ function toFileDetails(files: ModelFile[]): ModelFileDetails[] {
     size: file.size || file.lfs?.size || 0,
     lfs: file.lfs,
     path: file.rfilename,
+    split: file.split,
   }));
 }
 
@@ -657,10 +660,8 @@ async function fetchModelScopeDirectModel(
     );
   }
 
-  const files =
-    normalized.siblings.length > 0
-      ? normalized.siblings
-      : await fetchModelScopeFiles(sourceConfig, repoId, authToken);
+  const repoFiles = await fetchModelScopeFiles(sourceConfig, repoId, authToken);
+  const files = repoFiles.length > 0 ? repoFiles : normalized.siblings;
 
   return {
     ...normalized,
@@ -751,20 +752,23 @@ export async function fetchModelScopeModelFilesDetails({
   modelId: string;
   authToken?: string | null;
 }): Promise<ModelFileDetails[]> {
-  const detail = await fetchModelScopeDetail(sourceConfig, modelId, authToken);
-  const detailFiles = detail ? extractFiles(modelId, detail) : [];
-  const files =
-    detailFiles.length > 0
-      ? detailFiles
-      : await fetchModelScopeFiles(sourceConfig, modelId, authToken);
+  const files = await fetchModelScopeFiles(sourceConfig, modelId, authToken);
+  const detailFiles =
+    files.length > 0
+      ? []
+      : extractFiles(
+          modelId,
+          await fetchModelScopeDetail(sourceConfig, modelId, authToken),
+        );
+  const resolvedFiles = files.length > 0 ? files : detailFiles;
 
-  if (files.length === 0) {
+  if (resolvedFiles.length === 0) {
     throw new ModelScopeResponseError(
       `No GGUF files found for ModelScope model: ${modelId}`,
     );
   }
 
-  return toFileDetails(files);
+  return toFileDetails(resolvedFiles);
 }
 
 export async function fetchModelScopeGGUFSpecs({

--- a/src/api/modelSources/network.ts
+++ b/src/api/modelSources/network.ts
@@ -1,0 +1,28 @@
+export const MODEL_SOURCE_REQUEST_TIMEOUT_MS = 20000;
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = MODEL_SOURCE_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      const timeoutError = new Error(
+        `Network timeout: request exceeded ${timeoutMs}ms`,
+      );
+      timeoutError.name = 'NetworkError';
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/api/modelSources/registry.ts
+++ b/src/api/modelSources/registry.ts
@@ -1,0 +1,43 @@
+import {
+  HF_DOMAIN,
+  HF_MIRROR_DOMAIN,
+  MODELSCOPE_API_BASE,
+  MODELSCOPE_DOMAIN,
+} from '../../config';
+import {ModelSourceId} from '../../utils/types';
+import {ModelSourceConfig} from './types';
+
+export const MODEL_SOURCE_CONFIGS: Record<ModelSourceId, ModelSourceConfig> = {
+  huggingface: {
+    id: 'huggingface',
+    domain: HF_DOMAIN,
+    apiBase: `${HF_DOMAIN}/api`,
+    supportsAuth: true,
+    supportsPagination: true,
+    supportsHFAPI: true,
+  },
+  hf_mirror: {
+    id: 'hf_mirror',
+    domain: HF_MIRROR_DOMAIN,
+    apiBase: `${HF_MIRROR_DOMAIN}/api`,
+    supportsAuth: true,
+    supportsPagination: true,
+    supportsHFAPI: true,
+  },
+  modelscope: {
+    id: 'modelscope',
+    domain: MODELSCOPE_DOMAIN,
+    apiBase: MODELSCOPE_API_BASE,
+    supportsAuth: true,
+    supportsPagination: false,
+    supportsHFAPI: false,
+  },
+};
+
+export function getModelSourceConfig(source: ModelSourceId): ModelSourceConfig {
+  return MODEL_SOURCE_CONFIGS[source];
+}
+
+export function isHFCompatibleSource(source: ModelSourceId): boolean {
+  return MODEL_SOURCE_CONFIGS[source].supportsHFAPI;
+}

--- a/src/api/modelSources/types.ts
+++ b/src/api/modelSources/types.ts
@@ -1,0 +1,49 @@
+import {
+  GGUFSpecs,
+  HuggingFaceModelsResponse,
+  ModelFileDetails,
+  ModelSourceId,
+} from '../../utils/types';
+
+export interface ModelSourceConfig {
+  id: ModelSourceId;
+  domain: string;
+  apiBase: string;
+  supportsAuth: boolean;
+  supportsPagination: boolean;
+  supportsHFAPI: boolean;
+}
+
+export interface FetchSourceModelsParams {
+  source: ModelSourceId;
+  search?: string;
+  author?: string;
+  filter?: string;
+  sort?: string;
+  direction?: string;
+  limit?: number;
+  full?: boolean;
+  config?: boolean;
+  nextPageUrl?: string;
+  authToken?: string | null;
+}
+
+export interface FetchModelFilesParams {
+  source: ModelSourceId;
+  modelId: string;
+  authToken?: string | null;
+}
+
+export interface FetchGGUFSpecsParams extends FetchModelFilesParams {}
+
+export interface ModelSourceClient {
+  fetchModels(
+    params: Omit<FetchSourceModelsParams, 'source'>,
+  ): Promise<HuggingFaceModelsResponse>;
+  fetchModelFilesDetails(
+    params: Omit<FetchModelFilesParams, 'source'>,
+  ): Promise<ModelFileDetails[]>;
+  fetchGGUFSpecs(
+    params: Omit<FetchGGUFSpecsParams, 'source'>,
+  ): Promise<GGUFSpecs>;
+}

--- a/src/components/DownloadErrorDialog/DownloadErrorDialog.tsx
+++ b/src/components/DownloadErrorDialog/DownloadErrorDialog.tsx
@@ -36,15 +36,19 @@ export const DownloadErrorDialog: React.FC<DownloadErrorDialogProps> = ({
   const theme = useTheme();
   const l10n = React.useContext(L10nContext);
   const alerts = l10n.components.downloadErrorDialog;
+  const isHFCompatibleError =
+    error?.service === 'huggingface' || error?.service === 'hf_mirror';
 
   // Check if this is the case where token exists but is disabled
   const isTokenDisabledWhenAuthError =
     error?.code === 'authentication' &&
+    isHFCompatibleError &&
     hfStore.isTokenPresent &&
     !hfStore.useHfToken;
 
   const isTokenPresentWhenAuthError =
     error?.code === 'authentication' &&
+    isHFCompatibleError &&
     hfStore.isTokenPresent &&
     hfStore.useHfToken;
 
@@ -60,6 +64,9 @@ export const DownloadErrorDialog: React.FC<DownloadErrorDialogProps> = ({
     }
 
     if (error.code === 'authentication') {
+      if (!isHFCompatibleError) {
+        return 'other';
+      }
       if (error.message?.includes('Token is missing')) {
         return 'noToken';
       }
@@ -146,12 +153,13 @@ export const DownloadErrorDialog: React.FC<DownloadErrorDialogProps> = ({
 
   const getActions = () => {
     const actions: DialogAction[] = [];
+    const sourceUrl = model?.sourceWebUrl || model?.hfUrl;
 
-    if (model?.hfUrl && !isTokenDisabledWhenAuthError && !notEnoughSpace) {
+    if (sourceUrl && !isTokenDisabledWhenAuthError && !notEnoughSpace) {
       actions.push({
-        label: alerts.viewOnHuggingFace,
+        label: alerts.viewOnSource,
         onPress: () => {
-          Linking.openURL(model.hfUrl);
+          Linking.openURL(sourceUrl);
         },
         mode: 'text' as const,
       });

--- a/src/components/EnhancedSearchBar/EnhancedSearchBar.tsx
+++ b/src/components/EnhancedSearchBar/EnhancedSearchBar.tsx
@@ -13,6 +13,8 @@ import {L10nContext} from '../../utils';
 import {XIcon} from '../../assets/icons';
 
 import {SortOption, SearchFilters} from '../../store/HFStore';
+import {MODEL_SOURCE_IDS} from '../../utils/modelSources';
+import {ModelSourceId} from '../../utils/types';
 
 interface EnhancedSearchBarProps {
   value: string;
@@ -21,10 +23,12 @@ interface EnhancedSearchBarProps {
   containerStyle?: object;
   filters: SearchFilters;
   onFiltersChange: (filters: Partial<SearchFilters>) => void;
+  source?: ModelSourceId;
+  onSourceChange?: (source: ModelSourceId) => void;
   testID?: string;
 }
 
-type FilterType = 'author' | 'sort';
+type FilterType = 'source' | 'author' | 'sort';
 
 export const EnhancedSearchBar = ({
   value,
@@ -33,6 +37,8 @@ export const EnhancedSearchBar = ({
   containerStyle,
   filters,
   onFiltersChange,
+  source = 'huggingface',
+  onSourceChange,
   testID,
 }: EnhancedSearchBarProps) => {
   const theme = useTheme();
@@ -66,6 +72,15 @@ export const EnhancedSearchBar = ({
     [l10n],
   );
 
+  const sourceOptions = useMemo(
+    () =>
+      MODEL_SOURCE_IDS.map(value => ({
+        value,
+        label: l10n.models.search.sources[value],
+      })),
+    [l10n],
+  );
+
   const openFilterSheet = useCallback((filterType: FilterType) => {
     setActiveFilterSheet(filterType);
   }, []);
@@ -77,6 +92,11 @@ export const EnhancedSearchBar = ({
   const getFilterDisplayValue = useCallback(
     (filterType: FilterType): string => {
       switch (filterType) {
+        case 'source':
+          return (
+            sourceOptions.find(option => option.value === source)?.label ||
+            l10n.models.search.source
+          );
         case 'author':
           return filters.author || l10n.models.search.filters.author;
         case 'sort':
@@ -88,12 +108,14 @@ export const EnhancedSearchBar = ({
           return '';
       }
     },
-    [filters, sortOptions, l10n],
+    [filters, sortOptions, source, sourceOptions, l10n],
   );
 
   const isFilterActive = useCallback(
     (filterType: FilterType): boolean => {
       switch (filterType) {
+        case 'source':
+          return source !== 'huggingface';
         case 'author':
           return !!filters.author;
         case 'sort':
@@ -102,7 +124,7 @@ export const EnhancedSearchBar = ({
           return false;
       }
     },
-    [filters],
+    [filters, source],
   );
 
   // Memoized callback for clearing search
@@ -118,6 +140,14 @@ export const EnhancedSearchBar = ({
       closeFilterSheet();
     },
     [onFiltersChange, closeFilterSheet],
+  );
+
+  const handleSourceSelect = useCallback(
+    (filterValue: ModelSourceId) => {
+      onSourceChange?.(filterValue);
+      closeFilterSheet();
+    },
+    [onSourceChange, closeFilterSheet],
   );
 
   return (
@@ -160,6 +190,33 @@ export const EnhancedSearchBar = ({
         showsHorizontalScrollIndicator={false}
         style={styles.filterDropdownContainer}
         contentContainerStyle={styles.filterDropdownContent}>
+        {/* Source Filter Button */}
+        <TouchableOpacity
+          testID="filter-button-source"
+          onPress={() => openFilterSheet('source')}
+          style={[
+            styles.filterDropdownButton,
+            isFilterActive('source') && styles.filterDropdownButtonActive,
+          ]}>
+          <Text
+            variant="labelMedium"
+            style={[
+              styles.filterDropdownText,
+              isFilterActive('source') && styles.filterDropdownTextActive,
+            ]}>
+            {getFilterDisplayValue('source')}
+          </Text>
+          <Icon
+            name="chevron-down"
+            size={16}
+            color={
+              isFilterActive('source')
+                ? theme.colors.primary
+                : theme.colors.onSurfaceVariant
+            }
+          />
+        </TouchableOpacity>
+
         {/* Author Filter Button */}
         <TouchableOpacity
           testID="filter-button-author"
@@ -215,6 +272,42 @@ export const EnhancedSearchBar = ({
       </ScrollView>
 
       {/* Filter Sheets */}
+      <Sheet
+        isVisible={activeFilterSheet === 'source'}
+        onClose={closeFilterSheet}
+        title={l10n.models.search.sourceTitle}>
+        <Sheet.View style={styles.filterSheetContent}>
+          {sourceOptions.map(option => {
+            const isSelected = source === option.value;
+            return (
+              <TouchableOpacity
+                key={option.value}
+                onPress={() => handleSourceSelect(option.value)}
+                style={[
+                  styles.filterOption,
+                  isSelected && styles.filterOptionSelected,
+                ]}
+                activeOpacity={0.7}>
+                <Text
+                  style={[
+                    styles.filterOptionText,
+                    isSelected && styles.filterOptionTextSelected,
+                  ]}>
+                  {option.label}
+                </Text>
+                {isSelected && (
+                  <Icon
+                    name="check-circle"
+                    size={24}
+                    color={theme.colors.primary}
+                  />
+                )}
+              </TouchableOpacity>
+            );
+          })}
+        </Sheet.View>
+      </Sheet>
+
       <Sheet
         isVisible={activeFilterSheet === 'author'}
         onClose={closeFilterSheet}

--- a/src/components/EnhancedSearchBar/__tests__/EnhancedSearchBar.test.tsx
+++ b/src/components/EnhancedSearchBar/__tests__/EnhancedSearchBar.test.tsx
@@ -16,6 +16,8 @@ jest.mock('../../../hooks', () => ({
       primary: '#007bff',
       primaryContainer: '#e3f2fd',
       onPrimaryContainer: '#0d47a1',
+      btnPrimaryBg: '#e3f2fd',
+      secondary: '#007bff',
     },
     dark: false,
   }),
@@ -107,6 +109,10 @@ describe('EnhancedSearchBar', () => {
     const sortButton = getByTestId('filter-button-sort');
     expect(sortButton).toBeTruthy();
     fireEvent.press(sortButton);
+
+    const sourceButton = getByTestId('filter-button-source');
+    expect(sourceButton).toBeTruthy();
+    fireEvent.press(sourceButton);
   });
 
   it('shows active filter indicator when filters are applied', () => {

--- a/src/components/ErrorSnackbar/ErrorSnackbar.tsx
+++ b/src/components/ErrorSnackbar/ErrorSnackbar.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import {View} from 'react-native';
 import {Portal, Snackbar, Text} from 'react-native-paper';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import {useTheme} from '../../hooks';
+import {L10nContext} from '../../utils';
 import {ErrorState} from '../../utils/errors';
 import {createStyles} from './styles';
 
@@ -23,6 +24,7 @@ export const ErrorSnackbar: React.FC<ErrorSnackbarProps> = ({
   onReport,
 }) => {
   const theme = useTheme();
+  const l10n = useContext(L10nContext);
 
   if (!error) {
     return null;
@@ -36,7 +38,10 @@ export const ErrorSnackbar: React.FC<ErrorSnackbarProps> = ({
     if (error.code === 'authentication' || error.code === 'authorization') {
       switch (error.service) {
         case 'huggingface':
+        case 'hf_mirror':
           return 'key-alert'; // Specific icon for HF auth issues
+        case 'modelscope':
+          return 'cloud-alert-outline';
         case 'firebase':
           return 'firebase'; // Firebase-specific icon
         default:
@@ -66,7 +71,10 @@ export const ErrorSnackbar: React.FC<ErrorSnackbarProps> = ({
       (error.code === 'authentication' || error.code === 'authorization') &&
       onSettings
     ) {
-      const label = error.service === 'huggingface' ? 'Add Token' : 'Settings';
+      const label =
+        error.service === 'huggingface' || error.service === 'hf_mirror'
+          ? l10n.settings.setTokenButton
+          : l10n.screenTitles.settings;
 
       return {
         label,
@@ -78,7 +86,7 @@ export const ErrorSnackbar: React.FC<ErrorSnackbarProps> = ({
     // For model init errors, show report option
     if (error.context === 'modelInit' && onReport) {
       return {
-        label: 'Report',
+        label: l10n.components.modelErrorReportSheet.submit,
         onPress: onReport,
         labelStyle: {color: theme.colors.secondary},
       };
@@ -87,7 +95,7 @@ export const ErrorSnackbar: React.FC<ErrorSnackbarProps> = ({
     // For recoverable errors, show retry button
     if (error.recoverable && onRetry) {
       return {
-        label: 'Retry',
+        label: l10n.settings.retryConnection,
         onPress: onRetry,
         labelStyle: {color: theme.colors.secondary},
       };
@@ -95,7 +103,7 @@ export const ErrorSnackbar: React.FC<ErrorSnackbarProps> = ({
 
     // Default action is just to dismiss
     return {
-      label: 'Dismiss',
+      label: l10n.common.dismiss,
       onPress: onDismiss,
       labelStyle: {color: theme.colors.secondary},
     };

--- a/src/components/ErrorSnackbar/__tests__/ErrorSnackbar.test.tsx
+++ b/src/components/ErrorSnackbar/__tests__/ErrorSnackbar.test.tsx
@@ -52,8 +52,8 @@ describe('ErrorSnackbar', () => {
     // Check that the error message is displayed
     expect(getByText(l10n.en.errors.hfAuthenticationError)).toBeTruthy();
 
-    // Check that the "Add Token" action is available for HF auth errors
-    const addTokenButton = getByText('Add Token');
+    // Check that the localized token action is available for HF auth errors
+    const addTokenButton = getByText(l10n.en.settings.setTokenButton);
     fireEvent.press(addTokenButton);
     expect(mockSettings).toHaveBeenCalled();
   });
@@ -81,8 +81,8 @@ describe('ErrorSnackbar', () => {
     // Check that the error message is displayed
     expect(getByText('Network connection error')).toBeTruthy();
 
-    // For recoverable errors, check that "Retry" action is available
-    const retryButton = getByText('Retry');
+    // For recoverable errors, check that localized retry action is available
+    const retryButton = getByText(l10n.en.settings.retryConnection);
     fireEvent.press(retryButton);
     expect(mockRetry).toHaveBeenCalled();
   });
@@ -106,8 +106,8 @@ describe('ErrorSnackbar', () => {
     // Check that the error message is displayed
     expect(getByText('Server unavailable')).toBeTruthy();
 
-    // For non-recoverable errors without retry, check "Dismiss" action
-    const dismissButton = getByText('Dismiss');
+    // For non-recoverable errors without retry, check localized dismiss action
+    const dismissButton = getByText(l10n.en.common.dismiss);
     fireEvent.press(dismissButton);
     expect(mockDismiss).toHaveBeenCalled();
   });

--- a/src/components/ModelsHeaderRight/ModelsHeaderRight.tsx
+++ b/src/components/ModelsHeaderRight/ModelsHeaderRight.tsx
@@ -74,7 +74,10 @@ export const ModelsHeaderRight = observer(() => {
         }
         anchorPosition="bottom">
         {/* Filter section */}
-        <Menu.Item label="Filters" isGroupLabel />
+        <Menu.Item
+          label={l10n.components.modelsHeaderRight.filtersGroup}
+          isGroupLabel
+        />
         <Menu.Item
           icon={({size}) => (
             <Image
@@ -87,6 +90,18 @@ export const ModelsHeaderRight = observer(() => {
           selected={filters.includes('hf')}
         />
         <Menu.Item
+          icon={filters.includes('hf_mirror') ? 'mirror' : 'mirror-variant'}
+          onPress={() => toggleFilter('hf_mirror')}
+          label={l10n.components.modelsHeaderRight.menuTitleHfMirror}
+          selected={filters.includes('hf_mirror')}
+        />
+        <Menu.Item
+          icon={filters.includes('modelscope') ? 'cloud-check' : 'cloud-outline'}
+          onPress={() => toggleFilter('modelscope')}
+          label={l10n.components.modelsHeaderRight.menuTitleModelScope}
+          selected={filters.includes('modelscope')}
+        />
+        <Menu.Item
           icon={filters.includes('downloaded') ? 'download-circle' : 'download'}
           onPress={() => toggleFilter('downloaded')}
           label={l10n.components.modelsHeaderRight.menuTitleDownloaded}
@@ -94,7 +109,10 @@ export const ModelsHeaderRight = observer(() => {
         />
 
         {/* View section */}
-        <Menu.Item label="View" isGroupLabel />
+        <Menu.Item
+          label={l10n.components.modelsHeaderRight.viewGroup}
+          isGroupLabel
+        />
         <Menu.Item
           icon={filters.includes('grouped') ? 'layers' : 'layers-outline'}
           onPress={() => toggleFilter('grouped')}

--- a/src/config/urls.ts
+++ b/src/config/urls.ts
@@ -2,6 +2,9 @@ import {FIREBASE_FUNCTIONS_URL} from '@env';
 
 export const HF_DOMAIN = 'https://huggingface.co';
 export const HF_API_BASE = `${HF_DOMAIN}/api/models`;
+export const HF_MIRROR_DOMAIN = 'https://hf-mirror.com';
+export const MODELSCOPE_DOMAIN = 'https://modelscope.cn';
+export const MODELSCOPE_API_BASE = `${MODELSCOPE_DOMAIN}/api/v1`;
 
 // Fallback for Firebase Functions URL if not configured
 const FIREBASE_BASE =
@@ -10,13 +13,31 @@ const FIREBASE_BASE =
 export const urls = {
   // API URLs
   modelsList: () => `${HF_API_BASE}`,
+  hfCompatibleModelsList: (domain: string) => `${domain}/api/models`,
+  hfCompatibleModelTree: (domain: string, modelId: string) =>
+    `${domain}/api/models/${modelId}/tree/main`,
+  hfCompatibleModelSpecs: (domain: string, modelId: string) =>
+    `${domain}/api/models/${modelId}`,
   modelTree: (modelId: string) => `${HF_API_BASE}/${modelId}/tree/main`,
   modelSpecs: (modelId: string) => `${HF_API_BASE}/${modelId}`,
 
   // Web URLs
   modelDownloadFile: (modelId: string, filename: string) =>
     `${HF_DOMAIN}/${modelId}/resolve/main/${filename}`,
+  hfCompatibleModelDownloadFile: (
+    domain: string,
+    modelId: string,
+    filename: string,
+  ) => `${domain}/${modelId}/resolve/main/${filename}`,
   modelWebPage: (modelId: string) => `${HF_DOMAIN}/${modelId}`,
+  hfCompatibleModelWebPage: (domain: string, modelId: string) =>
+    `${domain}/${modelId}`,
+  modelScopeWebPage: (modelId: string) => `${MODELSCOPE_DOMAIN}/models/${modelId}`,
+  modelScopeDownloadFile: (
+    modelId: string,
+    filename: string,
+    revision: string = 'master',
+  ) => `${MODELSCOPE_DOMAIN}/models/${modelId}/resolve/${revision}/${filename}`,
 
   // Benchmark Endpoint
   benchmarkSubmit: () => `${FIREBASE_BASE}/api/v1/submit`,

--- a/src/hooks/__tests__/useMemoryCheck.test.ts
+++ b/src/hooks/__tests__/useMemoryCheck.test.ts
@@ -102,6 +102,31 @@ describe('useMemoryCheck', () => {
     });
   });
 
+  it('uses total-memory fallback when no calibration is available', async () => {
+    runInAction(() => {
+      modelStore.availableMemoryCeiling = undefined;
+      modelStore.largestSuccessfulLoad = undefined;
+    });
+    (DeviceInfo.getTotalMemory as jest.Mock).mockResolvedValue(8 * 1e9);
+
+    const {result, waitForNextUpdate} = renderHook(() =>
+      useMemoryCheck(localModel),
+    );
+
+    try {
+      await waitForNextUpdate();
+    } catch {
+      // Ignoring timeout
+    }
+
+    expect(result.current).toEqual({
+      memoryWarning: '',
+      shortMemoryWarning: '',
+      multimodalWarning: '',
+      fitStatus: 'fits',
+    });
+  });
+
   it('uses maximum of largestSuccessfulLoad and availableMemoryCeiling', async () => {
     // Set largestSuccessfulLoad higher than availableMemoryCeiling
     runInAction(() => {

--- a/src/hooks/useMemoryCheck.ts
+++ b/src/hooks/useMemoryCheck.ts
@@ -41,26 +41,7 @@ export const hasEnoughMemory = async (
     }
   }
 
-  // Get calibration data from ModelStore
-  const {largestSuccessfulLoad, availableMemoryCeiling} = modelStore;
-
-  // Calculate ceiling from calibration data
-  let ceiling: number;
-  if (
-    largestSuccessfulLoad !== undefined ||
-    availableMemoryCeiling !== undefined
-  ) {
-    // Use the maximum of both calibration signals
-    ceiling = Math.max(largestSuccessfulLoad ?? 0, availableMemoryCeiling ?? 0);
-  } else {
-    // Cold start: no calibration data yet, use conservative fallback
-    const totalMemory = await DeviceInfo.getTotalMemory();
-    // Use heuristic: min(60% of RAM, RAM - 1.2GB)
-    ceiling = Math.max(
-      Math.min(totalMemory * 0.6, totalMemory - 1.2 * 1e9),
-      0, // Ensure non-negative
-    );
-  }
+  const ceiling = await getAvailableMemoryCeiling();
 
   const memoryRequirement = getModelMemoryRequirement(
     modelForCalc,
@@ -70,6 +51,20 @@ export const hasEnoughMemory = async (
 
   return memoryRequirement <= ceiling;
 };
+
+async function getAvailableMemoryCeiling(): Promise<number> {
+  const calibratedCeiling = Math.max(
+    modelStore.largestSuccessfulLoad ?? 0,
+    modelStore.availableMemoryCeiling ?? 0,
+  );
+
+  if (calibratedCeiling > 0) {
+    return calibratedCeiling;
+  }
+
+  const totalMemory = await DeviceInfo.getTotalMemory();
+  return Math.max(Math.min(totalMemory * 0.6, totalMemory - 1.2 * 1e9), 0);
+}
 
 /**
  * Get memory fit status with details
@@ -93,11 +88,7 @@ async function getMemoryFitDetails(
   // Get device total memory
   const totalMemory = await DeviceInfo.getTotalMemory();
 
-  // Get learned available ceiling (already includes fallback from ModelStore.initializeStore)
-  const availableBytes = Math.max(
-    modelStore.largestSuccessfulLoad ?? 0,
-    modelStore.availableMemoryCeiling ?? 0,
-  );
+  const availableBytes = await getAvailableMemoryCeiling();
 
   // Determine status
   let status: MemoryFitStatus;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -197,7 +197,9 @@
       "unknownGroup": "Unbekannt",
       "availableToUse": "Startklar",
       "availableToDownload": "Download verfügbar",
-      "useAddButtonForMore": "Nutze + Taste um weitere Modelle zu finden"
+      "useAddButtonForMore": "Nutze + Taste um weitere Modelle zu finden",
+      "hfMirrorModel": "HF Mirror",
+      "modelScopeModel": "ModelScope"
     },
     "vision": "Bilderfassung",
     "mmproj": "Projector",
@@ -243,13 +245,18 @@
     "buttons": {
       "addFromHuggingFace": "Von Hugging Face hinzufügen",
       "addLocalModel": "Lokales Modell hinzufügen",
-      "reset": "Zurücksetzen"
+      "reset": "Zurücksetzen",
+      "addFromModelSources": "Modell herunterladen"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Hugging Face Modelle",
       "menuTitleDownloaded": "Heruntergeladene Modelle",
       "menuTitleGrouped": "Nach Modelltyp gruppieren",
-      "menuTitleReset": "Modellliste zurücksetzen"
+      "menuTitleReset": "Modellliste zurücksetzen",
+      "filtersGroup": "Filter",
+      "viewGroup": "Ansicht",
+      "menuTitleHfMirror": "Hugging Face Mirror",
+      "menuTitleModelScope": "ModelScope Modelle"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Zurücksetzen ausführen",
@@ -298,7 +305,7 @@
     "search": {
       "noResults": "Keine Modelle gefunden",
       "loadingMore": "Mehr laden...",
-      "searchPlaceholder": "Suche Hugging Face Modelle",
+      "searchPlaceholder": "Modell-Repositories suchen",
       "modelUpdatedLong": "Vor {{time}} geupdated",
       "modelUpdatedShort": "vor {{time}}",
       "modelUpdatedJustNowLong": "Soeben geupdated",
@@ -315,6 +322,13 @@
         "sortDownloads": "Downloads",
         "sortRecent": "Kürzlich aktualisiert",
         "sortLikes": "Am beliebtesten"
+      },
+      "source": "Quelle",
+      "sourceTitle": "Download-Quelle",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "HF Mirror",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -341,7 +355,8 @@
         "author": "Autor",
         "requiresProjectionModel": "Benötigt Projection Modell",
         "downloadProjectionModel": "Projection Modell herunterladen",
-        "viewModelCardOnHuggingFace": "Model Card auf Hugging Face anschauen"
+        "viewModelCardOnHuggingFace": "Model Card auf Hugging Face anschauen",
+        "viewModelCardOnSource": "Modellquelle anzeigen"
       },
       "accessibility": {
         "expandDetails": "Details erweitern",
@@ -671,7 +686,8 @@
       "enableAndRetry": "Aktivieren und erneut versuchen",
       "goToSettings": "Gehen Sie zu Einstellungen",
       "tryAgain": "Erneut versuchen",
-      "viewOnHuggingFace": "Modell auf HF anzeigen ↗"
+      "viewOnHuggingFace": "Modell auf HF anzeigen ↗",
+      "viewOnSource": "Modellquelle anzeigen ↗"
     },
     "headerRight": {
       "deleteChatTitle": "Löschen des Chat",
@@ -722,7 +738,11 @@
       "menuTitleHf": "Hugging Face Modelle",
       "menuTitleDownloaded": "Heruntergeladene Modelle",
       "menuTitleGrouped": "Nach Modelltyp gruppieren",
-      "menuTitleReset": "Modellliste zurücksetzen"
+      "menuTitleReset": "Modellliste zurücksetzen",
+      "filtersGroup": "Filter",
+      "viewGroup": "Ansicht",
+      "menuTitleHfMirror": "Hugging Face Mirror",
+      "menuTitleModelScope": "ModelScope Modelle"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Zurücksetzen ausführen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -197,6 +197,8 @@
     "labels": {
       "localModel": "Local",
       "hfModel": "HF",
+      "hfMirrorModel": "HF Mirror",
+      "modelScopeModel": "ModelScope",
       "unknownGroup": "Unknown",
       "availableToUse": "Ready to Use",
       "availableToDownload": "Available to Download",
@@ -245,11 +247,16 @@
     },
     "buttons": {
       "addFromHuggingFace": "Add from Hugging Face",
+      "addFromModelSources": "Download Model",
       "addLocalModel": "Add Local Model",
       "reset": "Reset"
     },
     "modelsHeaderRight": {
+      "filtersGroup": "Filters",
+      "viewGroup": "View",
       "menuTitleHf": "Hugging Face Models",
+      "menuTitleHfMirror": "Hugging Face Mirror",
+      "menuTitleModelScope": "ModelScope Models",
       "menuTitleDownloaded": "Downloaded Models",
       "menuTitleGrouped": "Group by Model Type",
       "menuTitleReset": "Reset Models List"
@@ -301,7 +308,14 @@
     "search": {
       "noResults": "No models found",
       "loadingMore": "Loading more...",
-      "searchPlaceholder": "Search Hugging Face models",
+      "searchPlaceholder": "Search model repositories",
+      "source": "Source",
+      "sourceTitle": "Download Source",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "HF Mirror",
+        "modelscope": "ModelScope"
+      },
       "modelUpdatedLong": "Updated {{time}} ago",
       "modelUpdatedShort": "{{time}} ago",
       "modelUpdatedJustNowLong": "Updated just now",
@@ -344,7 +358,8 @@
         "author": "Author",
         "requiresProjectionModel": "Requires projection model",
         "downloadProjectionModel": "Download projection model",
-        "viewModelCardOnHuggingFace": "View Model Card on Hugging Face"
+        "viewModelCardOnHuggingFace": "View Model Card on Hugging Face",
+        "viewModelCardOnSource": "View Model Source"
       },
       "accessibility": {
         "expandDetails": "Expand details",
@@ -689,7 +704,8 @@
       "enableAndRetry": "Enable and Retry",
       "goToSettings": "Go to Settings",
       "tryAgain": "Try Again",
-      "viewOnHuggingFace": "View Model on HF ↗"
+      "viewOnHuggingFace": "View Model on HF ↗",
+      "viewOnSource": "View Model Source ↗"
     },
     "headerRight": {
       "deleteChatTitle": "Delete Chat",
@@ -737,7 +753,11 @@
       "saveChanges": "Save Changes"
     },
     "modelsHeaderRight": {
+      "filtersGroup": "Filters",
+      "viewGroup": "View",
       "menuTitleHf": "Hugging Face Models",
+      "menuTitleHfMirror": "Hugging Face Mirror",
+      "menuTitleModelScope": "ModelScope Models",
       "menuTitleDownloaded": "Downloaded Models",
       "menuTitleGrouped": "Group by Model Type",
       "menuTitleReset": "Reset Models List"
@@ -1259,6 +1279,7 @@
     "networkTimeout": "Network timeout: Request took too long to complete",
     "hfNetworkError": "Network error: Unable to connect to Hugging Face API",
     "networkError": "Network error: Unable to connect to API",
+    "modelNativeBindingError": "The native model runtime is unavailable. Update or reinstall the app, then try again.",
     "downloadSetupFailedTitle": "Download Setup Failed",
     "downloadSetupFailedMessage": "Failed to prepare model for download: {{message}}",
     "cameraErrorTitle": "Camera Error",

--- a/src/locales/et.json
+++ b/src/locales/et.json
@@ -10,5 +10,46 @@
     "error": "Viga",
     "export": "Ekspordi",
     "networkError": "Võrguühenduse viga. Palun proovi uuesti."
+  },
+  "models": {
+    "labels": {
+      "hfMirrorModel": "HF peegel",
+      "modelScopeModel": "ModelScope"
+    },
+    "buttons": {
+      "addFromModelSources": "Laadi mudel alla"
+    },
+    "modelsHeaderRight": {
+      "filtersGroup": "Filtrid",
+      "viewGroup": "Vaade",
+      "menuTitleHfMirror": "Hugging Face peegel",
+      "menuTitleModelScope": "ModelScope mudelid"
+    },
+    "search": {
+      "searchPlaceholder": "Otsi mudelihoidlaid",
+      "source": "Allikas",
+      "sourceTitle": "Allalaadimise allikas",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "HF peegel",
+        "modelscope": "ModelScope"
+      }
+    },
+    "modelCard": {
+      "labels": {
+        "viewModelCardOnSource": "Vaata mudeli allikat"
+      }
+    }
+  },
+  "components": {
+    "downloadErrorDialog": {
+      "viewOnSource": "Vaata mudeli allikat ↗"
+    },
+    "modelsHeaderRight": {
+      "filtersGroup": "Filtrid",
+      "viewGroup": "Vaade",
+      "menuTitleHfMirror": "Hugging Face peegel",
+      "menuTitleModelScope": "ModelScope mudelid"
+    }
   }
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -200,7 +200,9 @@
       "unknownGroup": "نامشخص",
       "availableToUse": "آماده استفاده",
       "availableToDownload": "قابل دانلود",
-      "useAddButtonForMore": "برای یافتن مدل‌های بیشتر از دکمه + استفاده کنید"
+      "useAddButtonForMore": "برای یافتن مدل‌های بیشتر از دکمه + استفاده کنید",
+      "hfMirrorModel": "آینه HF",
+      "modelScopeModel": "ModelScope"
     },
     "vision": "بینایی",
     "mmproj": "پروجکتور",
@@ -246,13 +248,18 @@
     "buttons": {
       "addFromHuggingFace": "افزودن از Hugging Face",
       "addLocalModel": "افزودن مدل محلی",
-      "reset": "بازنشانی"
+      "reset": "بازنشانی",
+      "addFromModelSources": "دانلود مدل"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "مدل‌های Hugging Face",
       "menuTitleDownloaded": "مدل‌های دانلود شده",
       "menuTitleGrouped": "گروه‌بندی بر اساس نوع مدل",
-      "menuTitleReset": "بازنشانی لیست مدل‌ها"
+      "menuTitleReset": "بازنشانی لیست مدل‌ها",
+      "filtersGroup": "فیلترها",
+      "viewGroup": "نما",
+      "menuTitleHfMirror": "آینه Hugging Face",
+      "menuTitleModelScope": "مدل‌های ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "ادامه بازنشانی",
@@ -301,7 +308,7 @@
     "search": {
       "noResults": "مدلی یافت نشد",
       "loadingMore": "بارگذاری بیشتر...",
-      "searchPlaceholder": "جستجوی مدل‌های Hugging Face",
+      "searchPlaceholder": "جستجوی مخزن‌های مدل",
       "modelUpdatedLong": "{{time}} پیش به‌روزرسانی شده",
       "modelUpdatedShort": "{{time}} پیش",
       "modelUpdatedJustNowLong": "همین الان به‌روزرسانی شده",
@@ -318,6 +325,13 @@
         "sortDownloads": "دانلودها",
         "sortRecent": "آخرین به‌روزرسانی",
         "sortLikes": "محبوب‌ترین"
+      },
+      "source": "منبع",
+      "sourceTitle": "منبع دانلود",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "آینه HF",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -344,7 +358,8 @@
         "author": "نویسنده",
         "requiresProjectionModel": "نیاز به مدل پروجکشن",
         "downloadProjectionModel": "دانلود مدل پروجکشن",
-        "viewModelCardOnHuggingFace": "مشاهده کارت مدل در Hugging Face"
+        "viewModelCardOnHuggingFace": "مشاهده کارت مدل در Hugging Face",
+        "viewModelCardOnSource": "مشاهده منبع مدل"
       },
       "accessibility": {
         "expandDetails": "نمایش جزئیات",
@@ -671,7 +686,8 @@
       "enableAndRetry": "فعال‌سازی و تلاش مجدد",
       "goToSettings": "رفتن به تنظیمات",
       "tryAgain": "تلاش مجدد",
-      "viewOnHuggingFace": "مشاهده مدل در HF ↗"
+      "viewOnHuggingFace": "مشاهده مدل در HF ↗",
+      "viewOnSource": "مشاهده منبع مدل ↗"
     },
     "headerRight": {
       "deleteChatTitle": "حذف چت",
@@ -722,7 +738,11 @@
       "menuTitleHf": "مدل‌های Hugging Face",
       "menuTitleDownloaded": "مدل‌های دانلود شده",
       "menuTitleGrouped": "گروه‌بندی بر اساس نوع مدل",
-      "menuTitleReset": "بازنشانی لیست مدل‌ها"
+      "menuTitleReset": "بازنشانی لیست مدل‌ها",
+      "filtersGroup": "فیلترها",
+      "viewGroup": "نما",
+      "menuTitleHfMirror": "آینه Hugging Face",
+      "menuTitleModelScope": "مدل‌های ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "ادامه بازنشانی",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -103,18 +103,25 @@
       "unknownGroup": "Inconnu",
       "availableToUse": "Prêt à utiliser",
       "availableToDownload": "Disponible au téléchargement",
-      "useAddButtonForMore": "Utilisez le bouton + pour trouver plus de modèles"
+      "useAddButtonForMore": "Utilisez le bouton + pour trouver plus de modèles",
+      "hfMirrorModel": "Miroir HF",
+      "modelScopeModel": "ModelScope"
     },
     "buttons": {
       "addFromHuggingFace": "Ajouter depuis Hugging Face",
       "addLocalModel": "Ajouter un modèle local",
-      "reset": "Réinitialiser"
+      "reset": "Réinitialiser",
+      "addFromModelSources": "Télécharger un modèle"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Modèles Hugging Face",
       "menuTitleDownloaded": "Modèles téléchargés",
       "menuTitleGrouped": "Grouper par type de modèle",
-      "menuTitleReset": "Réinitialiser la liste des modèles"
+      "menuTitleReset": "Réinitialiser la liste des modèles",
+      "filtersGroup": "Filtres",
+      "viewGroup": "Affichage",
+      "menuTitleHfMirror": "Miroir Hugging Face",
+      "menuTitleModelScope": "Modèles ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Procéder à la réinitialisation",
@@ -163,12 +170,19 @@
     "search": {
       "noResults": "Aucun modèle trouvé",
       "loadingMore": "Chargement...",
-      "searchPlaceholder": "Rechercher des modèles Hugging Face",
+      "searchPlaceholder": "Rechercher des dépôts de modèles",
       "modelUpdatedLong": "Mis à jour il y a {{time}}",
       "modelUpdatedShort": "il y a {{time}}",
       "modelUpdatedJustNowLong": "Mis à jour à l'instant",
       "modelUpdatedJustNowShort": "à l'instant",
-      "errorOccurred": "Impossible de charger les modèles. Veuillez réessayer."
+      "errorOccurred": "Impossible de charger les modèles. Veuillez réessayer.",
+      "source": "Source",
+      "sourceTitle": "Source de téléchargement",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "Miroir HF",
+        "modelscope": "ModelScope"
+      }
     },
     "modelCard": {
       "alerts": {
@@ -185,7 +199,8 @@
         "offload": "Décharger"
       },
       "labels": {
-        "skills": "Compétences : "
+        "skills": "Compétences : ",
+        "viewModelCardOnSource": "Voir la source du modèle"
       }
     },
     "modelSettings": {
@@ -408,7 +423,8 @@
       "enableAndRetry": "Activer et réessayer",
       "goToSettings": "Aller aux paramètres",
       "tryAgain": "Réessayer",
-      "viewOnHuggingFace": "Voir le modèle sur HF ↗"
+      "viewOnHuggingFace": "Voir le modèle sur HF ↗",
+      "viewOnSource": "Voir la source du modèle ↗"
     },
     "headerRight": {
       "deleteChatTitle": "Supprimer la discussion",
@@ -459,7 +475,11 @@
       "menuTitleHf": "Modèles Hugging Face",
       "menuTitleDownloaded": "Modèles téléchargés",
       "menuTitleGrouped": "Grouper par type de modèle",
-      "menuTitleReset": "Réinitialiser la liste des modèles"
+      "menuTitleReset": "Réinitialiser la liste des modèles",
+      "filtersGroup": "Filtres",
+      "viewGroup": "Affichage",
+      "menuTitleHfMirror": "Miroir Hugging Face",
+      "menuTitleModelScope": "Modèles ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Procéder à la réinitialisation",

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -197,7 +197,9 @@
       "unknownGroup": "לא ידוע",
       "availableToUse": "מוכן לשימוש",
       "availableToDownload": "זמין להורדה",
-      "useAddButtonForMore": "השתמש בכפתור + כדי להוסיף מודלים נוספים"
+      "useAddButtonForMore": "השתמש בכפתור + כדי להוסיף מודלים נוספים",
+      "hfMirrorModel": "מראת HF",
+      "modelScopeModel": "ModelScope"
     },
     "vision": "ראיה",
     "mmproj": "שכבת התאמה",
@@ -243,13 +245,18 @@
     "buttons": {
       "addFromHuggingFace": "הוסף מ-Hugging Face",
       "addLocalModel": "הוסף מודל מקומי",
-      "reset": "איפוס"
+      "reset": "איפוס",
+      "addFromModelSources": "הורד מודל"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "מודלי Hugging Face",
       "menuTitleDownloaded": "מודלים שהורדו",
       "menuTitleGrouped": "קיבוץ לפי סוג מודל",
-      "menuTitleReset": "איפוס רשימת מודלים"
+      "menuTitleReset": "איפוס רשימת מודלים",
+      "filtersGroup": "מסננים",
+      "viewGroup": "תצוגה",
+      "menuTitleHfMirror": "מראת Hugging Face",
+      "menuTitleModelScope": "מודלי ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "המשך עם איפוס",
@@ -298,7 +305,7 @@
     "search": {
       "noResults": "לא נמצאו מודלים",
       "loadingMore": "טוען עוד...",
-      "searchPlaceholder": "חפש מודלי Hugging Face",
+      "searchPlaceholder": "חפש מאגרי מודלים",
       "modelUpdatedLong": "עודכן לפני {{time}}",
       "modelUpdatedShort": "לפני {{time}}",
       "modelUpdatedJustNowLong": "עודכן עכשיו",
@@ -315,6 +322,13 @@
         "sortDownloads": "הורדות",
         "sortRecent": "עודכן לאחרונה",
         "sortLikes": "הכי אהוב"
+      },
+      "source": "מקור",
+      "sourceTitle": "מקור הורדה",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "מראת HF",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -341,7 +355,8 @@
         "author": "בעלים",
         "requiresProjectionModel": "דורש מודל שכבת התאמה",
         "downloadProjectionModel": "הורד מודל שכבת התאמה",
-        "viewModelCardOnHuggingFace": "הצג כרטיס מודל ב-Hugging Face"
+        "viewModelCardOnHuggingFace": "הצג כרטיס מודל ב-Hugging Face",
+        "viewModelCardOnSource": "הצג מקור מודל"
       },
       "accessibility": {
         "expandDetails": "הרחב פרטים",
@@ -667,7 +682,8 @@
       "enableAndRetry": "הפעלה וניסיון חוזר",
       "goToSettings": "עבור אל ההגדרות",
       "tryAgain": "נסה שוב",
-      "viewOnHuggingFace": "הצג מודל ב-HF ↖"
+      "viewOnHuggingFace": "הצג מודל ב-HF ↖",
+      "viewOnSource": "הצג מקור מודל ↗"
     },
     "headerRight": {
       "deleteChatTitle": "מחק צ'אט",
@@ -718,7 +734,11 @@
       "menuTitleHf": "מודלי Hugging Face",
       "menuTitleDownloaded": "מודלים שהורדו",
       "menuTitleGrouped": "קיבוץ לפי סוג מודל",
-      "menuTitleReset": "איפוס רשימת מודלים"
+      "menuTitleReset": "איפוס רשימת מודלים",
+      "filtersGroup": "מסננים",
+      "viewGroup": "תצוגה",
+      "menuTitleHfMirror": "מראת Hugging Face",
+      "menuTitleModelScope": "מודלי ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "המשך עם האיפוס",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -197,7 +197,9 @@
       "unknownGroup": "Tidak Diketahui",
       "availableToUse": "Siap Digunakan",
       "availableToDownload": "Tersedia untuk Diunduh",
-      "useAddButtonForMore": "Gunakan tombol + untuk menemukan model lain"
+      "useAddButtonForMore": "Gunakan tombol + untuk menemukan model lain",
+      "hfMirrorModel": "Mirror HF",
+      "modelScopeModel": "ModelScope"
     },
     "vision": "Visi",
     "mmproj": "Proyektor",
@@ -243,13 +245,18 @@
     "buttons": {
       "addFromHuggingFace": "Tambah dari Hugging Face",
       "addLocalModel": "Tambah Model Lokal",
-      "reset": "Atur Ulang"
+      "reset": "Atur Ulang",
+      "addFromModelSources": "Unduh Model"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Model Hugging Face",
       "menuTitleDownloaded": "Model yang Diunduh",
       "menuTitleGrouped": "Kelompokkan Berdasarkan Jenis Model",
-      "menuTitleReset": "Atur Ulang Daftar Model"
+      "menuTitleReset": "Atur Ulang Daftar Model",
+      "filtersGroup": "Filter",
+      "viewGroup": "Tampilan",
+      "menuTitleHfMirror": "Mirror Hugging Face",
+      "menuTitleModelScope": "Model ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Lanjutkan Atur Ulang",
@@ -298,7 +305,7 @@
     "search": {
       "noResults": "Model tidak ditemukan",
       "loadingMore": "Memuat lebih banyak...",
-      "searchPlaceholder": "Cari model Hugging Face",
+      "searchPlaceholder": "Cari repositori model",
       "modelUpdatedLong": "Diperbarui {{time}} lalu",
       "modelUpdatedShort": "{{time}} lalu",
       "modelUpdatedJustNowLong": "Diperbarui baru saja",
@@ -315,6 +322,13 @@
         "sortDownloads": "Jumlah Unduhan",
         "sortRecent": "Terbaru Diperbarui",
         "sortLikes": "Paling Disukai"
+      },
+      "source": "Sumber",
+      "sourceTitle": "Sumber Unduhan",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "Mirror HF",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -341,7 +355,8 @@
         "author": "Penulis",
         "requiresProjectionModel": "Memerlukan model proyeksi",
         "downloadProjectionModel": "Unduh model proyeksi",
-        "viewModelCardOnHuggingFace": "Lihat Kartu Model di Hugging Face"
+        "viewModelCardOnHuggingFace": "Lihat Kartu Model di Hugging Face",
+        "viewModelCardOnSource": "Lihat Sumber Model"
       },
       "accessibility": {
         "expandDetails": "Perluas detail",
@@ -668,7 +683,8 @@
       "enableAndRetry": "Aktifkan dan Coba Lagi",
       "goToSettings": "Buka Pengaturan",
       "tryAgain": "Coba Lagi",
-      "viewOnHuggingFace": "Lihat Model di HF ↗"
+      "viewOnHuggingFace": "Lihat Model di HF ↗",
+      "viewOnSource": "Lihat Sumber Model ↗"
     },
     "headerRight": {
       "deleteChatTitle": "Hapus Obrolan",
@@ -719,7 +735,11 @@
       "menuTitleHf": "Model Hugging Face",
       "menuTitleDownloaded": "Model yang Diunduh",
       "menuTitleGrouped": "Kelompokkan Berdasarkan Jenis Model",
-      "menuTitleReset": "Atur Ulang Daftar Model"
+      "menuTitleReset": "Atur Ulang Daftar Model",
+      "filtersGroup": "Filter",
+      "viewGroup": "Tampilan",
+      "menuTitleHfMirror": "Mirror Hugging Face",
+      "menuTitleModelScope": "Model ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Lanjutkan Atur Ulang",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -160,7 +160,9 @@
       "unknownGroup": "不明",
       "availableToUse": "使用可能",
       "availableToDownload": "ダウンロード可能",
-      "useAddButtonForMore": "+ ボタンを他のモデルを探す"
+      "useAddButtonForMore": "+ ボタンを他のモデルを探す",
+      "hfMirrorModel": "HFミラー",
+      "modelScopeModel": "ModelScope"
     },
     "vision": "ビジョン",
     "mmproj": "プロジェクター",
@@ -206,13 +208,18 @@
     "buttons": {
       "addFromHuggingFace": "Hugging Faceから追加",
       "addLocalModel": "ローカルモデルを追加",
-      "reset": "リセット"
+      "reset": "リセット",
+      "addFromModelSources": "モデルをダウンロード"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Hugging Faceモデル",
       "menuTitleDownloaded": "ダウンロード済みモデル",
       "menuTitleGrouped": "モデルタイプでグループ化",
-      "menuTitleReset": "モデルリストをリセット"
+      "menuTitleReset": "モデルリストをリセット",
+      "filtersGroup": "フィルター",
+      "viewGroup": "表示",
+      "menuTitleHfMirror": "Hugging Faceミラー",
+      "menuTitleModelScope": "ModelScopeモデル"
     },
     "modelsResetDialog": {
       "proceedWithReset": "リセットを続行",
@@ -261,7 +268,7 @@
     "search": {
       "noResults": "モデルが見つかりません",
       "loadingMore": "読み込み中...",
-      "searchPlaceholder": "Hugging Faceモデルを検索",
+      "searchPlaceholder": "モデルリポジトリを検索",
       "modelUpdatedLong": "{{time}}前に更新",
       "modelUpdatedShort": "{{time}}前",
       "modelUpdatedJustNowLong": "たった今更新",
@@ -278,6 +285,13 @@
         "sortDownloads": "ダウンロード数",
         "sortRecent": "最近更新",
         "sortLikes": "いいね数"
+      },
+      "source": "ソース",
+      "sourceTitle": "ダウンロード元",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "HFミラー",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -304,7 +318,8 @@
         "author": "作者",
         "requiresProjectionModel": "投影モデルが必要",
         "downloadProjectionModel": "投影モデルをダウンロード",
-        "viewModelCardOnHuggingFace": "Hugging Faceでモデルカードを表示"
+        "viewModelCardOnHuggingFace": "Hugging Faceでモデルカードを表示",
+        "viewModelCardOnSource": "モデルのソースを表示"
       },
       "accessibility": {
         "expandDetails": "詳細を展開",
@@ -629,7 +644,8 @@
       "enableAndRetry": "トークンを有効にして再試行",
       "goToSettings": "設定へ移動",
       "tryAgain": "再試行",
-      "viewOnHuggingFace": "HFでモデルを表示 ↗"
+      "viewOnHuggingFace": "HFでモデルを表示 ↗",
+      "viewOnSource": "モデルのソースを表示 ↗"
     },
     "headerRight": {
       "deleteChatTitle": "チャットを削除",
@@ -680,7 +696,11 @@
       "menuTitleHf": "Hugging Faceモデル",
       "menuTitleDownloaded": "ダウンロード済みモデル",
       "menuTitleGrouped": "モデルタイプでグループ化",
-      "menuTitleReset": "モデルリストをリセット"
+      "menuTitleReset": "モデルリストをリセット",
+      "filtersGroup": "フィルター",
+      "viewGroup": "表示",
+      "menuTitleHfMirror": "Hugging Faceミラー",
+      "menuTitleModelScope": "ModelScopeモデル"
     },
     "modelsResetDialog": {
       "proceedWithReset": "リセットする",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -269,7 +269,11 @@
       "menuTitleHf": "Hugging Face 모델",
       "menuTitleDownloaded": "다운로드된 모델",
       "menuTitleGrouped": "모델 유형으로 그룹화",
-      "menuTitleReset": "모델 목록 초기화"
+      "menuTitleReset": "모델 목록 초기화",
+      "filtersGroup": "필터",
+      "viewGroup": "보기",
+      "menuTitleHfMirror": "Hugging Face 미러",
+      "menuTitleModelScope": "ModelScope 모델"
     },
     "chatHeaderTitle": {
       "defaultTitle": "채팅"
@@ -562,7 +566,8 @@
       "enableAndRetry": "활성화 및 재시도",
       "goToSettings": "설정으로 이동",
       "tryAgain": "다시 시도",
-      "viewOnHuggingFace": "HF에서 모델 보기 ↗"
+      "viewOnHuggingFace": "HF에서 모델 보기 ↗",
+      "viewOnSource": "모델 소스 보기 ↗"
     },
     "hfTokenSheet": {
       "title": "Hugging Face 토큰",
@@ -719,12 +724,15 @@
       "availableToDownload": "다운로드 가능",
       "useAddButtonForMore": "+ 버튼을 눌러 더 많은 모델을 찾아보세요",
       "unknownGroup": "알 수 없음",
-      "availableToUse": "사용 가능"
+      "availableToUse": "사용 가능",
+      "hfMirrorModel": "HF 미러",
+      "modelScopeModel": "ModelScope"
     },
     "buttons": {
       "addFromHuggingFace": "Hugging Face에서 가져오기",
       "addLocalModel": "내 기기에서 모델 추가",
-      "reset": "재설정"
+      "reset": "재설정",
+      "addFromModelSources": "모델 다운로드"
     },
     "modelsResetDialog": {
       "confirmReset": "재설정 확인",
@@ -734,7 +742,11 @@
       "menuTitleHf": "Hugging Face 모델",
       "menuTitleDownloaded": "다운로드된 모델",
       "menuTitleGrouped": "모델 유형으로 그룹화",
-      "menuTitleReset": "모델 목록 초기화"
+      "menuTitleReset": "모델 목록 초기화",
+      "filtersGroup": "필터",
+      "viewGroup": "보기",
+      "menuTitleHfMirror": "Hugging Face 미러",
+      "menuTitleModelScope": "ModelScope 모델"
     },
     "chatTemplate": {
       "label": "기본 채팅 템플릿:"
@@ -779,7 +791,7 @@
     "search": {
       "noResults": "모델을 찾을 수 없습니다",
       "loadingMore": "더 불러오는 중...",
-      "searchPlaceholder": "Hugging Face 모델 검색",
+      "searchPlaceholder": "모델 저장소 검색",
       "modelUpdatedLong": "{{time}} 전 업데이트됨",
       "modelUpdatedShort": "{{time}} 전",
       "modelUpdatedJustNowLong": "방금 업데이트됨",
@@ -796,6 +808,13 @@
         "sortDownloads": "다운로드 수",
         "sortRecent": "최근 업데이트",
         "sortLikes": "많은 추천"
+      },
+      "source": "소스",
+      "sourceTitle": "다운로드 소스",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "HF 미러",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -822,7 +841,8 @@
         "author": "제작자",
         "requiresProjectionModel": "프로젝션 모델 필요",
         "downloadProjectionModel": "프로젝션 모델 다운로드",
-        "viewModelCardOnHuggingFace": "Hugging Face에서 모델 카드 보기"
+        "viewModelCardOnHuggingFace": "Hugging Face에서 모델 카드 보기",
+        "viewModelCardOnSource": "모델 소스 보기"
       },
       "accessibility": {
         "expandDetails": "세부정보 펼치기",

--- a/src/locales/ms.json
+++ b/src/locales/ms.json
@@ -160,7 +160,9 @@
       "unknownGroup": "Tidak Diketahui",
       "availableToUse": "Sedia Digunakan",
       "availableToDownload": "Tersedia untuk Dimuat Turun",
-      "useAddButtonForMore": "Guna butang + untuk mencari model lain"
+      "useAddButtonForMore": "Guna butang + untuk mencari model lain",
+      "hfMirrorModel": "Cermin HF",
+      "modelScopeModel": "ModelScope"
     },
     "vision": "Penglihatan",
     "mmproj": "Projektor",
@@ -206,13 +208,18 @@
     "buttons": {
       "addFromHuggingFace": "Tambah daripada Hugging Face",
       "addLocalModel": "Tambah Model Tempatan",
-      "reset": "Tetap Semula"
+      "reset": "Tetap Semula",
+      "addFromModelSources": "Muat Turun Model"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Model Hugging Face",
       "menuTitleDownloaded": "Model yang Dimuat Turun",
       "menuTitleGrouped": "Kumpulkan Mengikut Jenis Model",
-      "menuTitleReset": "Tetap Semula Senarai Model"
+      "menuTitleReset": "Tetap Semula Senarai Model",
+      "filtersGroup": "Penapis",
+      "viewGroup": "Paparan",
+      "menuTitleHfMirror": "Cermin Hugging Face",
+      "menuTitleModelScope": "Model ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Teruskan Tetapan Semula",
@@ -261,7 +268,7 @@
     "search": {
       "noResults": "Model tidak ditemui",
       "loadingMore": "Memuatkan lebih banyak...",
-      "searchPlaceholder": "Cari model Hugging Face",
+      "searchPlaceholder": "Cari repositori model",
       "modelUpdatedLong": "Dikemas kini {{time}} lalu",
       "modelUpdatedShort": "{{time}} lalu",
       "modelUpdatedJustNowLong": "Dikemas kini baru sahaja",
@@ -278,6 +285,13 @@
         "sortDownloads": "Bilangan Muat Turun",
         "sortRecent": "Dikemas Kini Terkini",
         "sortLikes": "Paling Disukai"
+      },
+      "source": "Sumber",
+      "sourceTitle": "Sumber Muat Turun",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "Cermin HF",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -304,7 +318,8 @@
         "author": "Pengarang",
         "requiresProjectionModel": "Memerlukan model unjuran",
         "downloadProjectionModel": "Muat turun model unjuran",
-        "viewModelCardOnHuggingFace": "Lihat Kad Model di Hugging Face"
+        "viewModelCardOnHuggingFace": "Lihat Kad Model di Hugging Face",
+        "viewModelCardOnSource": "Lihat Sumber Model"
       },
       "accessibility": {
         "expandDetails": "Kembangkan butiran",
@@ -629,7 +644,8 @@
       "enableAndRetry": "Dayakan dan Cuba Lagi",
       "goToSettings": "Pergi ke Tetapan",
       "tryAgain": "Cuba Lagi",
-      "viewOnHuggingFace": "Lihat Model di HF ↗"
+      "viewOnHuggingFace": "Lihat Model di HF ↗",
+      "viewOnSource": "Lihat Sumber Model ↗"
     },
     "headerRight": {
       "deleteChatTitle": "Padam Sembang",
@@ -680,7 +696,11 @@
       "menuTitleHf": "Model Hugging Face",
       "menuTitleDownloaded": "Model yang Dimuat Turun",
       "menuTitleGrouped": "Kumpulkan Mengikut Jenis Model",
-      "menuTitleReset": "Tetap Semula Senarai Model"
+      "menuTitleReset": "Tetap Semula Senarai Model",
+      "filtersGroup": "Penapis",
+      "viewGroup": "Paparan",
+      "menuTitleHfMirror": "Cermin Hugging Face",
+      "menuTitleModelScope": "Model ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Teruskan Tetapan Semula",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -302,7 +302,11 @@
       "menuTitleHf": "Модели от Hugging Face",
       "menuTitleDownloaded": "Загруженные модели",
       "menuTitleGrouped": "Группировать по типу модели",
-      "menuTitleReset": "Сбросить список моделей"
+      "menuTitleReset": "Сбросить список моделей",
+      "filtersGroup": "Фильтры",
+      "viewGroup": "Вид",
+      "menuTitleHfMirror": "Зеркало Hugging Face",
+      "menuTitleModelScope": "Модели ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Выполнить сброс",
@@ -562,7 +566,8 @@
       "enableAndRetry": "Включить и повторить",
       "goToSettings": "В настройки",
       "tryAgain": "Ещё раз",
-      "viewOnHuggingFace": "Открыть на HF ↗"
+      "viewOnHuggingFace": "Открыть на HF ↗",
+      "viewOnSource": "Открыть источник модели ↗"
     },
     "hfTokenSheet": {
       "title": "Токен Hugging Face",
@@ -743,7 +748,11 @@
       "menuTitleHf": "Модели от Hugging Face",
       "menuTitleDownloaded": "Загруженные модели",
       "menuTitleGrouped": "Группировать по типу модели",
-      "menuTitleReset": "Сбросить список моделей"
+      "menuTitleReset": "Сбросить список моделей",
+      "filtersGroup": "Фильтры",
+      "viewGroup": "Вид",
+      "menuTitleHfMirror": "Зеркало Hugging Face",
+      "menuTitleModelScope": "Модели ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Выполнить сброс",
@@ -763,12 +772,15 @@
       "unknownGroup": "Неизвестно",
       "availableToUse": "Готово к использованию",
       "availableToDownload": "Доступно для загрузки",
-      "useAddButtonForMore": "Используйте кнопку +, чтобы найти больше моделей"
+      "useAddButtonForMore": "Используйте кнопку +, чтобы найти больше моделей",
+      "hfMirrorModel": "Зеркало HF",
+      "modelScopeModel": "ModelScope"
     },
     "buttons": {
       "addFromHuggingFace": "Добавить из Hugging Face",
       "addLocalModel": "Добавить локальную модель",
-      "reset": "Сброс"
+      "reset": "Сброс",
+      "addFromModelSources": "Скачать модель"
     },
     "chatTemplate": {
       "label": "Базовый шаблон чата:"
@@ -779,7 +791,7 @@
     "search": {
       "noResults": "Модели не найдены",
       "loadingMore": "Загрузка дополнительных данных...",
-      "searchPlaceholder": "Поиск моделей на Hugging Face",
+      "searchPlaceholder": "Поиск репозиториев моделей",
       "modelUpdatedLong": "Обновлено {{time}} назад",
       "modelUpdatedShort": "{{time}} назад",
       "modelUpdatedJustNowLong": "Обновлено только что",
@@ -796,6 +808,13 @@
         "sortDownloads": "Загрузки",
         "sortRecent": "Недавно обновлено",
         "sortLikes": "Самые популярные"
+      },
+      "source": "Источник",
+      "sourceTitle": "Источник загрузки",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "Зеркало HF",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -822,7 +841,8 @@
         "author": "Автор",
         "requiresProjectionModel": "Требуется модель проекции",
         "downloadProjectionModel": "Загрузить модель проекции",
-        "viewModelCardOnHuggingFace": "Открыть карточку модели на Hugging Face"
+        "viewModelCardOnHuggingFace": "Открыть карточку модели на Hugging Face",
+        "viewModelCardOnSource": "Открыть источник модели"
       },
       "accessibility": {
         "expandDetails": "Развернуть детали",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -200,7 +200,9 @@
       "hfModel": "HF",
       "availableToUse": "Готовий до використання",
       "availableToDownload": "Доступно для завантаження",
-      "useAddButtonForMore": "Натисніть кнопку «+», щоб переглянути інші моделі"
+      "useAddButtonForMore": "Натисніть кнопку «+», щоб переглянути інші моделі",
+      "hfMirrorModel": "Дзеркало HF",
+      "modelScopeModel": "ModelScope"
     },
     "vision": "Бачення",
     "mmproj": "Проектор",
@@ -246,13 +248,18 @@
     "buttons": {
       "addFromHuggingFace": "Додати з Hugging Face",
       "addLocalModel": "Додати локальну модель",
-      "reset": "Скинути"
+      "reset": "Скинути",
+      "addFromModelSources": "Завантажити модель"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Моделі Hugging Face",
       "menuTitleDownloaded": "Завантажені моделі",
       "menuTitleGrouped": "Групувати за типом моделі",
-      "menuTitleReset": "Оновити список моделей"
+      "menuTitleReset": "Оновити список моделей",
+      "filtersGroup": "Фільтри",
+      "viewGroup": "Вигляд",
+      "menuTitleHfMirror": "Дзеркало Hugging Face",
+      "menuTitleModelScope": "Моделі ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Продовжити скидання",
@@ -301,7 +308,7 @@
     "search": {
       "noResults": "Моделей не знайдено",
       "loadingMore": "Завантажується...",
-      "searchPlaceholder": "Пошук моделей Hugging Face",
+      "searchPlaceholder": "Пошук репозиторіїв моделей",
       "modelUpdatedLong": "Оновлено {{time}} тому",
       "modelUpdatedShort": "{{time}} тому",
       "modelUpdatedJustNowLong": "Щойно оновлено",
@@ -318,6 +325,13 @@
         "sortDownloads": "Завантажень",
         "sortRecent": "Нещодавно оновлено",
         "sortLikes": "Найпопулярніша"
+      },
+      "source": "Джерело",
+      "sourceTitle": "Джерело завантаження",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "Дзеркало HF",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -344,7 +358,8 @@
         "author": "Автор",
         "requiresProjectionModel": "Потрібна модель проекції",
         "downloadProjectionModel": "Завантажити модель прогнозування",
-        "viewModelCardOnHuggingFace": "Переглянути картку моделі на Hugging Face"
+        "viewModelCardOnHuggingFace": "Переглянути картку моделі на Hugging Face",
+        "viewModelCardOnSource": "Переглянути джерело моделі"
       },
       "accessibility": {
         "expandDetails": "Розгорнути детальну інформацію",
@@ -676,7 +691,8 @@
       "enableAndRetry": "Увімкнути та спробувати ще раз",
       "goToSettings": "Перейти до налаштувань",
       "tryAgain": "Спробувати ще Рфаз",
-      "viewOnHuggingFace": "Переглянути модель на HF ↗"
+      "viewOnHuggingFace": "Переглянути модель на HF ↗",
+      "viewOnSource": "Переглянути джерело моделі ↗"
     },
     "headerRight": {
       "deleteChatTitle": "Видалити чат",
@@ -727,7 +743,11 @@
       "menuTitleHf": "Моделі Hugging Face",
       "menuTitleDownloaded": "Завантажені моделі",
       "menuTitleGrouped": "Групувати за типом моделі",
-      "menuTitleReset": "Оновити список моделей"
+      "menuTitleReset": "Оновити список моделей",
+      "filtersGroup": "Фільтри",
+      "viewGroup": "Вигляд",
+      "menuTitleHfMirror": "Дзеркало Hugging Face",
+      "menuTitleModelScope": "Моделі ModelScope"
     },
     "modelsResetDialog": {
       "proceedWithReset": "Продовжити скидання",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -197,7 +197,9 @@
       "unknownGroup": "未知",
       "availableToUse": "可使用",
       "availableToDownload": "可下载",
-      "useAddButtonForMore": "点击 + 按钮添加更多模型"
+      "useAddButtonForMore": "点击 + 按钮添加更多模型",
+      "hfMirrorModel": "HF镜像",
+      "modelScopeModel": "魔搭"
     },
     "vision": "视觉",
     "mmproj": "投影仪",
@@ -243,13 +245,18 @@
     "buttons": {
       "addFromHuggingFace": "从Hugging Face添加",
       "addLocalModel": "添加本地模型",
-      "reset": "重置"
+      "reset": "重置",
+      "addFromModelSources": "下载模型"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Hugging Face模型",
       "menuTitleDownloaded": "已下载模型",
       "menuTitleGrouped": "按模型类型分组",
-      "menuTitleReset": "重置模型列表"
+      "menuTitleReset": "重置模型列表",
+      "filtersGroup": "筛选",
+      "viewGroup": "视图",
+      "menuTitleHfMirror": "Hugging Face镜像",
+      "menuTitleModelScope": "魔搭模型"
     },
     "modelsResetDialog": {
       "proceedWithReset": "继续重置",
@@ -298,7 +305,7 @@
     "search": {
       "noResults": "找不到模型",
       "loadingMore": "加载中...",
-      "searchPlaceholder": "搜索Hugging Face模型",
+      "searchPlaceholder": "搜索模型仓库",
       "modelUpdatedLong": "{{time}}前更新",
       "modelUpdatedShort": "{{time}}前",
       "modelUpdatedJustNowLong": "刚刚更新",
@@ -315,6 +322,13 @@
         "sortDownloads": "下载量",
         "sortRecent": "最近更新",
         "sortLikes": "点赞数"
+      },
+      "source": "来源",
+      "sourceTitle": "下载来源",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "HF镜像",
+        "modelscope": "魔搭"
       }
     },
     "modelCard": {
@@ -341,7 +355,8 @@
         "author": "作者",
         "requiresProjectionModel": "需要投影模型",
         "downloadProjectionModel": "下载投影模型",
-        "viewModelCardOnHuggingFace": "在Hugging Face上查看模型卡片"
+        "viewModelCardOnHuggingFace": "在Hugging Face上查看模型卡片",
+        "viewModelCardOnSource": "查看模型来源"
       },
       "accessibility": {
         "expandDetails": "展开详情",
@@ -668,7 +683,8 @@
       "enableAndRetry": "启用并重试",
       "goToSettings": "前往设置",
       "tryAgain": "重试",
-      "viewOnHuggingFace": "在HF上查看模型 ↗"
+      "viewOnHuggingFace": "在HF上查看模型 ↗",
+      "viewOnSource": "查看模型来源 ↗"
     },
     "headerRight": {
       "deleteChatTitle": "删除聊天",
@@ -719,7 +735,11 @@
       "menuTitleHf": "Hugging Face模型",
       "menuTitleDownloaded": "已下载模型",
       "menuTitleGrouped": "按模型类型分组",
-      "menuTitleReset": "重置模型列表"
+      "menuTitleReset": "重置模型列表",
+      "filtersGroup": "筛选",
+      "viewGroup": "视图",
+      "menuTitleHfMirror": "Hugging Face镜像",
+      "menuTitleModelScope": "魔搭模型"
     },
     "modelsResetDialog": {
       "proceedWithReset": "继续重置",

--- a/src/locales/zh_Hant.json
+++ b/src/locales/zh_Hant.json
@@ -265,7 +265,11 @@
       "menuTitleHf": "Hugging Face 模型",
       "menuTitleDownloaded": "已下載模型",
       "menuTitleGrouped": "按模型類型分組",
-      "menuTitleReset": "重置模型列表"
+      "menuTitleReset": "重置模型列表",
+      "filtersGroup": "篩選",
+      "viewGroup": "檢視",
+      "menuTitleHfMirror": "Hugging Face 鏡像",
+      "menuTitleModelScope": "ModelScope 模型"
     },
     "modelsResetDialog": {
       "proceedWithReset": "繼續重置",
@@ -528,7 +532,8 @@
       "enableAndRetry": "啟用並重試",
       "goToSettings": "前往設定",
       "tryAgain": "再試一次",
-      "viewOnHuggingFace": "在 HF 上查看模型 ↗"
+      "viewOnHuggingFace": "在 HF 上查看模型 ↗",
+      "viewOnSource": "查看模型來源 ↗"
     },
     "hfTokenSheet": {
       "save": "儲存 Token",
@@ -719,18 +724,25 @@
       "unknownGroup": "未知",
       "availableToUse": "準備使用",
       "availableToDownload": "可用下載",
-      "useAddButtonForMore": "點擊「+」按鈕即可搜尋更多模型"
+      "useAddButtonForMore": "點擊「+」按鈕即可搜尋更多模型",
+      "hfMirrorModel": "HF 鏡像",
+      "modelScopeModel": "ModelScope"
     },
     "buttons": {
       "addFromHuggingFace": "從 Hugging Face 新增",
       "addLocalModel": "新增本地模型",
-      "reset": "重置"
+      "reset": "重置",
+      "addFromModelSources": "下載模型"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Hugging Face 模型",
       "menuTitleDownloaded": "已下載模型",
       "menuTitleGrouped": "按模型類型分組",
-      "menuTitleReset": "重置模型列表"
+      "menuTitleReset": "重置模型列表",
+      "filtersGroup": "篩選",
+      "viewGroup": "檢視",
+      "menuTitleHfMirror": "Hugging Face 鏡像",
+      "menuTitleModelScope": "ModelScope 模型"
     },
     "modelsResetDialog": {
       "proceedWithReset": "執行重置",
@@ -779,7 +791,7 @@
     "search": {
       "noResults": "未找到模型",
       "loadingMore": "正在載入更多…",
-      "searchPlaceholder": "搜尋 Hugging Face 模型",
+      "searchPlaceholder": "搜尋模型倉庫",
       "modelUpdatedLong": "更新於 {{time}} 之前",
       "modelUpdatedShort": "{{time}} 之前",
       "modelUpdatedJustNowLong": "剛剛更新",
@@ -796,6 +808,13 @@
         "sortDownloads": "下載",
         "sortRecent": "最近更新",
         "sortLikes": "最受歡迎"
+      },
+      "source": "來源",
+      "sourceTitle": "下載來源",
+      "sources": {
+        "huggingface": "Hugging Face",
+        "hf_mirror": "HF 鏡像",
+        "modelscope": "ModelScope"
       }
     },
     "modelCard": {
@@ -822,7 +841,8 @@
         "author": "作者",
         "requiresProjectionModel": "需要投影模型",
         "downloadProjectionModel": "下載投影模型",
-        "viewModelCardOnHuggingFace": "在 Hugging Face 觀看模型卡"
+        "viewModelCardOnHuggingFace": "在 Hugging Face 觀看模型卡",
+        "viewModelCardOnSource": "查看模型來源"
       },
       "accessibility": {
         "loadingIndicator": "正在載入",

--- a/src/screens/ModelsScreen/FABGroup/FABGroup.tsx
+++ b/src/screens/ModelsScreen/FABGroup/FABGroup.tsx
@@ -52,8 +52,8 @@ export const FABGroup: React.FC<FABGroupProps> = ({
       {
         testID: 'hf-fab',
         icon: HFIcon,
-        label: l10n.models.buttons.addFromHuggingFace,
-        accessibilityLabel: l10n.models.buttons.addFromHuggingFace,
+        label: l10n.models.buttons.addFromModelSources,
+        accessibilityLabel: l10n.models.buttons.addFromModelSources,
         style: styles.actionButton,
         onPress: () => {
           onAddHFModel();

--- a/src/screens/ModelsScreen/HFModelSearch/DetailsView/DetailsView.tsx
+++ b/src/screens/ModelsScreen/HFModelSearch/DetailsView/DetailsView.tsx
@@ -1,7 +1,8 @@
 import React, {useContext} from 'react';
-import {View} from 'react-native';
+import {ActivityIndicator, Image, View} from 'react-native';
 
 import {Text, Chip, Tooltip} from 'react-native-paper';
+import {observer} from 'mobx-react';
 import {BottomSheetFlatList} from '@gorhom/bottom-sheet';
 
 import {ModelTypeTag, Sheet} from '../../../../components';
@@ -10,6 +11,7 @@ import {useTheme} from '../../../../hooks';
 
 import {createStyles} from './styles';
 import {ModelFileCard} from './ModelFileCard';
+import {hfStore} from '../../../../store';
 
 import {HuggingFaceModel, ModelFile} from '../../../../utils/types';
 import {
@@ -25,28 +27,84 @@ interface DetailsViewProps {
   hfModel: HuggingFaceModel;
 }
 
-export const DetailsView = ({hfModel}: DetailsViewProps) => {
+export const DetailsView = observer(({hfModel}: DetailsViewProps) => {
   const theme = useTheme();
   const styles = createStyles(theme);
   const l10n = useContext(L10nContext);
+  const [avatarFailed, setAvatarFailed] = React.useState(false);
 
   // Check if this is a vision repository
   const isVision = isVisionRepo(hfModel.siblings || []);
+  const sourceLabel = l10n.models.search.sources[hfModel.source || 'huggingface'];
 
   // Get LLM files (non-mmproj files) - projection models are hidden from UI
   const llmFiles = getLLMFiles(hfModel.siblings || []);
+  const detailsError =
+    hfStore.error?.context === 'modelDetails' ? hfStore.error : null;
+  const showLoading = hfStore.modelDetailsLoading && llmFiles.length === 0;
+  const showError = !showLoading && detailsError && llmFiles.length === 0;
+  const showEmpty = !showLoading && !showError && llmFiles.length === 0;
 
   const renderItem = ({item}: {item: ModelFile}) => (
     <ModelFileCard key={item.rfilename} modelFile={item} hfModel={hfModel} />
   );
 
+  const renderEmptyState = () => {
+    if (showLoading) {
+      return (
+        <View style={styles.emptyStateContainer}>
+          <ActivityIndicator color={theme.colors.primary} />
+          <Text style={styles.emptyStateText}>
+            {l10n.models.search.loadingMore}
+          </Text>
+        </View>
+      );
+    }
+
+    if (showError) {
+      return (
+        <View style={styles.emptyStateContainer}>
+          <Text style={styles.errorText}>{detailsError.message}</Text>
+        </View>
+      );
+    }
+
+    if (showEmpty) {
+      return (
+        <View style={styles.emptyStateContainer}>
+          <Text style={styles.emptyStateText}>
+            {l10n.models.search.noResults}
+          </Text>
+        </View>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <View style={styles.content}>
       <View style={styles.header}>
         <View style={styles.authorRow}>
+          <View style={styles.avatarContainer}>
+            {hfModel.avatarUrl && !avatarFailed ? (
+              <Image
+                source={{uri: hfModel.avatarUrl}}
+                style={styles.avatar}
+                onError={() => setAvatarFailed(true)}
+              />
+            ) : (
+              <Text style={styles.avatarText}>
+                {hfModel.author.slice(0, 1).toUpperCase()}
+              </Text>
+            )}
+          </View>
           <Text variant="headlineSmall" style={styles.modelAuthor}>
             {hfModel.author}
           </Text>
+          <Chip compact mode="outlined" textStyle={styles.statText}>
+            {sourceLabel}
+          </Chip>
           {isVision && (
             <ModelTypeTag
               type="vision"
@@ -66,6 +124,14 @@ export const DetailsView = ({hfModel}: DetailsViewProps) => {
             </Text>
           </Tooltip>
         </View>
+        {hfModel.description && (
+          <Text
+            variant="bodySmall"
+            style={styles.modelDescription}
+            numberOfLines={3}>
+            {hfModel.description}
+          </Text>
+        )}
         <View style={styles.modelStats}>
           <Chip
             icon="clock"
@@ -105,17 +171,21 @@ export const DetailsView = ({hfModel}: DetailsViewProps) => {
           {l10n.models.details.title}
         </Text>
       </View>
-      <BottomSheetFlatList
-        data={llmFiles}
-        keyExtractor={(item: ModelFile) => item.rfilename}
-        renderItem={renderItem}
-        renderScrollComponent={props => (
-          <Sheet.ScrollView bottomOffset={100} {...props} />
-        )}
-        contentContainerStyle={styles.list}
-      />
+      {llmFiles.length === 0 ? (
+        renderEmptyState()
+      ) : (
+        <BottomSheetFlatList
+          data={llmFiles}
+          keyExtractor={(item: ModelFile) => item.rfilename}
+          renderItem={renderItem}
+          renderScrollComponent={props => (
+            <Sheet.ScrollView bottomOffset={100} {...props} />
+          )}
+          contentContainerStyle={styles.list}
+        />
+      )}
       {/* TODO: Currently projection models are hidden from UI,
       we should add them to the model card like in a dropdown form.*/}
     </View>
   );
-};
+});

--- a/src/screens/ModelsScreen/HFModelSearch/DetailsView/ModelFileCard/ModelFileCard.tsx
+++ b/src/screens/ModelsScreen/HFModelSearch/DetailsView/ModelFileCard/ModelFileCard.tsx
@@ -62,7 +62,12 @@ export const ModelFileCard: FC<ModelFileCardProps> = observer(
       () => createStyles(theme, isProjection),
       [theme, isProjection],
     );
-    const HF_YELLOW = '#FFD21E';
+    const sourceAccent =
+      hfModel.source === 'modelscope'
+        ? '#00A971'
+        : hfModel.source === 'hf_mirror'
+          ? '#5E8CFF'
+          : '#FFD21E';
 
     // Check if we have all the necessary data, as some are fetched async, like size.
     const isModelInfoReady = Boolean(
@@ -82,13 +87,18 @@ export const ModelFileCard: FC<ModelFileCardProps> = observer(
     const downloadProgress = storeModel?.progress || 0;
     const downloadSpeed = storeModel?.downloadSpeed;
 
+    const isSameSourceFile = useMemo(
+      () => (model: Model) => model.id === convertedModel.id,
+      [convertedModel.id],
+    );
+
     const isBookmarked = computed(() =>
-      modelStore.models.some(model => model.hfModelFile?.oid === modelFile.oid),
+      modelStore.models.some(isSameSourceFile),
     ).get();
 
     const isDownloaded = computed(() =>
       modelStore.models.some(
-        model => model.hfModelFile?.oid === modelFile.oid && model.isDownloaded,
+        model => isSameSourceFile(model) && model.isDownloaded,
       ),
     ).get();
 
@@ -150,9 +160,7 @@ export const ModelFileCard: FC<ModelFileCardProps> = observer(
 
     const handleUnbookmark = () => {
       if (isBookmarked) {
-        const model = modelStore.models.find(
-          (m: Model) => m.hfModelFile?.oid === modelFile.oid,
-        );
+        const model = modelStore.models.find(isSameSourceFile);
         if (model?.origin === ModelOrigin.PRESET) {
           Alert.alert(
             l10n.models.modelFile.alerts.cannotRemoveTitle,
@@ -215,9 +223,7 @@ export const ModelFileCard: FC<ModelFileCardProps> = observer(
     };
 
     const handleDelete = () => {
-      const model = modelStore.models.find(
-        m => m.hfModelFile?.oid === modelFile.oid,
-      );
+      const model = modelStore.models.find(isSameSourceFile);
       if (model?.isDownloaded) {
         Alert.alert(
           l10n.models.modelFile.alerts.deleteTitle,
@@ -275,7 +281,10 @@ export const ModelFileCard: FC<ModelFileCardProps> = observer(
         style={styles.fileCardContainer}
         testID={`model-file-card-${modelFile.rfilename}`}>
         <LinearGradient
-          colors={[theme.dark ? HF_YELLOW + '90' : HF_YELLOW, 'transparent']}
+          colors={[
+            theme.dark ? sourceAccent + '90' : sourceAccent,
+            'transparent',
+          ]}
           locations={[1, 1]}
           start={{x: 0, y: 0}}
           end={{x: 1, y: 0}}

--- a/src/screens/ModelsScreen/HFModelSearch/DetailsView/ModelFileCard/__tests__/ModelFileCard.test.tsx
+++ b/src/screens/ModelsScreen/HFModelSearch/DetailsView/ModelFileCard/__tests__/ModelFileCard.test.tsx
@@ -18,6 +18,7 @@ import {ModelFileCard} from '../ModelFileCard';
 import {downloadManager} from '../../../../../../services/downloads';
 
 import {modelStore} from '../../../../../../store';
+import {hfAsModel} from '../../../../../../utils';
 
 const render = (ui: React.ReactElement, options: any = {}) =>
   baseRender(ui, {withBottomSheetProvider: true, ...options});
@@ -164,6 +165,65 @@ describe('ModelFileCard', () => {
       'Delete Model',
       'Are you sure you want to delete this downloaded model?',
       expect.any(Array),
+    );
+  });
+
+  it('does not treat another source file with the same oid as bookmarked', async () => {
+    const mirrorModel = hfAsModel(
+      {
+        ...mockHFModel1,
+        source: 'hf_mirror',
+        sourceRepoId: mockHFModel1.id,
+        url: 'https://hf-mirror.com/owner/hf-model-name-1',
+      },
+      mockHFModel1.siblings[0],
+    );
+    modelStore.models = [mirrorModel];
+
+    const {getByTestId} = render(
+      <ModelFileCard
+        modelFile={mockHFModel1.siblings[0]}
+        hfModel={mockHFModel1}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('bookmark-button'));
+    });
+
+    expect(modelStore.removeModelFromList).not.toHaveBeenCalled();
+    expect(modelStore.addHFModel).toHaveBeenCalledWith(
+      mockHFModel1,
+      mockHFModel1.siblings[0],
+    );
+  });
+
+  it('does not treat different files without oid as the same model', async () => {
+    const firstFile = {
+      rfilename: 'model-a.gguf',
+      size: 1000,
+      canFitInStorage: true,
+    };
+    const secondFile = {
+      rfilename: 'model-b.gguf',
+      size: 1000,
+      canFitInStorage: true,
+    };
+    const storeModel = hfAsModel(mockHFModel1, firstFile);
+    modelStore.models = [storeModel];
+
+    const {getByTestId} = render(
+      <ModelFileCard modelFile={secondFile} hfModel={mockHFModel1} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('bookmark-button'));
+    });
+
+    expect(modelStore.removeModelFromList).not.toHaveBeenCalled();
+    expect(modelStore.addHFModel).toHaveBeenCalledWith(
+      mockHFModel1,
+      secondFile,
     );
   });
 });

--- a/src/screens/ModelsScreen/HFModelSearch/DetailsView/__tests__/DetailsView.test.tsx
+++ b/src/screens/ModelsScreen/HFModelSearch/DetailsView/__tests__/DetailsView.test.tsx
@@ -7,11 +7,17 @@ import {
 } from '../../../../../../jest/fixtures/models';
 import {formatNumber, timeAgo} from '../../../../../utils';
 import {l10n} from '../../../../../locales';
+import {hfStore} from '../../../../../store';
 
 const render = (ui: React.ReactElement, options: any = {}) =>
   baseRender(ui, {withBottomSheetProvider: true, ...options});
 
 describe('DetailsView', () => {
+  beforeEach(() => {
+    hfStore.error = null;
+    hfStore.modelDetailsLoading = false;
+  });
+
   it('renders basic model information', () => {
     const {getByText} = render(<DetailsView hfModel={mockHFModel1} />);
 
@@ -51,5 +57,15 @@ describe('DetailsView', () => {
       expect(getByTestId(`model-file-card-${file.rfilename}`)).toBeDefined();
       expect(getByTestId(`model-file-name-${file.rfilename}`)).toBeDefined();
     });
+  });
+
+  it('renders loading state while model file details are loading', () => {
+    hfStore.modelDetailsLoading = true;
+
+    const {getByText} = render(
+      <DetailsView hfModel={{...mockHFModel1, siblings: []}} />,
+    );
+
+    expect(getByText(l10n.en.models.search.loadingMore)).toBeDefined();
   });
 });

--- a/src/screens/ModelsScreen/HFModelSearch/DetailsView/styles.ts
+++ b/src/screens/ModelsScreen/HFModelSearch/DetailsView/styles.ts
@@ -35,8 +35,29 @@ export const createStyles = (theme: Theme) =>
       marginBottom: 6,
       gap: 8,
     },
+    avatarContainer: {
+      width: 34,
+      height: 34,
+      borderRadius: 8,
+      backgroundColor: theme.colors.surfaceVariant,
+      alignItems: 'center',
+      justifyContent: 'center',
+      overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.outline,
+    },
+    avatar: {
+      width: 34,
+      height: 34,
+    },
+    avatarText: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: theme.colors.onSurfaceVariant,
+    },
     modelAuthor: {
       marginBottom: 0,
+      flexShrink: 1,
     },
     titleContainer: {
       marginBottom: 10,
@@ -48,6 +69,11 @@ export const createStyles = (theme: Theme) =>
     },
     modelTitle: {
       fontWeight: 'bold',
+    },
+    modelDescription: {
+      color: theme.colors.onSurfaceVariant,
+      marginBottom: 10,
+      lineHeight: 18,
     },
     modelStats: {
       flexDirection: 'row',
@@ -76,5 +102,20 @@ export const createStyles = (theme: Theme) =>
       marginTop: 12,
       marginBottom: 4,
       color: theme.colors.onSurfaceVariant,
+    },
+    emptyStateContainer: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: 32,
+      paddingHorizontal: 16,
+      gap: 8,
+    },
+    emptyStateText: {
+      color: theme.colors.onSurfaceVariant,
+      textAlign: 'center',
+    },
+    errorText: {
+      color: theme.colors.error,
+      textAlign: 'center',
     },
   });

--- a/src/screens/ModelsScreen/HFModelSearch/HFModelSearch.tsx
+++ b/src/screens/ModelsScreen/HFModelSearch/HFModelSearch.tsx
@@ -24,22 +24,32 @@ export const HFModelSearch: React.FC<HFModelSearchProps> = observer(
     const [selectedModel, setSelectedModel] = useState<HuggingFaceModel | null>(
       null,
     );
+    const latestModelSelection = React.useRef(0);
 
     // Clear state when closed
     useEffect(() => {
       if (!visible) {
         setSelectedModel(null);
+        setDetailsVisible(false);
       }
     }, [visible]);
 
     const debouncedSearch = useMemo(
       () =>
         debounce(async (query: string) => {
-          hfStore.setSearchQuery(query);
           await hfStore.fetchModels();
         }, DEBOUNCE_DELAY),
       [], // Empty dependencies since we don't want to recreate this
     );
+
+    useEffect(() => {
+      if (!visible) {
+        return;
+      }
+      debouncedSearch.cancel();
+      setSelectedModel(null);
+      setDetailsVisible(false);
+    }, [debouncedSearch, hfStore.selectedSource, visible]);
 
     // Update search query without triggering immediate search
     const handleSearchChange = useCallback(
@@ -55,10 +65,22 @@ export const HFModelSearch: React.FC<HFModelSearchProps> = observer(
       }
     }, [handleSearchChange, visible]);
 
+    useEffect(
+      () => () => {
+        debouncedSearch.cancel();
+      },
+      [debouncedSearch],
+    );
+
     const handleModelSelect = async (model: HuggingFaceModel) => {
+      const selectionId = latestModelSelection.current + 1;
+      latestModelSelection.current = selectionId;
       setSelectedModel(model);
       setDetailsVisible(true);
       await hfStore.fetchModelData(model.id);
+      if (selectionId !== latestModelSelection.current) {
+        return;
+      }
       const updatedModel = hfStore.getModelById(model.id);
       if (updatedModel) {
         setSelectedModel({...updatedModel});

--- a/src/screens/ModelsScreen/HFModelSearch/SearchView/SearchView.tsx
+++ b/src/screens/ModelsScreen/HFModelSearch/SearchView/SearchView.tsx
@@ -1,5 +1,11 @@
-import React, {useState, useContext, useCallback, useRef} from 'react';
-import {TouchableOpacity, View} from 'react-native';
+import React, {
+  useState,
+  useContext,
+  useCallback,
+  useRef,
+  useEffect,
+} from 'react';
+import {Image, TouchableOpacity, View} from 'react-native';
 
 import {observer} from 'mobx-react';
 import {Text, Chip, Button} from 'react-native-paper';
@@ -26,7 +32,9 @@ import {
   timeAgo,
   L10nContext,
   isVisionRepo,
+  formatBytes,
 } from '../../../../utils';
+import {ModelSourceId} from '../../../../utils/types';
 
 interface SearchViewProps {
   testID?: string;
@@ -40,13 +48,21 @@ export const SearchView = observer(
     const l10n = useContext(L10nContext);
 
     const styles = createStyles(theme);
-    const [searchQuery, setSearchQuery] = useState('');
+    const [searchQuery, setSearchQuery] = useState(hfStore.searchQuery);
+    const [failedAvatars, setFailedAvatars] = useState<Record<string, true>>(
+      {},
+    );
     const lastOnEndReachedCall = useRef<number>(0);
 
     const handleSearchChange = (query: string) => {
       setSearchQuery(query);
+      hfStore.setSearchQuery(query);
       onChangeSearchQuery(query);
     };
+
+    useEffect(() => {
+      setSearchQuery(hfStore.searchQuery);
+    }, [hfStore.searchQuery]);
 
     const handleFiltersChange = useCallback(
       (newFilters: Partial<typeof hfStore.searchFilters>) => {
@@ -55,6 +71,11 @@ export const SearchView = observer(
       },
       [],
     );
+
+    const handleSourceChange = useCallback((source: ModelSourceId) => {
+      hfStore.setSelectedSource(source);
+      hfStore.fetchModels();
+    }, []);
 
     const handleEndReached = useCallback(() => {
       const now = Date.now();
@@ -74,19 +95,65 @@ export const SearchView = observer(
     const renderItem = ({item}: {item: HuggingFaceModel}) => {
       // Check if this is a vision repository
       const isVision = isVisionRepo(item.siblings || []);
+      const fileCount = item.siblings?.length || 0;
+      const totalSize = (item.siblings || []).reduce(
+        (sum, file) => sum + (file.size || file.lfs?.size || 0),
+        0,
+      );
+      const modelSize = totalSize || item.modelSize || 0;
+      const params = item.specs?.gguf?.total || 0;
+      const sourceLabel =
+        l10n.models.search.sources[item.source || 'huggingface'];
+      const title = extractHFModelTitle(item.id);
+      const avatarFailed = failedAvatars[item.id];
 
       return (
         <TouchableOpacity
           key={item.id}
           onPress={() => onModelSelect(item)}
           accessible={true}
-          accessibilityLabel={`${item.author} ${extractHFModelTitle(item.id)}`}
-          testID={`hf-model-item-${item.id}`}>
-          <Text variant="labelMedium" style={styles.modelAuthor}>
-            {item.author}
-          </Text>
-          <View style={styles.modelNameContainer}>
-            <Text style={styles.modelName}>{extractHFModelTitle(item.id)}</Text>
+          accessibilityLabel={`${item.author} ${title}`}
+          testID={`hf-model-item-${item.source || 'huggingface'}-${item.id}`}>
+          <View style={styles.modelRow}>
+            <View style={styles.avatarContainer}>
+              {item.avatarUrl && !avatarFailed ? (
+                <Image
+                  source={{uri: item.avatarUrl}}
+                  style={styles.avatar}
+                  onError={() =>
+                    setFailedAvatars(previous => ({
+                      ...previous,
+                      [item.id]: true,
+                    }))
+                  }
+                />
+              ) : (
+                <Text style={styles.avatarText}>
+                  {(item.author || title).slice(0, 1).toUpperCase()}
+                </Text>
+              )}
+            </View>
+            <View style={styles.modelContent}>
+              <View style={styles.authorRow}>
+                <Text variant="labelMedium" style={styles.modelAuthor}>
+                  {item.author}
+                </Text>
+                <Chip compact mode="outlined" textStyle={styles.sourceChipText}>
+                  {sourceLabel}
+                </Chip>
+              </View>
+              <View style={styles.modelNameContainer}>
+                <Text style={styles.modelName}>{title}</Text>
+              </View>
+              {item.description && (
+                <Text
+                  style={styles.modelDescription}
+                  numberOfLines={2}
+                  ellipsizeMode="tail">
+                  {item.description}
+                </Text>
+              )}
+            </View>
           </View>
           <View style={styles.statsContainer}>
             {isVision && (
@@ -122,6 +189,43 @@ export const SearchView = observer(
                 {formatNumber(item.likes)}
               </Text>
             </View>
+            {fileCount > 0 && (
+              <View style={styles.statItem}>
+                <Icon
+                  name="file-cabinet"
+                  size={12}
+                  color={theme.colors.onSurfaceVariant}
+                />
+                <Text variant="labelSmall" style={styles.statText}>
+                  {fileCount}
+                  {totalSize > 0 ? ` / ${formatBytes(totalSize)}` : ''}
+                </Text>
+              </View>
+            )}
+            {fileCount === 0 && modelSize > 0 && (
+              <View style={styles.statItem}>
+                <Icon
+                  name="harddisk"
+                  size={12}
+                  color={theme.colors.onSurfaceVariant}
+                />
+                <Text variant="labelSmall" style={styles.statText}>
+                  {formatBytes(modelSize)}
+                </Text>
+              </View>
+            )}
+            {params > 0 && (
+              <View style={styles.statItem}>
+                <Icon
+                  name="memory"
+                  size={12}
+                  color={theme.colors.onSurfaceVariant}
+                />
+                <Text variant="labelSmall" style={styles.statText}>
+                  {formatNumber(params, 2, true, true)}
+                </Text>
+              </View>
+            )}
             {Boolean(item.gated) && (
               <Chip compact mode="outlined" textStyle={styles.gatedChipText}>
                 <Icon name="lock" size={12} color={theme.colors.primary} />{' '}
@@ -155,21 +259,27 @@ export const SearchView = observer(
             <Text style={styles.errorText}>{hfStore.error.message}</Text>
             {hfStore.error.code === 'authentication' && (
               <Text style={styles.errorHintText}>
-                {l10n.components.hfTokenSheet.searchErrorHint}
+                {hfStore.error.service === 'huggingface' ||
+                hfStore.error.service === 'hf_mirror'
+                  ? l10n.components.hfTokenSheet.searchErrorHint
+                  : hfStore.error.message}
               </Text>
             )}
-            {hfStore.error.code === 'authentication' && hfStore.useHfToken && (
-              <Button
-                mode="outlined"
-                style={styles.disableTokenButton}
-                onPress={() => {
-                  hfStore.setUseHfToken(false);
-                  hfStore.clearError();
-                  hfStore.fetchModels();
-                }}>
-                {l10n.components.hfTokenSheet.disableAndRetry}
-              </Button>
-            )}
+            {hfStore.error.code === 'authentication' &&
+              hfStore.useHfToken &&
+              (hfStore.error.service === 'huggingface' ||
+                hfStore.error.service === 'hf_mirror') && (
+                <Button
+                  mode="outlined"
+                  style={styles.disableTokenButton}
+                  onPress={() => {
+                    hfStore.setUseHfToken(false);
+                    hfStore.clearError();
+                    hfStore.fetchModels();
+                  }}>
+                  {l10n.components.hfTokenSheet.disableAndRetry}
+                </Button>
+              )}
           </View>
         );
       }
@@ -195,11 +305,15 @@ export const SearchView = observer(
           onFiltersChange={filters => {
             handleFiltersChange(filters);
           }}
+          source={hfStore.selectedSource}
+          onSourceChange={handleSourceChange}
           testID="enhanced-search-bar"
         />
         <BottomSheetFlatList
           data={hfStore.models}
-          keyExtractor={(item: HuggingFaceModel) => item.id}
+          keyExtractor={(item: HuggingFaceModel) =>
+            `${item.source || 'huggingface'}-${item.id}`
+          }
           renderItem={renderItem}
           contentContainerStyle={styles.list}
           renderScrollComponent={props => (

--- a/src/screens/ModelsScreen/HFModelSearch/SearchView/styles.ts
+++ b/src/screens/ModelsScreen/HFModelSearch/SearchView/styles.ts
@@ -14,10 +14,45 @@ export const createStyles = (theme: Theme) =>
     divider: {
       marginVertical: 12,
     },
+    modelRow: {
+      flexDirection: 'row',
+      gap: 12,
+      alignItems: 'flex-start',
+    },
+    avatarContainer: {
+      width: 38,
+      height: 38,
+      borderRadius: 8,
+      backgroundColor: theme.colors.surfaceVariant,
+      alignItems: 'center',
+      justifyContent: 'center',
+      overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: theme.colors.outline,
+    },
+    avatar: {
+      width: 38,
+      height: 38,
+    },
+    avatarText: {
+      fontSize: 16,
+      fontWeight: '600',
+      color: theme.colors.onSurfaceVariant,
+    },
+    modelContent: {
+      flex: 1,
+      minWidth: 0,
+    },
+    authorRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      marginBottom: 2,
+    },
     modelAuthor: {
       fontSize: 14,
       color: theme.colors.onSurfaceVariant,
-      marginBottom: 2,
+      flexShrink: 1,
     },
     modelNameContainer: {
       flexDirection: 'row',
@@ -30,10 +65,18 @@ export const createStyles = (theme: Theme) =>
       fontWeight: '500',
       color: theme.colors.onSurface,
     },
+    modelDescription: {
+      fontSize: 13,
+      lineHeight: 18,
+      color: theme.colors.onSurfaceVariant,
+      marginBottom: 6,
+    },
     statsContainer: {
       flexDirection: 'row',
       alignItems: 'center',
+      flexWrap: 'wrap',
       gap: 12,
+      paddingLeft: 50,
     },
     statItem: {
       flexDirection: 'row',
@@ -57,6 +100,9 @@ export const createStyles = (theme: Theme) =>
       color: theme.colors.onSurfaceVariant,
     },
     gatedChipText: {
+      fontSize: 10,
+    },
+    sourceChipText: {
       fontSize: 10,
     },
     emptyStateContainer: {

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -122,7 +122,10 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
     const isActiveModel = activeModelId === model.id;
     const isDownloaded = model.isDownloaded;
     const isDownloading = modelStore.isDownloading(model.id);
-    const isHfModel = model.origin === ModelOrigin.HF;
+    const isHfModel =
+      model.origin === ModelOrigin.HF ||
+      model.origin === ModelOrigin.HF_MIRROR ||
+      model.origin === ModelOrigin.MODELSCOPE;
     const isRemoteModel = model.origin === ModelOrigin.REMOTE;
 
     // Check projection model status for downloaded vision models
@@ -221,14 +224,15 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
       }
     }, [model, l10n]);
 
-    const openHuggingFaceUrl = useCallback(() => {
-      if (model.hfUrl) {
-        Linking.openURL(model.hfUrl).catch(err => {
+    const openSourceUrl = useCallback(() => {
+      const sourceUrl = model.sourceWebUrl || model.hfUrl;
+      if (sourceUrl) {
+        Linking.openURL(sourceUrl).catch(err => {
           console.error('Failed to open URL:', err);
           setSnackbarVisible(true);
         });
       }
-    }, [model.hfUrl]);
+    }, [model.hfUrl, model.sourceWebUrl]);
 
     const handleRemove = useCallback(() => {
       Alert.alert(
@@ -905,11 +909,11 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                   </TouchableOpacity>
                 )}
 
-                {/* HuggingFace Link */}
-                {model.hfUrl && (
+                {/* Source Link */}
+                {(model.sourceWebUrl || model.hfUrl) && (
                   <TouchableOpacity
                     testID="open-huggingface-url"
-                    onPress={openHuggingFaceUrl}
+                    onPress={openSourceUrl}
                     style={styles.hfLinkButton}
                     activeOpacity={0.7}>
                     <View style={styles.hfLinkContent}>
@@ -919,10 +923,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                         stroke={theme.colors.primary}
                       />
                       <Text style={styles.hfLinkText}>
-                        {
-                          l10n.models.modelCard.labels
-                            .viewModelCardOnHuggingFace
-                        }
+                        {l10n.models.modelCard.labels.viewModelCardOnSource}
                       </Text>
                     </View>
                   </TouchableOpacity>

--- a/src/screens/ModelsScreen/ModelsScreen.tsx
+++ b/src/screens/ModelsScreen/ModelsScreen.tsx
@@ -30,6 +30,7 @@ import {uiStore, modelStore, hfStore, UIStore, serverStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {Model, ModelOrigin} from '../../utils/types';
 import {ErrorState} from '../../utils/errors';
+import {getModelSource} from '../../utils/modelSources';
 
 export const ModelsScreen: React.FC = observer(() => {
   const l10n = useContext(L10nContext);
@@ -288,8 +289,17 @@ export const ModelsScreen: React.FC = observer(() => {
         return 0;
       });
     }
-    if (filters.includes('hf')) {
-      result = result.filter(model => model.origin === ModelOrigin.HF);
+    const selectedSources = ['hf', 'hf_mirror', 'modelscope'].filter(filter =>
+      filters.includes(filter),
+    );
+    if (selectedSources.length > 0) {
+      result = result.filter(model => {
+        const source = getModelSource(model);
+        return (
+          (selectedSources.includes('hf') && source === 'huggingface') ||
+          selectedSources.includes(source)
+        );
+      });
     }
     return result;
   }).get();
@@ -300,6 +310,12 @@ export const ModelsScreen: React.FC = observer(() => {
         return l10n.models.labels.availableToUse;
       case UIStore.GROUP_KEYS.AVAILABLE_TO_DOWNLOAD:
         return l10n.models.labels.availableToDownload;
+      case 'huggingface':
+        return l10n.models.labels.hfModel;
+      case 'hf_mirror':
+        return l10n.models.labels.hfMirrorModel;
+      case 'modelscope':
+        return l10n.models.labels.modelScopeModel;
       default:
         return key;
     }
@@ -318,10 +334,15 @@ export const ModelsScreen: React.FC = observer(() => {
 
     return filteredAndSortedModels.reduce(
       (acc, item) => {
-        const groupKey =
+        const rawGroupKey =
           item.origin === ModelOrigin.LOCAL || item.isLocal
             ? l10n.models.labels.localModel
-            : item.type || l10n.models.labels.unknownGroup;
+            : item.origin === ModelOrigin.HF ||
+                item.origin === ModelOrigin.HF_MIRROR ||
+                item.origin === ModelOrigin.MODELSCOPE
+              ? getModelSource(item)
+              : item.type || l10n.models.labels.unknownGroup;
+        const groupKey = getGroupDisplayName(rawGroupKey);
 
         if (!acc[groupKey]) {
           acc[groupKey] = [];

--- a/src/services/downloads/DownloadManager.ts
+++ b/src/services/downloads/DownloadManager.ts
@@ -13,6 +13,7 @@ import {Model} from '../../utils/types';
 import {formatBytes, hasEnoughSpace} from '../../utils';
 import {uiStore} from '../../store';
 import NativeDownloadModule from '../../specs/NativeDownloadModule';
+import {expandSplitModelFile} from '../../utils/hf';
 import type {
   DownloadConfig,
   DownloadResponse,
@@ -38,10 +39,29 @@ function getDownloadHeaders(
   return headers;
 }
 
+function getSplitStorageRoot(destinationPath: string, entryRFilename: string) {
+  const fallbackDir = destinationPath.substring(
+    0,
+    destinationPath.lastIndexOf('/'),
+  );
+  if (!entryRFilename.includes('/')) {
+    return fallbackDir;
+  }
+
+  const entrySuffix = `/${entryRFilename}`;
+  return destinationPath.endsWith(entrySuffix)
+    ? destinationPath.slice(0, -entrySuffix.length)
+    : fallbackDir;
+}
+
 export class DownloadManager {
   private downloadJobs: DownloadMap;
   private callbacks: DownloadEventCallbacks = {};
   private eventEmitter: NativeEventEmitter | null = null;
+  private androidSplitWaiters = new Map<
+    string,
+    {resolve: () => void; reject: (error: Error) => void}
+  >();
 
   constructor() {
     console.log(`${TAG}: Initializing DownloadManager`);
@@ -97,10 +117,18 @@ export class DownloadManager {
             ? `${etaMinutes} ${l10nData.common.minutes}`
             : `${Math.ceil(etaSeconds)} ${l10nData.common.seconds}`;
 
+        const aggregateBase = job.aggregateBytesWritten || 0;
+        const aggregateTotal = job.aggregateBytesTotal || event.totalBytes;
+        const aggregateWritten = aggregateBase + event.bytesWritten;
+        const aggregateProgress =
+          aggregateTotal > 0
+            ? (aggregateWritten / aggregateTotal) * 100
+            : event.progress;
+
         const progress: DownloadProgress = {
-          bytesDownloaded: event.bytesWritten,
-          bytesTotal: event.totalBytes,
-          progress: event.progress,
+          bytesDownloaded: aggregateWritten,
+          bytesTotal: aggregateTotal,
+          progress: aggregateProgress,
           speed: `${formatBytes(event.bytesWritten)} (${speedMBps} MB/s)`,
           eta: etaText,
           rawSpeed: speedBps,
@@ -122,6 +150,13 @@ export class DownloadManager {
 
       this.eventEmitter.addListener('onDownloadComplete', event => {
         console.log(`${TAG}: Download completed for ID: ${event.downloadId}`);
+        const waiter = this.androidSplitWaiters.get(event.downloadId);
+        if (waiter) {
+          this.androidSplitWaiters.delete(event.downloadId);
+          waiter.resolve();
+          return;
+        }
+
         // Find the job by download ID
         const job = Array.from(this.downloadJobs.values()).find(
           _job => _job.downloadId === event.downloadId,
@@ -155,6 +190,13 @@ export class DownloadManager {
           `${TAG}: (js) Download failed for ID: ${event.downloadId}`,
           event.error,
         );
+        const waiter = this.androidSplitWaiters.get(event.downloadId);
+        if (waiter) {
+          this.androidSplitWaiters.delete(event.downloadId);
+          waiter.reject(new Error(event.error));
+          return;
+        }
+
         // Find the job by download ID
         const job = Array.from(this.downloadJobs.values()).find(
           _job => _job.downloadId === event.downloadId,
@@ -261,6 +303,11 @@ export class DownloadManager {
     } catch (err) {
       console.error(`${TAG}: Failed to create directory:`, err);
       throw err;
+    }
+
+    if (model.splitDownload) {
+      await this.startSplitDownload(model, destinationPath, authToken);
+      return;
     }
 
     if (Platform.OS === 'ios') {
@@ -401,6 +448,346 @@ export class DownloadManager {
     }
   }
 
+  private async startSplitDownload(
+    model: Model,
+    destinationPath: string,
+    authToken?: string | null,
+  ): Promise<void> {
+    const split = model.splitDownload;
+    if (!split || !model.hfModelFile) {
+      throw new Error('Model split metadata is missing');
+    }
+
+    const parts = expandSplitModelFile(model.hfModelFile);
+    if (parts.length !== split.totalParts) {
+      throw new Error('Model split file list is incomplete');
+    }
+
+    const dirPath = getSplitStorageRoot(destinationPath, split.entryRFilename);
+    const tempDir = `${dirPath}/.partial-${encodeURIComponent(model.filename)}`;
+    const totalBytes =
+      split.totalSize ||
+      parts.reduce((sum, part) => sum + (part.size || part.lfs?.size || 0), 0);
+    let completedBytes = 0;
+
+    const downloadJob: DownloadJob = {
+      model,
+      state: {
+        isDownloading: true,
+        progress: null,
+        error: null,
+      },
+      destination: destinationPath,
+      lastBytesWritten: 0,
+      lastUpdateTime: Date.now(),
+      tempPaths: [],
+      aggregateBytesWritten: 0,
+      aggregateBytesTotal: totalBytes,
+    };
+
+    this.downloadJobs.set(model.id, downloadJob);
+    this.callbacks.onStart?.(model.id);
+
+    try {
+      await RNFS.mkdir(tempDir);
+
+      for (const part of parts) {
+        if (downloadJob.cancelRequested) {
+          throw new Error('Download cancelled');
+        }
+        if (!part.url) {
+          throw new Error(`Split file has no download URL: ${part.rfilename}`);
+        }
+
+        const partPath = `${tempDir}/${part.rfilename.replace(/[\\/]/g, '__')}`;
+        downloadJob.tempPaths!.push(partPath);
+        downloadJob.lastBytesWritten = 0;
+        downloadJob.lastUpdateTime = Date.now();
+        downloadJob.aggregateBytesWritten = completedBytes;
+
+        await this.downloadSplitPart(
+          model,
+          part.url,
+          partPath,
+          part.size || part.lfs?.size || 0,
+          downloadJob,
+          authToken,
+        );
+
+        const stat = await RNFS.stat(partPath);
+        completedBytes += Number(stat.size || part.size || 0);
+      }
+
+      await this.moveSplitPartsIntoPlace(
+        model,
+        tempDir,
+        dirPath,
+        destinationPath,
+        parts.map(part => part.rfilename),
+      );
+
+      if (downloadJob.cancelRequested) {
+        throw new Error('Download cancelled');
+      }
+
+      downloadJob.state.isDownloading = false;
+      downloadJob.state.progress = {
+        bytesDownloaded: totalBytes,
+        bytesTotal: totalBytes,
+        progress: 100,
+        speed: '0 B/s',
+        eta: '0 sec',
+        rawSpeed: 0,
+        rawEta: 0,
+      };
+      this.callbacks.onComplete?.(model.id);
+      this.downloadJobs.delete(model.id);
+    } catch (error) {
+      downloadJob.state.error =
+        error instanceof Error ? error : new Error(String(error));
+      downloadJob.state.isDownloading = false;
+      await this.cleanupSplitTempFiles(downloadJob);
+      this.downloadJobs.delete(model.id);
+      this.callbacks.onError?.(model.id, downloadJob.state.error);
+      throw error;
+    }
+  }
+
+  private async downloadSplitPart(
+    model: Model,
+    url: string,
+    destinationPath: string,
+    expectedBytes: number,
+    downloadJob: DownloadJob,
+    authToken?: string | null,
+  ): Promise<void> {
+    if (Platform.OS === 'ios') {
+      await this.downloadSplitPartIOS(
+        model,
+        url,
+        destinationPath,
+        expectedBytes,
+        downloadJob,
+        authToken,
+      );
+      return;
+    }
+
+    await this.downloadSplitPartAndroid(
+      model,
+      url,
+      destinationPath,
+      expectedBytes,
+      downloadJob,
+      authToken,
+    );
+  }
+
+  private async downloadSplitPartIOS(
+    model: Model,
+    url: string,
+    destinationPath: string,
+    expectedBytes: number,
+    downloadJob: DownloadJob,
+    authToken?: string | null,
+  ): Promise<void> {
+    const downloadResult = RNFS.downloadFile({
+      fromUrl: url,
+      toFile: destinationPath,
+      background: uiStore.iOSBackgroundDownloading,
+      discretionary: false,
+      progressInterval: 800,
+      headers: getDownloadHeaders(model, authToken),
+      begin: res => {
+        const totalBytes =
+          downloadJob.aggregateBytesTotal ||
+          downloadJob.aggregateBytesWritten! + res.contentLength;
+        const progress: DownloadProgress = {
+          bytesDownloaded: downloadJob.aggregateBytesWritten || 0,
+          bytesTotal: totalBytes,
+          progress:
+            totalBytes > 0
+              ? ((downloadJob.aggregateBytesWritten || 0) / totalBytes) * 100
+              : 0,
+          speed: '0 B/s',
+          eta: uiStore.l10n.common.calculating,
+          rawSpeed: 0,
+          rawEta: 0,
+        };
+
+        downloadJob.state.progress = progress;
+        this.callbacks.onProgress?.(model.id, progress);
+      },
+      progress: res => {
+        if (!this.downloadJobs.has(model.id) || downloadJob.cancelRequested) {
+          return;
+        }
+
+        const currentTime = Date.now();
+        const timeDiff = (currentTime - downloadJob.lastUpdateTime) / 1000 || 1;
+        const bytesDiff = res.bytesWritten - downloadJob.lastBytesWritten;
+        const speedBps = bytesDiff / timeDiff;
+        const speedMBps = (speedBps / (1024 * 1024)).toFixed(2);
+        const totalBytes =
+          downloadJob.aggregateBytesTotal ||
+          (downloadJob.aggregateBytesWritten || 0) + expectedBytes;
+        const aggregateWritten =
+          (downloadJob.aggregateBytesWritten || 0) + res.bytesWritten;
+        const remainingBytes = totalBytes - aggregateWritten;
+        const etaSeconds = speedBps > 0 ? remainingBytes / speedBps : 0;
+        const etaMinutes = Math.ceil(etaSeconds / 60);
+        const l10nData = uiStore.l10n;
+        const etaText =
+          etaSeconds >= 60
+            ? `${etaMinutes} ${l10nData.common.minutes}`
+            : `${Math.ceil(etaSeconds)} ${l10nData.common.seconds}`;
+
+        const progress: DownloadProgress = {
+          bytesDownloaded: aggregateWritten,
+          bytesTotal: totalBytes,
+          progress: totalBytes > 0 ? (aggregateWritten / totalBytes) * 100 : 0,
+          speed: `${formatBytes(res.bytesWritten)} (${speedMBps} MB/s)`,
+          eta: etaText,
+          rawSpeed: speedBps,
+          rawEta: etaSeconds,
+        };
+
+        downloadJob.state.progress = progress;
+        downloadJob.lastBytesWritten = res.bytesWritten;
+        downloadJob.lastUpdateTime = currentTime;
+        this.callbacks.onProgress?.(model.id, progress);
+      },
+    });
+
+    downloadJob.jobId = downloadResult.jobId;
+    downloadJob.activeJobId = downloadResult.jobId;
+    let result;
+    try {
+      result = await downloadResult.promise;
+    } finally {
+      downloadJob.activeJobId = undefined;
+    }
+
+    if (downloadJob.cancelRequested) {
+      throw new Error('Download cancelled');
+    }
+    if (result.statusCode !== 200) {
+      throw new Error(`Download failed with status: ${result.statusCode}`);
+    }
+  }
+
+  private async downloadSplitPartAndroid(
+    model: Model,
+    url: string,
+    destinationPath: string,
+    _expectedBytes: number,
+    downloadJob: DownloadJob,
+    authToken?: string | null,
+  ): Promise<void> {
+    const config: DownloadConfig = {
+      destination: destinationPath,
+      networkType: 'ANY',
+      priority: 1,
+      progressInterval: 1000,
+      headers: getDownloadHeaders(model, authToken),
+      ...(authToken ? {authToken} : {}),
+    };
+    const response: DownloadResponse = await NativeDownloadModule.startDownload(
+      url,
+      config,
+    );
+    downloadJob.downloadId = response.downloadId;
+    downloadJob.activeDownloadId = response.downloadId;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        this.androidSplitWaiters.set(response.downloadId, {
+          resolve,
+          reject,
+        });
+      });
+    } finally {
+      this.androidSplitWaiters.delete(response.downloadId);
+      downloadJob.activeDownloadId = undefined;
+    }
+  }
+
+  private async moveSplitPartsIntoPlace(
+    model: Model,
+    tempDir: string,
+    dirPath: string,
+    destinationPath: string,
+    rfilenames: string[],
+  ) {
+    for (const rfilename of rfilenames) {
+      const tempPath = `${tempDir}/${rfilename.replace(/[\\/]/g, '__')}`;
+      const finalPath = `${dirPath}/${rfilename}`;
+      const slashIndex = finalPath.lastIndexOf('/');
+      if (slashIndex > 0) {
+        const finalDir = finalPath.substring(0, slashIndex);
+        await RNFS.mkdir(finalDir);
+      }
+
+      const exists = await RNFS.exists(finalPath);
+      if (exists) {
+        await RNFS.unlink(finalPath);
+      }
+      await RNFS.moveFile(tempPath, finalPath);
+    }
+
+    const entryExists = await RNFS.exists(destinationPath);
+    if (!entryExists) {
+      throw new Error(`Split entry file was not downloaded for ${model.id}`);
+    }
+  }
+
+  private async cleanupSplitTempFiles(job: DownloadJob) {
+    for (const path of job.tempPaths || []) {
+      try {
+        if (await RNFS.exists(path)) {
+          await RNFS.unlink(path);
+        }
+      } catch (error) {
+        console.warn(`${TAG}: Failed to clean up split temp file`, {
+          path,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    try {
+      const exists = await RNFS.exists(job.destination);
+      if (exists) {
+        await RNFS.unlink(job.destination);
+      }
+    } catch (error) {
+      console.warn(`${TAG}: Failed to clean up split entry file`, {
+        path: job.destination,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    if (job.model.splitDownload && job.model.hfModelFile) {
+      const dirPath = getSplitStorageRoot(
+        job.destination,
+        job.model.splitDownload.entryRFilename,
+      );
+      for (const part of expandSplitModelFile(job.model.hfModelFile)) {
+        const finalPath = `${dirPath}/${part.rfilename}`;
+        try {
+          if (await RNFS.exists(finalPath)) {
+            await RNFS.unlink(finalPath);
+          }
+        } catch (error) {
+          console.warn(`${TAG}: Failed to clean up split final file`, {
+            path: finalPath,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+  }
+
   private async startAndroidDownload(
     model: Model,
     destinationPath: string,
@@ -469,20 +856,27 @@ export class DownloadManager {
     const job = this.downloadJobs.get(modelId);
     if (job) {
       try {
+        job.cancelRequested = true;
         if (Platform.OS === 'ios') {
           console.log(
             `${TAG}: Cancelling iOS download for ID: ${modelId}, jobId: ${job.jobId}`,
           );
-          if (job.jobId) {
-            RNFS.stopDownload(job.jobId); // job.jobId is now correctly typed as number
+          if (job.activeJobId || job.jobId) {
+            RNFS.stopDownload(job.activeJobId || job.jobId!);
           }
         } else if (
           Platform.OS === 'android' &&
           NativeDownloadModule &&
-          job.downloadId
+          (job.activeDownloadId || job.downloadId)
         ) {
           console.log(`${TAG}: Cancelling Android download:`, modelId);
-          await NativeDownloadModule.cancelDownload(job.downloadId);
+          const activeDownloadId = job.activeDownloadId || job.downloadId!;
+          const waiter = this.androidSplitWaiters.get(activeDownloadId);
+          if (waiter) {
+            this.androidSplitWaiters.delete(activeDownloadId);
+            waiter.reject(new Error('Download cancelled'));
+          }
+          await NativeDownloadModule.cancelDownload(activeDownloadId);
         }
 
         // Clean up the partial download file
@@ -512,6 +906,10 @@ export class DownloadManager {
               });
             }
           }
+        }
+
+        if (job.model.splitDownload) {
+          await this.cleanupSplitTempFiles(job);
         }
 
         // Update state and remove job

--- a/src/services/downloads/DownloadManager.ts
+++ b/src/services/downloads/DownloadManager.ts
@@ -19,6 +19,24 @@ import type {
 } from '../../specs/NativeDownloadModule';
 
 const TAG = 'DownloadManager';
+const MODELSCOPE_DOMAIN = 'https://modelscope.cn';
+
+function getDownloadHeaders(
+  model: Model,
+  authToken?: string | null,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  if (authToken) {
+    headers.Authorization = `Bearer ${authToken}`;
+  }
+
+  if (model.source === 'modelscope') {
+    headers.Referer = `${MODELSCOPE_DOMAIN}/`;
+  }
+
+  return headers;
+}
 
 export class DownloadManager {
   private downloadJobs: DownloadMap;
@@ -280,9 +298,7 @@ export class DownloadManager {
         background: uiStore.iOSBackgroundDownloading,
         discretionary: false,
         progressInterval: 800,
-        headers: {
-          ...(authToken ? {Authorization: `Bearer ${authToken}`} : {}),
-        },
+        headers: getDownloadHeaders(model, authToken),
         begin: res => {
           console.log(`${TAG}: Download started for ID: ${model.id}`, {
             statusCode: res.statusCode,
@@ -414,6 +430,7 @@ export class DownloadManager {
         networkType: 'ANY',
         priority: 1,
         progressInterval: 1000,
+        headers: getDownloadHeaders(model, authToken),
         ...(authToken ? {authToken} : {}),
       };
       const response: DownloadResponse =

--- a/src/services/downloads/__tests__/DownloadManager.test.ts
+++ b/src/services/downloads/__tests__/DownloadManager.test.ts
@@ -107,6 +107,34 @@ describe('DownloadManager', () => {
     expect(downloadManager.isDownloading('model-1')).toBe(true);
   });
 
+  it('passes source-specific headers to Android downloads', async () => {
+    NativeModules.DownloadModule.startDownload.mockResolvedValue({
+      downloadId: 'download123',
+    });
+    const modelScopeModel = {
+      ...basicModel,
+      id: 'modelscope:owner/repo/model.gguf',
+      source: 'modelscope',
+    };
+
+    await downloadManager.startDownload(
+      modelScopeModel as any,
+      '/path/to/model.bin',
+      'token-123',
+    );
+
+    expect(NativeModules.DownloadModule.startDownload).toHaveBeenCalledWith(
+      modelScopeModel.downloadUrl,
+      expect.objectContaining({
+        authToken: 'token-123',
+        headers: {
+          Authorization: 'Bearer token-123',
+          Referer: 'https://modelscope.cn/',
+        },
+      }),
+    );
+  });
+
   it('starts a download on iOS', async () => {
     (Platform as any).OS = 'ios';
 
@@ -138,6 +166,36 @@ describe('DownloadManager', () => {
 
     expect(callbacks.onComplete).toHaveBeenCalledWith('model-1');
     expect(downloadManager.isDownloading('model-1')).toBe(false);
+  });
+
+  it('passes source-specific headers to iOS downloads', async () => {
+    (Platform as any).OS = 'ios';
+    const modelScopeModel = {
+      ...basicModel,
+      id: 'modelscope:owner/repo/model.gguf',
+      source: 'modelscope',
+    };
+    const mockDownloadResult = {
+      jobId: 123,
+      promise: Promise.resolve({statusCode: 200}),
+    };
+
+    (RNFS.downloadFile as jest.Mock).mockReturnValue(mockDownloadResult);
+
+    await downloadManager.startDownload(
+      modelScopeModel as any,
+      '/path/to/model.bin',
+      'token-123',
+    );
+
+    expect(RNFS.downloadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer token-123',
+          Referer: 'https://modelscope.cn/',
+        },
+      }),
+    );
   });
 
   it('cancels a download', async () => {

--- a/src/services/downloads/__tests__/DownloadManager.test.ts
+++ b/src/services/downloads/__tests__/DownloadManager.test.ts
@@ -1,6 +1,7 @@
 import {NativeModules, Platform, NativeEventEmitter} from 'react-native';
 
 import * as RNFS from '@dr.pogodin/react-native-fs';
+import {waitFor} from '@testing-library/react-native';
 
 import {basicModel} from '../../../../jest/fixtures/models';
 
@@ -410,5 +411,137 @@ describe('DownloadManager', () => {
     );
 
     expect(iosDownloadManager.isDownloading('model-1')).toBe(false);
+  });
+
+  it('downloads all GGUF split parts on Android before completing the model', async () => {
+    const splitModel = {
+      ...basicModel,
+      id: 'owner/repo/Q2_K/model.gguf-00001-of-00002.gguf',
+      filename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+      size: 300,
+      hfModelFile: {
+        rfilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+        size: 300,
+        split: {
+          entryRFilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+          displayRFilename: 'Q2_K/model.gguf',
+          totalSize: 300,
+          totalParts: 2,
+          parts: [
+            {
+              rfilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+              index: 1,
+              total: 2,
+              size: 100,
+              url: 'https://example.com/Q2_K/model.gguf-00001-of-00002.gguf',
+            },
+            {
+              rfilename: 'Q2_K/model.gguf-00002-of-00002.gguf',
+              index: 2,
+              total: 2,
+              size: 200,
+              url: 'https://example.com/Q2_K/model.gguf-00002-of-00002.gguf',
+            },
+          ],
+        },
+      },
+      splitDownload: {
+        entryRFilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+        displayRFilename: 'Q2_K/model.gguf',
+        totalSize: 300,
+        totalParts: 2,
+        parts: [
+          {
+            rfilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+            index: 1,
+            total: 2,
+            size: 100,
+            url: 'https://example.com/Q2_K/model.gguf-00001-of-00002.gguf',
+          },
+          {
+            rfilename: 'Q2_K/model.gguf-00002-of-00002.gguf',
+            index: 2,
+            total: 2,
+            size: 200,
+            url: 'https://example.com/Q2_K/model.gguf-00002-of-00002.gguf',
+          },
+        ],
+      },
+    };
+    NativeModules.DownloadModule.startDownload
+      .mockResolvedValueOnce({downloadId: 'split-1'})
+      .mockResolvedValueOnce({downloadId: 'split-2'});
+    (RNFS.stat as jest.Mock)
+      .mockResolvedValueOnce({size: 100})
+      .mockResolvedValueOnce({size: 200});
+    const movedFiles = new Set<string>();
+    (RNFS.moveFile as jest.Mock).mockImplementation(
+      (_from: string, to: string) => {
+        movedFiles.add(to);
+        return Promise.resolve();
+      },
+    );
+    (RNFS.exists as jest.Mock).mockImplementation((path: string) =>
+      Promise.resolve(movedFiles.has(path)),
+    );
+
+    const callbacks = {
+      onStart: jest.fn(),
+      onProgress: jest.fn(),
+      onComplete: jest.fn(),
+      onError: jest.fn(),
+    };
+    downloadManager.setCallbacks(callbacks);
+
+    const completeListener = mockEventEmitter.addListener.mock.calls.find(
+      call => call[0] === 'onDownloadComplete',
+    )[1];
+
+    const promise = downloadManager.startDownload(
+      splitModel as any,
+      '/models/owner/repo/Q2_K/model.gguf-00001-of-00002.gguf',
+    );
+
+    await waitFor(() =>
+      expect(NativeModules.DownloadModule.startDownload).toHaveBeenCalledTimes(
+        1,
+      ),
+    );
+    completeListener({downloadId: 'split-1'});
+    await waitFor(() =>
+      expect(NativeModules.DownloadModule.startDownload).toHaveBeenCalledTimes(
+        2,
+      ),
+    );
+    completeListener({downloadId: 'split-2'});
+    await promise;
+
+    expect(NativeModules.DownloadModule.startDownload).toHaveBeenCalledTimes(2);
+    expect(NativeModules.DownloadModule.startDownload).toHaveBeenNthCalledWith(
+      1,
+      'https://example.com/Q2_K/model.gguf-00001-of-00002.gguf',
+      expect.objectContaining({
+        destination:
+          '/models/owner/repo/.partial-Q2_K%2Fmodel.gguf-00001-of-00002.gguf/Q2_K__model.gguf-00001-of-00002.gguf',
+      }),
+    );
+    expect(NativeModules.DownloadModule.startDownload).toHaveBeenNthCalledWith(
+      2,
+      'https://example.com/Q2_K/model.gguf-00002-of-00002.gguf',
+      expect.objectContaining({
+        destination:
+          '/models/owner/repo/.partial-Q2_K%2Fmodel.gguf-00001-of-00002.gguf/Q2_K__model.gguf-00002-of-00002.gguf',
+      }),
+    );
+    expect(RNFS.moveFile).toHaveBeenCalledWith(
+      '/models/owner/repo/.partial-Q2_K%2Fmodel.gguf-00001-of-00002.gguf/Q2_K__model.gguf-00001-of-00002.gguf',
+      '/models/owner/repo/Q2_K/model.gguf-00001-of-00002.gguf',
+    );
+    expect(RNFS.moveFile).toHaveBeenCalledWith(
+      '/models/owner/repo/.partial-Q2_K%2Fmodel.gguf-00001-of-00002.gguf/Q2_K__model.gguf-00002-of-00002.gguf',
+      '/models/owner/repo/Q2_K/model.gguf-00002-of-00002.gguf',
+    );
+    expect(callbacks.onComplete).toHaveBeenCalledWith(splitModel.id);
+    expect(downloadManager.isDownloading(splitModel.id)).toBe(false);
   });
 });

--- a/src/services/downloads/types.ts
+++ b/src/services/downloads/types.ts
@@ -28,6 +28,12 @@ export interface DownloadJob {
   destination: string;
   lastBytesWritten: number;
   lastUpdateTime: number;
+  cancelRequested?: boolean;
+  tempPaths?: string[];
+  activeJobId?: number;
+  activeDownloadId?: string;
+  aggregateBytesWritten?: number;
+  aggregateBytesTotal?: number;
 }
 
 export type DownloadMap = Map<string, DownloadJob>;

--- a/src/specs/NativeDownloadModule.ts
+++ b/src/specs/NativeDownloadModule.ts
@@ -4,6 +4,7 @@ import {Platform, TurboModuleRegistry} from 'react-native';
 export interface DownloadConfig {
   destination: string;
   authToken?: string;
+  headers?: {[key: string]: string};
   networkType?: 'WIFI' | 'ANY';
   progressInterval?: number;
   priority?: number;

--- a/src/store/HFStore.ts
+++ b/src/store/HFStore.ts
@@ -3,13 +3,16 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {makePersistable} from 'mobx-persist-store';
 import * as Keychain from 'react-native-keychain';
 
-import {fetchGGUFSpecs, fetchModelFilesDetails, fetchModels} from '../api/hf';
+import {
+  fetchGGUFSpecsFromSource,
+  fetchModelFilesDetailsFromSource,
+  fetchModelsFromSource,
+} from '../api/modelSources';
 
 import {hasEnoughSpace, hfAsModel} from '../utils';
-import {processHFSearchResults} from '../utils/hf';
 import {ErrorState, createErrorState} from '../utils/errors';
 
-import {HuggingFaceModel} from '../utils/types';
+import {HuggingFaceModel, ModelSourceId} from '../utils/types';
 
 // Service name for keychain storage
 const HF_TOKEN_SERVICE = 'hf_token_service';
@@ -30,12 +33,20 @@ class HFStore {
   private lastFetchedNextLink: string | null = null;
   private lastFetchMoreAttempt: number = 0;
   private consecutiveSmallResults: number = 0;
+  private searchRequestId = 0;
+  private fetchMoreRequestId = 0;
+  private activeSearchRequestId = 0;
+  private activeFetchMoreRequestId = 0;
+  private modelDetailsRequestId = 0;
+  modelDetailsLoading = false;
+  private activeModelDetailsId: string | null = null;
   searchQuery = '';
   queryFilter = 'gguf,conversational';
   queryFull = true;
   queryConfig = true;
   hfToken: string | null = null;
   useHfToken: boolean = true; // Only applies when token is set
+  selectedSource: ModelSourceId = 'huggingface';
 
   // search filters
   searchFilters: SearchFilters = {
@@ -48,7 +59,7 @@ class HFStore {
 
     makePersistable(this, {
       name: 'HFStore',
-      properties: ['useHfToken'],
+      properties: ['useHfToken', 'selectedSource'],
       storage: AsyncStorage,
     });
 
@@ -79,6 +90,27 @@ class HFStore {
 
   get shouldUseToken(): boolean {
     return this.isTokenPresent && this.useHfToken;
+  }
+
+  get shouldUseTokenForSelectedSource(): boolean {
+    return this.shouldUseTokenForSource(this.selectedSource);
+  }
+
+  setSelectedSource(source: ModelSourceId) {
+    runInAction(() => {
+      this.selectedSource = source;
+      this.models = [];
+      this.nextPageLink = null;
+      this.error = null;
+      this.lastFetchedNextLink = null;
+      this.consecutiveSmallResults = 0;
+      this.lastFetchMoreAttempt = 0;
+      this.searchRequestId++;
+      this.fetchMoreRequestId++;
+      this.isLoading = false;
+      this.activeModelDetailsId = null;
+      this.modelDetailsLoading = false;
+    });
   }
 
   setUseHfToken(useToken: boolean) {
@@ -159,12 +191,60 @@ class HFStore {
     this.error = null;
   }
 
+  private isCurrentSearchRequest(
+    requestId: number,
+    source: ModelSourceId,
+    searchQuery: string,
+    filters: SearchFilters,
+  ) {
+    return (
+      requestId === this.searchRequestId &&
+      source === this.selectedSource &&
+      searchQuery === this.searchQuery &&
+      filters.author === this.searchFilters.author &&
+      filters.sortBy === this.searchFilters.sortBy
+    );
+  }
+
+  private isCurrentFetchMoreRequest(
+    requestId: number,
+    source: ModelSourceId,
+    nextPageLink: string,
+  ) {
+    return (
+      requestId === this.fetchMoreRequestId &&
+      source === this.selectedSource &&
+      nextPageLink === this.lastFetchedNextLink
+    );
+  }
+
+  private isCurrentModelDetailsRequest(
+    requestId?: number,
+    modelId?: string,
+  ) {
+    return (
+      requestId === undefined ||
+      (requestId === this.modelDetailsRequestId &&
+        (!modelId || modelId === this.activeModelDetailsId))
+    );
+  }
+
   // Fetch the GGUF specs for a specific model,
   // such as number of parameters, context length, chat template, etc.
-  async fetchAndSetGGUFSpecs(modelId: string) {
+  async fetchAndSetGGUFSpecs(modelId: string, requestId?: number) {
     try {
-      const authToken = this.shouldUseToken ? this.hfToken : null;
-      const specs = await fetchGGUFSpecs(modelId, authToken);
+      const source = this.getSourceForModelId(modelId);
+      const authToken = this.shouldUseTokenForSource(source)
+        ? this.hfToken
+        : null;
+      const specs = await fetchGGUFSpecsFromSource({
+        source,
+        modelId,
+        authToken,
+      });
+      if (!this.isCurrentModelDetailsRequest(requestId, modelId)) {
+        return;
+      }
       const model = this.models.find(m => m.id === modelId);
       if (model) {
         runInAction(() => {
@@ -172,9 +252,16 @@ class HFStore {
         });
       }
     } catch (error) {
+      if (!this.isCurrentModelDetailsRequest(requestId, modelId)) {
+        return;
+      }
       console.error('Failed to fetch GGUF specs:', error);
       runInAction(() => {
-        this.error = createErrorState(error, 'modelDetails', 'huggingface');
+        this.error = createErrorState(
+          error,
+          'modelDetails',
+          this.getSourceForModelId(modelId),
+        );
       });
     }
   }
@@ -208,11 +295,21 @@ class HFStore {
   }
 
   // Fetch the details (sizes, oid, lfs, ...) of the model files
-  async fetchModelFileDetails(modelId: string) {
+  async fetchModelFileDetails(modelId: string, requestId?: number) {
     try {
       console.log('Fetching model file details for', modelId);
-      const authToken = this.shouldUseToken ? this.hfToken : null;
-      const fileDetails = await fetchModelFilesDetails(modelId, authToken);
+      const source = this.getSourceForModelId(modelId);
+      const authToken = this.shouldUseTokenForSource(source)
+        ? this.hfToken
+        : null;
+      const fileDetails = await fetchModelFilesDetailsFromSource({
+        source,
+        modelId,
+        authToken,
+      });
+      if (!this.isCurrentModelDetailsRequest(requestId, modelId)) {
+        return;
+      }
       const model = this.models.find(m => m.id === modelId);
 
       if (!model) {
@@ -228,9 +325,16 @@ class HFStore {
         model.siblings = updatedSiblings;
       });
     } catch (error) {
+      if (!this.isCurrentModelDetailsRequest(requestId, modelId)) {
+        return;
+      }
       console.error('Error fetching model file sizes:', error);
       runInAction(() => {
-        this.error = createErrorState(error, 'modelDetails', 'huggingface');
+        this.error = createErrorState(
+          error,
+          'modelDetails',
+          this.getSourceForModelId(modelId),
+        );
       });
     }
   }
@@ -240,15 +344,46 @@ class HFStore {
   }
 
   async fetchModelData(modelId: string) {
+    const requestId = ++this.modelDetailsRequestId;
+    runInAction(() => {
+      this.modelDetailsLoading = true;
+      this.activeModelDetailsId = modelId;
+      this.error = null;
+    });
+
     try {
-      await this.fetchAndSetGGUFSpecs(modelId);
-      await this.fetchModelFileDetails(modelId);
+      await this.fetchAndSetGGUFSpecs(modelId, requestId);
+      await this.fetchModelFileDetails(modelId, requestId);
     } catch (error) {
+      if (!this.isCurrentModelDetailsRequest(requestId, modelId)) {
+        return;
+      }
       console.error('Error fetching model data:', error);
       runInAction(() => {
-        this.error = createErrorState(error, 'modelDetails', 'huggingface');
+        this.error = createErrorState(
+          error,
+          'modelDetails',
+          this.getSourceForModelId(modelId),
+        );
       });
+    } finally {
+      if (this.isCurrentModelDetailsRequest(requestId, modelId)) {
+        runInAction(() => {
+          this.modelDetailsLoading = false;
+        });
+      }
     }
+  }
+
+  private shouldUseTokenForSource(source: ModelSourceId): boolean {
+    return this.shouldUseToken;
+  }
+
+  private getSourceForModelId(modelId: string): ModelSourceId {
+    return (
+      this.models.find(model => model.id === modelId)?.source ||
+      this.selectedSource
+    );
   }
 
   get hasMoreResults() {
@@ -299,6 +434,17 @@ class HFStore {
 
   // Fetch the models from the Hugging Face API
   async fetchModels() {
+    const requestId = ++this.searchRequestId;
+    const source = this.selectedSource;
+    const searchQuery = this.searchQuery;
+    const searchFilters = {...this.searchFilters};
+    const filter = this.buildFilterString();
+    const sortParams = this.getSortParams();
+    const authToken = this.shouldUseTokenForSelectedSource
+      ? this.hfToken
+      : null;
+
+    this.activeSearchRequestId = requestId;
     this.isLoading = true;
     this.error = null;
 
@@ -308,28 +454,46 @@ class HFStore {
     this.lastFetchMoreAttempt = 0;
 
     try {
-      const authToken = this.shouldUseToken ? this.hfToken : null;
-      const sortParams = this.getSortParams();
-
-      const {models, nextLink} = await fetchModels({
-        search: this.searchQuery,
-        author: this.searchFilters.author || undefined,
+      const {models, nextLink} = await fetchModelsFromSource({
+        source,
+        search: searchQuery,
+        author: searchFilters.author || undefined,
         limit: 10,
         sort: sortParams?.sort,
         direction: sortParams?.direction,
-        filter: this.buildFilterString(),
+        filter,
         full: this.queryFull,
         config: this.queryConfig,
         authToken: authToken,
       });
 
-      let processedModels = processHFSearchResults(models);
+      if (
+        !this.isCurrentSearchRequest(
+          requestId,
+          source,
+          searchQuery,
+          searchFilters,
+        )
+      ) {
+        return;
+      }
 
       runInAction(() => {
-        this.models = processedModels;
+        this.models = models;
         this.nextPageLink = nextLink;
       });
     } catch (error) {
+      if (
+        !this.isCurrentSearchRequest(
+          requestId,
+          source,
+          searchQuery,
+          searchFilters,
+        )
+      ) {
+        return;
+      }
+
       runInAction(() => {
         this.isLoading = false;
         this.nextPageLink = null;
@@ -337,12 +501,14 @@ class HFStore {
       });
       // this need to be in a separate runInAction for the ui to render properly.
       runInAction(() => {
-        this.error = createErrorState(error, 'search', 'huggingface');
+        this.error = createErrorState(error, 'search', source);
       });
     } finally {
-      runInAction(() => {
-        this.isLoading = false;
-      });
+      if (requestId === this.activeSearchRequestId) {
+        runInAction(() => {
+          this.isLoading = false;
+        });
+      }
     }
   }
 
@@ -366,42 +532,55 @@ class HFStore {
       );
       return;
     }
-    this.lastFetchedNextLink = this.nextPageLink;
+    const requestId = ++this.fetchMoreRequestId;
+    const source = this.selectedSource;
+    const nextPageLink = this.nextPageLink;
+    this.activeFetchMoreRequestId = requestId;
+    this.lastFetchedNextLink = nextPageLink;
     this.lastFetchMoreAttempt = Date.now();
 
     this.isLoading = true;
     this.error = null;
 
     try {
-      const authToken = this.shouldUseToken ? this.hfToken : null;
-      const {models, nextLink} = await fetchModels({
-        nextPageUrl: this.nextPageLink,
+      const authToken = this.shouldUseTokenForSelectedSource
+        ? this.hfToken
+        : null;
+      const {models, nextLink} = await fetchModelsFromSource({
+        source,
+        nextPageUrl: nextPageLink,
         authToken: authToken,
       });
 
-      let processedModels = processHFSearchResults(models);
+      if (!this.isCurrentFetchMoreRequest(requestId, source, nextPageLink)) {
+        return;
+      }
 
       runInAction(() => {
         // Track consecutive small results for pagination protection
-        if (processedModels.length < 3) {
+        if (models.length < 3) {
           this.consecutiveSmallResults++;
         } else {
           this.consecutiveSmallResults = 0;
         }
 
-        processedModels.forEach((model: HuggingFaceModel) =>
-          this.models.push(model),
-        );
+        models.forEach((model: HuggingFaceModel) => this.models.push(model));
         this.nextPageLink = nextLink;
       });
     } catch (error) {
+      if (!this.isCurrentFetchMoreRequest(requestId, source, nextPageLink)) {
+        return;
+      }
+
       runInAction(() => {
-        this.error = createErrorState(error, 'search', 'huggingface');
+        this.error = createErrorState(error, 'search', source);
       });
     } finally {
-      runInAction(() => {
-        this.isLoading = false;
-      });
+      if (requestId === this.activeFetchMoreRequestId) {
+        runInAction(() => {
+          this.isLoading = false;
+        });
+      }
     }
   }
 }

--- a/src/store/HFStore.ts
+++ b/src/store/HFStore.ts
@@ -9,7 +9,11 @@ import {
   fetchModelsFromSource,
 } from '../api/modelSources';
 
-import {hasEnoughSpace, hfAsModel} from '../utils';
+import {
+  createSiblingsFromFileDetails,
+  hasEnoughSpace,
+  hfAsModel,
+} from '../utils';
 import {ErrorState, createErrorState} from '../utils/errors';
 
 import {HuggingFaceModel, ModelSourceId} from '../utils/types';
@@ -218,10 +222,7 @@ class HFStore {
     );
   }
 
-  private isCurrentModelDetailsRequest(
-    requestId?: number,
-    modelId?: string,
-  ) {
+  private isCurrentModelDetailsRequest(requestId?: number, modelId?: string) {
     return (
       requestId === undefined ||
       (requestId === this.modelDetailsRequestId &&
@@ -284,6 +285,7 @@ class HFStore {
           size: details.size,
           oid: details.oid,
           lfs: details.lfs,
+          split: details.split || file.split,
         };
 
         return {
@@ -313,6 +315,25 @@ class HFStore {
       const model = this.models.find(m => m.id === modelId);
 
       if (!model) {
+        return;
+      }
+
+      if (model.siblings.length === 0 && fileDetails.length > 0) {
+        const source = this.getSourceForModelId(modelId);
+        const updatedSiblings = await Promise.all(
+          createSiblingsFromFileDetails(
+            model.sourceRepoId || model.id,
+            fileDetails,
+          ).map(async file => ({
+            ...file,
+            canFitInStorage: await hasEnoughSpace(hfAsModel(model, file)),
+          })),
+        );
+
+        runInAction(() => {
+          model.source = source;
+          model.siblings = updatedSiblings;
+        });
         return;
       }
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -14,7 +14,7 @@ import {
   toApiCompletionParams,
 } from '../utils/completionTypes';
 
-import {fetchModelFilesDetails} from '../api/hf';
+import {fetchModelFilesDetailsFromSource} from '../api/modelSources';
 import {
   LocalCompletionEngine,
   OpenAICompletionEngine,
@@ -33,6 +33,13 @@ import {
   inferRepoFromModelId,
   parseSizeLabel,
 } from '../utils';
+import {
+  buildSourceModelId,
+  getModelSource,
+  getRepoIdFromModelId,
+  getSourceStorageDir,
+  MODEL_SOURCE_ORIGIN,
+} from '../utils/modelSources';
 import {getRecommendedProjectionModel} from '../utils/multimodalHelpers';
 import {getOriginalModelName} from '../utils/formatters';
 import {defaultModels, MODEL_LIST_VERSION} from './defaultModels';
@@ -56,6 +63,7 @@ import {
 } from '../utils/types';
 
 import {ErrorState, createErrorState} from '../utils/errors';
+import {isLlamaJsiBindingsError} from '../utils/llamaErrors';
 import {chatSessionRepository} from '../repositories/ChatSessionRepository';
 import {hasEnoughMemory} from '../hooks/useMemoryCheck';
 import {
@@ -256,9 +264,14 @@ class ModelStore {
           });
         }
 
-        const errorState = createErrorState(error, 'download', 'huggingface', {
-          modelId,
-        });
+        const errorState = createErrorState(
+          error,
+          'download',
+          getModelSource(model),
+          {
+            modelId,
+          },
+        );
 
         runInAction(() => {
           this.downloadError = errorState;
@@ -618,10 +631,14 @@ class ModelStore {
       }
     });
 
-    // Handle HF and LOCAL models
+    // Handle repository-backed source models and LOCAL models
     mergedModels.forEach(model => {
       if (
-        model.origin === ModelOrigin.HF ||
+        [
+          ModelOrigin.HF,
+          ModelOrigin.HF_MIRROR,
+          ModelOrigin.MODELSCOPE,
+        ].includes(model.origin) ||
         model.origin === ModelOrigin.LOCAL ||
         model.isLocal
       ) {
@@ -630,7 +647,13 @@ class ModelStore {
           const defaultSettings = getLocalModelDefaultSettings();
           model.defaultChatTemplate = {...defaultSettings.chatTemplate};
           model.defaultStopWords = defaultSettings.completionParams.stop;
-        } else if (model.origin === ModelOrigin.HF) {
+        } else if (
+          [
+            ModelOrigin.HF,
+            ModelOrigin.HF_MIRROR,
+            ModelOrigin.MODELSCOPE,
+          ].includes(model.origin)
+        ) {
           const defaultSettings = getHFDefaultSettings(
             model.hfModel as HuggingFaceModel,
           );
@@ -648,8 +671,15 @@ class ModelStore {
           ...(model.defaultStopWords || []),
         ];
 
-        // Infer repo from model.id if missing (for existing HF models)
-        if (model.origin === ModelOrigin.HF && !model.repo) {
+        // Infer repo from model.id if missing (for existing source models)
+        if (
+          [
+            ModelOrigin.HF,
+            ModelOrigin.HF_MIRROR,
+            ModelOrigin.MODELSCOPE,
+          ].includes(model.origin) &&
+          !model.repo
+        ) {
           const inferredRepo = inferRepoFromModelId(model.id);
           if (inferredRepo) {
             model.repo = inferredRepo;
@@ -657,6 +687,21 @@ class ModelStore {
               `[ModelStore] Inferred repo "${inferredRepo}" from model.id: ${model.id}`,
             );
           }
+        }
+
+        if (!model.source) {
+          model.source = getModelSource(model);
+        }
+
+        if (!model.sourceRepoId) {
+          model.sourceRepoId =
+            model.hfModel?.sourceRepoId ||
+            model.hfModel?.id ||
+            getRepoIdFromModelId(model.id);
+        }
+
+        if (!model.sourceWebUrl && model.hfUrl) {
+          model.sourceWebUrl = model.hfUrl;
         }
       }
     });
@@ -801,7 +846,7 @@ class ModelStore {
    * - LOCAL: Uses the model's fullPath property
    * - PRESET: Checks both legacy path (DocumentDirectoryPath/filename) and
    *          new path (DocumentDirectoryPath/models/preset/author/filename)
-   * - HF: Uses DocumentDirectoryPath/models/hf/author/filename
+   * - HF/HF mirror/ModelScope: Uses DocumentDirectoryPath/models/<source>/author/repo/filename
    *
    * IMPORTANT: This logic is duplicated in native Swift code for iOS Shortcuts
    * See: ios/PocketPal/AppIntents/PalDataProvider.swift - parseModelPath() method
@@ -860,9 +905,17 @@ class ModelStore {
       return newPath;
     }
 
-    // For HF models, use author/repo/model structure with backwards compatibility
-    if (model.origin === ModelOrigin.HF) {
+    // For repository-backed source models, use author/repo/model structure.
+    if (
+      [
+        ModelOrigin.HF,
+        ModelOrigin.HF_MIRROR,
+        ModelOrigin.MODELSCOPE,
+      ].includes(model.origin)
+    ) {
       const author = model.author || 'unknown';
+      const source = getModelSource(model);
+      const sourceDir = getSourceStorageDir(source);
 
       // Try to get repo from model, or infer from model.id, or fallback to 'unknown'
       let repo = model.repo;
@@ -870,20 +923,24 @@ class ModelStore {
         repo = inferRepoFromModelId(model.id) || 'unknown';
       }
 
-      // Old path structure (for backwards compatibility)
-      const oldPath = `${RNFS.DocumentDirectoryPath}/models/hf/${author}/${model.filename}`;
+      const oldPath =
+        source === 'huggingface'
+          ? `${RNFS.DocumentDirectoryPath}/models/hf/${author}/${model.filename}`
+          : '';
 
       // New path structure includes repository name
-      const newPath = `${RNFS.DocumentDirectoryPath}/models/hf/${author}/${repo}/${model.filename}`;
+      const newPath = `${RNFS.DocumentDirectoryPath}/models/${sourceDir}/${author}/${repo}/${model.filename}`;
 
-      // Check if file exists at old path (backwards compatibility)
-      // This handles: existing downloads, models after reset, models after app update
-      try {
-        if (await RNFS.exists(oldPath)) {
-          return oldPath;
+      if (oldPath) {
+        // Check if file exists at old path (backwards compatibility)
+        // This handles: existing downloads, models after reset, models after app update
+        try {
+          if (await RNFS.exists(oldPath)) {
+            return oldPath;
+          }
+        } catch (err) {
+          console.log('Error checking old HF model path:', err);
         }
-      } catch (err) {
-        console.log('Error checking old HF model path:', err);
       }
 
       // Otherwise use new path
@@ -898,9 +955,25 @@ class ModelStore {
   async checkFileExists(model: Model) {
     const filePath = await this.getModelFullPath(model);
     const exists = await RNFS.exists(filePath);
+    let sizeMatches = true;
+
+    if (exists && model.size && model.size > 0) {
+      try {
+        const fileStats = await RNFS.stat(filePath);
+        const expectedSize = Number(model.size);
+        const actualSize = Number(fileStats.size);
+        sizeMatches =
+          expectedSize > 0 &&
+          actualSize > 0 &&
+          Math.abs(actualSize - expectedSize) / expectedSize <= 0.001;
+      } catch (err) {
+        console.log('Error checking model file size:', err);
+        sizeMatches = false;
+      }
+    }
 
     // Don't mark as downloaded if currently downloading
-    if (exists && !downloadManager.isDownloading(model.id)) {
+    if (exists && sizeMatches && !downloadManager.isDownloading(model.id)) {
       if (!model.isDownloaded) {
         console.log(
           'checkFileExists: marking as downloaded - this should not happen:',
@@ -1001,6 +1074,8 @@ class ModelStore {
       return;
     }
 
+    const source = getModelSource(model);
+
     try {
       const destinationPath = await this.getModelFullPath(model);
       const authToken = hfStore.shouldUseToken ? hfStore.hfToken : null;
@@ -1012,7 +1087,7 @@ class ModelStore {
       console.error('Failed to start download:', err);
 
       // Create proper error state for the snackbar system
-      const errorState = createErrorState(err, 'download', 'huggingface', {
+      const errorState = createErrorState(err, 'download', source, {
         modelId,
       });
 
@@ -1291,6 +1366,10 @@ class ModelStore {
         }
       });
     } catch (error) {
+      if (isLlamaJsiBindingsError(error)) {
+        return;
+      }
+
       console.warn('[ModelStore] Failed to fetch GGUF metadata:', error);
     }
   };
@@ -1714,16 +1793,22 @@ class ModelStore {
 
       return ctx;
     } catch (error) {
-      console.error(
-        `Failed to initialize model context for "${model.name}" (${model.id}):`,
-        error,
-      );
+      if (isLlamaJsiBindingsError(error)) {
+        console.error(
+          `Failed to initialize model context for "${model.name}" (${model.id}): native llama runtime unavailable`,
+        );
+      } else {
+        console.error(
+          `Failed to initialize model context for "${model.name}" (${model.id}):`,
+          error,
+        );
+      }
 
       // Set error state for UI feedback - include model info and context params for error reporting
       const errorState = createErrorState(error, 'modelInit', undefined, {
         modelId: model.id,
         modelName: model.name,
-        modelUrl: model.hfUrl,
+        modelUrl: model.sourceWebUrl || model.hfUrl,
         modelSize: model.size,
         contextParams: effectiveSettings,
       });
@@ -2017,9 +2102,12 @@ class ModelStore {
       if (newModel.supportsMultimodal && options?.projectionModelId) {
         // Validate that selected projection model exists in repository
         const mmprojFiles = getMmprojFiles(hfModel.siblings || []);
+        const source = hfModel.source || 'huggingface';
+        const repoId = hfModel.sourceRepoId || hfModel.id;
         const selectedExists = mmprojFiles.some(
           file =>
-            `${hfModel.id}/${file.rfilename}` === options.projectionModelId,
+            buildSourceModelId(source, repoId, file.rfilename) ===
+            options.projectionModelId,
         );
 
         if (selectedExists) {
@@ -2038,7 +2126,7 @@ class ModelStore {
       await new Promise(resolve => setTimeout(resolve, 200));
 
       // Use the centralized download method which handles mmproj automatically
-      this.checkSpaceAndDownload(newModel.id);
+      await this.checkSpaceAndDownload(newModel.id);
 
       // The error handling is now done in the downloadManager callbacks
     } catch (error) {
@@ -2083,12 +2171,18 @@ class ModelStore {
       newModel.supportsMultimodal &&
       newModel.compatibleProjectionModels?.length
     ) {
+      const source = hfModel.source || 'huggingface';
+      const repoId = hfModel.sourceRepoId || hfModel.id;
       // Get the mmproj files from the repository
       const mmprojFiles = getMmprojFiles(hfModel.siblings || []);
 
       // Add each projection model to the store if it doesn't exist
       for (const mmprojFile of mmprojFiles) {
-        const projModelId = `${hfModel.id}/${mmprojFile.rfilename}`;
+        const projModelId = buildSourceModelId(
+          source,
+          repoId,
+          mmprojFile.rfilename,
+        );
         const existingProjModel = this.models.find(m => m.id === projModelId);
 
         if (!existingProjModel) {
@@ -2104,7 +2198,7 @@ class ModelStore {
       // to ensure they're current with what's now in the store
       if (storeModel) {
         const updatedCompatibleModels = mmprojFiles.map(
-          file => `${hfModel.id}/${file.rfilename}`,
+          file => buildSourceModelId(source, repoId, file.rfilename),
         );
 
         runInAction(() => {
@@ -2123,7 +2217,11 @@ class ModelStore {
               mmprojFilenames,
             );
             if (recommendedFile) {
-              storeModel.defaultProjectionModel = `${hfModel.id}/${recommendedFile}`;
+              storeModel.defaultProjectionModel = buildSourceModelId(
+                source,
+                repoId,
+                recommendedFile,
+              );
             }
           }
         });
@@ -2133,13 +2231,13 @@ class ModelStore {
     // If this is a projection model, check if we need to update any vision models
     if (newModel.modelType === ModelType.PROJECTION) {
       // Get the repository ID from the model ID
-      const repoId = newModel.id.split('/').slice(0, 2).join('/');
+      const repoId = getRepoIdFromModelId(newModel.id);
 
       // Find vision models from the same repository
       const visionModels = this.models.filter(
         m =>
           m.supportsMultimodal &&
-          m.id.startsWith(repoId) &&
+          (!repoId || getRepoIdFromModelId(m.id) === repoId) &&
           m.id !== newModel.id,
       );
 
@@ -2280,8 +2378,12 @@ class ModelStore {
       model.ggufMetadata = undefined;
     });
 
-    const hfModels = this.models.filter(
-      model => model.origin === ModelOrigin.HF,
+    const hfModels = this.models.filter(model =>
+      [
+        ModelOrigin.HF,
+        ModelOrigin.HF_MIRROR,
+        ModelOrigin.MODELSCOPE,
+      ].includes(model.origin),
     );
     hfModels.forEach(model => {
       const defaultSettings = getHFDefaultSettings(
@@ -3074,7 +3176,7 @@ class ModelStore {
   };
 
   /**
-   * Fetches and updates model file details from HuggingFace.
+   * Fetches and updates source model file details.
    * This is used when we need to get the lfs.oid for integrity checks.
    * @param model - The model to update
    * @returns Promise<void>
@@ -3085,7 +3187,13 @@ class ModelStore {
     }
 
     try {
-      const fileDetails = await fetchModelFilesDetails(model.hfModel.id);
+      const source = getModelSource(model);
+      const authToken = hfStore.shouldUseToken ? hfStore.hfToken : null;
+      const fileDetails = await fetchModelFilesDetailsFromSource({
+        source,
+        modelId: model.hfModel.sourceRepoId || model.hfModel.id,
+        authToken,
+      });
       const matchingFile = fileDetails.find(
         file => file.path === model.hfModelFile?.rfilename,
       );

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -33,6 +33,7 @@ import {
   inferRepoFromModelId,
   parseSizeLabel,
 } from '../utils';
+import {expandSplitModelFile} from '../utils/hf';
 import {
   buildSourceModelId,
   getModelSource,
@@ -81,6 +82,18 @@ import {
 import NativeHardwareInfo from '../specs/NativeHardwareInfo';
 import {getModelMemoryRequirement} from '../utils/memoryEstimator';
 import {loadLlamaModelInfo} from 'llama.rn';
+
+function getSplitStorageRoot(entryPath: string, entryRFilename: string) {
+  const fallbackDir = entryPath.substring(0, entryPath.lastIndexOf('/'));
+  if (!entryRFilename.includes('/')) {
+    return fallbackDir;
+  }
+
+  const entrySuffix = `/${entryRFilename}`;
+  return entryPath.endsWith(entrySuffix)
+    ? entryPath.slice(0, -entrySuffix.length)
+    : fallbackDir;
+}
 
 /**
  * Factory function to create a Model object for a remote model from an OpenAI-compatible server.
@@ -907,11 +920,9 @@ class ModelStore {
 
     // For repository-backed source models, use author/repo/model structure.
     if (
-      [
-        ModelOrigin.HF,
-        ModelOrigin.HF_MIRROR,
-        ModelOrigin.MODELSCOPE,
-      ].includes(model.origin)
+      [ModelOrigin.HF, ModelOrigin.HF_MIRROR, ModelOrigin.MODELSCOPE].includes(
+        model.origin,
+      )
     ) {
       const author = model.author || 'unknown';
       const source = getModelSource(model);
@@ -954,18 +965,52 @@ class ModelStore {
 
   async checkFileExists(model: Model) {
     const filePath = await this.getModelFullPath(model);
-    const exists = await RNFS.exists(filePath);
+    let exists = await RNFS.exists(filePath);
     let sizeMatches = true;
+
+    if (exists && model.splitDownload && model.hfModelFile) {
+      try {
+        const dirPath = getSplitStorageRoot(
+          filePath,
+          model.splitDownload.entryRFilename,
+        );
+        let totalSize = 0;
+        for (const part of expandSplitModelFile(model.hfModelFile)) {
+          const partPath = `${dirPath}/${part.rfilename}`;
+          const partExists = await RNFS.exists(partPath);
+          if (!partExists) {
+            exists = false;
+            sizeMatches = false;
+            break;
+          }
+          const partStats = await RNFS.stat(partPath);
+          totalSize += Number(partStats.size || 0);
+        }
+
+        if (exists && model.size && model.size > 0) {
+          sizeMatches =
+            totalSize > 0 &&
+            Math.abs(totalSize - Number(model.size)) / Number(model.size) <=
+              0.001;
+        }
+      } catch (err) {
+        console.log('Error checking split model file size:', err);
+        exists = false;
+        sizeMatches = false;
+      }
+    }
 
     if (exists && model.size && model.size > 0) {
       try {
-        const fileStats = await RNFS.stat(filePath);
-        const expectedSize = Number(model.size);
-        const actualSize = Number(fileStats.size);
-        sizeMatches =
-          expectedSize > 0 &&
-          actualSize > 0 &&
-          Math.abs(actualSize - expectedSize) / expectedSize <= 0.001;
+        if (!model.splitDownload) {
+          const fileStats = await RNFS.stat(filePath);
+          const expectedSize = Number(model.size);
+          const actualSize = Number(fileStats.size);
+          sizeMatches =
+            expectedSize > 0 &&
+            actualSize > 0 &&
+            Math.abs(actualSize - expectedSize) / expectedSize <= 0.001;
+        }
       } catch (err) {
         console.log('Error checking model file size:', err);
         sizeMatches = false;
@@ -998,6 +1043,21 @@ class ModelStore {
 
   initializeDownloadStatus = async () => {
     await this.refreshDownloadStatuses();
+  };
+
+  private getSplitModelFilePaths = async (model: Model): Promise<string[]> => {
+    if (!model.splitDownload || !model.hfModelFile) {
+      return [await this.getModelFullPath(model)];
+    }
+
+    const entryPath = await this.getModelFullPath(model);
+    const dirPath = getSplitStorageRoot(
+      entryPath,
+      model.splitDownload.entryRFilename,
+    );
+    return expandSplitModelFile(model.hfModelFile).map(
+      part => `${dirPath}/${part.rfilename}`,
+    );
   };
 
   removeInvalidLocalModels = () => {
@@ -1191,7 +1251,8 @@ class ModelStore {
       }
     }
 
-    const filePath = await this.getModelFullPath(_model);
+    const filePaths = await this.getSplitModelFilePaths(_model);
+    const filePath = filePaths[0];
     if (_model.isLocal || _model.origin === ModelOrigin.LOCAL) {
       // Local models are always removed from the list, when the file is deleted.
 
@@ -1210,7 +1271,13 @@ class ModelStore {
 
       // Delete the file from internal storage
       try {
-        await RNFS.unlink(filePath);
+        await Promise.all(
+          filePaths.map(async path => {
+            if (await RNFS.exists(path)) {
+              await RNFS.unlink(path);
+            }
+          }),
+        );
       } catch (err) {
         console.error('Failed to delete local model file:', err);
       }
@@ -1220,7 +1287,13 @@ class ModelStore {
 
       try {
         if (filePath) {
-          await RNFS.unlink(filePath);
+          await Promise.all(
+            filePaths.map(async path => {
+              if (await RNFS.exists(path)) {
+                await RNFS.unlink(path);
+              }
+            }),
+          );
 
           // Check if we need to release context (if this model is currently active)
           const needsContextRelease = this.activeModelId === _model.id;
@@ -2197,8 +2270,8 @@ class ModelStore {
       // If we're working with an existing model, update its projection model references
       // to ensure they're current with what's now in the store
       if (storeModel) {
-        const updatedCompatibleModels = mmprojFiles.map(
-          file => buildSourceModelId(source, repoId, file.rfilename),
+        const updatedCompatibleModels = mmprojFiles.map(file =>
+          buildSourceModelId(source, repoId, file.rfilename),
         );
 
         runInAction(() => {
@@ -2379,11 +2452,9 @@ class ModelStore {
     });
 
     const hfModels = this.models.filter(model =>
-      [
-        ModelOrigin.HF,
-        ModelOrigin.HF_MIRROR,
-        ModelOrigin.MODELSCOPE,
-      ].includes(model.origin),
+      [ModelOrigin.HF, ModelOrigin.HF_MIRROR, ModelOrigin.MODELSCOPE].includes(
+        model.origin,
+      ),
     );
     hfModels.forEach(model => {
       const defaultSettings = getHFDefaultSettings(

--- a/src/store/__tests__/HFStore.test.ts
+++ b/src/store/__tests__/HFStore.test.ts
@@ -7,13 +7,13 @@ import {
 } from '../../../jest/fixtures/models';
 import {hfStore} from '../../store/HFStore';
 import {
-  fetchGGUFSpecs,
-  fetchModelFilesDetails,
-  fetchModels,
-} from '../../api/hf';
+  fetchGGUFSpecsFromSource,
+  fetchModelFilesDetailsFromSource,
+  fetchModelsFromSource,
+} from '../../api/modelSources';
 
 // Mock the API calls
-jest.mock('../../api/hf');
+jest.mock('../../api/modelSources');
 
 describe('HFStore', () => {
   beforeEach(() => {
@@ -25,6 +25,8 @@ describe('HFStore', () => {
     hfStore.error = null;
     hfStore.nextPageLink = null;
     hfStore.searchQuery = '';
+    hfStore.selectedSource = 'huggingface';
+    hfStore.modelDetailsLoading = false;
     // Clear the token to ensure tests start with no authentication
     hfStore.hfToken = null;
     hfStore.useHfToken = true;
@@ -32,6 +34,12 @@ describe('HFStore', () => {
     (hfStore as any).lastFetchMoreAttempt = 0;
     (hfStore as any).consecutiveSmallResults = 0;
     (hfStore as any).lastFetchedNextLink = null;
+    (hfStore as any).searchRequestId = 0;
+    (hfStore as any).fetchMoreRequestId = 0;
+    (hfStore as any).activeSearchRequestId = 0;
+    (hfStore as any).activeFetchMoreRequestId = 0;
+    (hfStore as any).modelDetailsRequestId = 0;
+    (hfStore as any).activeModelDetailsId = null;
   });
 
   describe('fetchModels', () => {
@@ -40,7 +48,7 @@ describe('HFStore', () => {
         models: [mockHFModel1, mockHFModel2],
         nextLink: 'next-page-url',
       };
-      (fetchModels as jest.Mock).mockResolvedValueOnce(mockResponse);
+      (fetchModelsFromSource as jest.Mock).mockResolvedValueOnce(mockResponse);
 
       await hfStore.fetchModels();
 
@@ -54,7 +62,7 @@ describe('HFStore', () => {
     });
 
     it('should handle fetch error', async () => {
-      (fetchModels as jest.Mock).mockRejectedValueOnce(
+      (fetchModelsFromSource as jest.Mock).mockRejectedValueOnce(
         new Error('Network error'),
       );
 
@@ -71,6 +79,58 @@ describe('HFStore', () => {
       );
       expect(hfStore.isLoading).toBe(false);
     });
+
+    it('passes the configured token to ModelScope searches', async () => {
+      const mockResponse = {
+        models: [mockHFModel1],
+        nextLink: null,
+      };
+      hfStore.setSelectedSource('modelscope');
+      hfStore.hfToken = 'modelscope-token';
+      hfStore.useHfToken = true;
+      (fetchModelsFromSource as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      await hfStore.fetchModels();
+
+      expect(fetchModelsFromSource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'modelscope',
+          authToken: 'modelscope-token',
+        }),
+      );
+    });
+
+    it('ignores stale search results when a newer query completes first', async () => {
+      let resolveFirstSearch: (value: any) => void = () => {};
+      const firstSearch = new Promise(resolve => {
+        resolveFirstSearch = resolve;
+      });
+      const secondResponse = {
+        models: [mockHFModel2],
+        nextLink: null,
+      };
+
+      (fetchModelsFromSource as jest.Mock)
+        .mockReturnValueOnce(firstSearch)
+        .mockResolvedValueOnce(secondResponse);
+
+      hfStore.setSearchQuery('old');
+      const firstRequest = hfStore.fetchModels();
+      hfStore.setSearchQuery('new');
+      const secondRequest = hfStore.fetchModels();
+
+      await secondRequest;
+
+      resolveFirstSearch({
+        models: [mockHFModel1],
+        nextLink: 'stale-next',
+      });
+      await firstRequest;
+
+      expect(hfStore.models).toHaveLength(1);
+      expect(hfStore.models[0].id).toBe(mockHFModel2.id);
+      expect(hfStore.nextPageLink).toBeNull();
+    });
   });
 
   describe('fetchMoreModels', () => {
@@ -78,7 +138,7 @@ describe('HFStore', () => {
       hfStore.nextPageLink = null;
       await hfStore.fetchMoreModels();
 
-      expect(fetchModels).not.toHaveBeenCalled();
+      expect(fetchModelsFromSource).not.toHaveBeenCalled();
     });
 
     it('should append new models to existing ones', async () => {
@@ -90,7 +150,7 @@ describe('HFStore', () => {
         models: [mockHFModel2],
         nextLink: null,
       };
-      (fetchModels as jest.Mock).mockResolvedValueOnce(mockResponse);
+      (fetchModelsFromSource as jest.Mock).mockResolvedValueOnce(mockResponse);
 
       await hfStore.fetchMoreModels();
 
@@ -109,14 +169,14 @@ describe('HFStore', () => {
         models: [mockHFModel2],
         nextLink: 'next-page-url-2',
       };
-      (fetchModels as jest.Mock).mockResolvedValueOnce(mockResponse);
+      (fetchModelsFromSource as jest.Mock).mockResolvedValueOnce(mockResponse);
 
       await hfStore.fetchMoreModels();
-      expect(fetchModels).toHaveBeenCalledTimes(1);
+      expect(fetchModelsFromSource).toHaveBeenCalledTimes(1);
 
       // Immediate second call should be prevented due to debouncing
       await hfStore.fetchMoreModels();
-      expect(fetchModels).toHaveBeenCalledTimes(1); // Still only 1 call
+      expect(fetchModelsFromSource).toHaveBeenCalledTimes(1); // Still only 1 call
     });
 
     it('should track consecutive small results', async () => {
@@ -129,7 +189,7 @@ describe('HFStore', () => {
         nextLink: 'next-page-url-2',
       };
 
-      (fetchModels as jest.Mock)
+      (fetchModelsFromSource as jest.Mock)
         .mockResolvedValueOnce(smallResponse)
         .mockResolvedValueOnce(smallResponse)
         .mockResolvedValueOnce(smallResponse);
@@ -150,15 +210,99 @@ describe('HFStore', () => {
     it('should fetch both GGUF specs and file sizes', async () => {
       const modelId = 'owner/hf-model-name-1';
 
-      (fetchGGUFSpecs as jest.Mock).mockResolvedValueOnce(mockGGUFSpecs1);
-      (fetchModelFilesDetails as jest.Mock).mockResolvedValueOnce(
+      (fetchGGUFSpecsFromSource as jest.Mock).mockResolvedValueOnce(
+        mockGGUFSpecs1,
+      );
+      (fetchModelFilesDetailsFromSource as jest.Mock).mockResolvedValueOnce(
         mockHFModelFiles1,
       );
 
       await hfStore.fetchModelData(modelId);
 
-      expect(fetchGGUFSpecs).toHaveBeenCalledWith(modelId, null);
-      expect(fetchModelFilesDetails).toHaveBeenCalledWith(modelId, null);
+      expect(fetchGGUFSpecsFromSource).toHaveBeenCalledWith({
+        source: 'huggingface',
+        modelId,
+        authToken: null,
+      });
+      expect(fetchModelFilesDetailsFromSource).toHaveBeenCalledWith({
+        source: 'huggingface',
+        modelId,
+        authToken: null,
+      });
+    });
+
+    it('passes the configured token to ModelScope model detail requests', async () => {
+      const modelId = 'Qwen/Qwen2.5-GGUF';
+      hfStore.models = [
+        {
+          ...mockHFModel1,
+          id: modelId,
+          source: 'modelscope',
+        },
+      ];
+      hfStore.hfToken = 'modelscope-token';
+      hfStore.useHfToken = true;
+      (fetchGGUFSpecsFromSource as jest.Mock).mockResolvedValueOnce(
+        mockGGUFSpecs1,
+      );
+      (fetchModelFilesDetailsFromSource as jest.Mock).mockResolvedValueOnce(
+        mockHFModelFiles1,
+      );
+
+      await hfStore.fetchModelData(modelId);
+
+      expect(fetchGGUFSpecsFromSource).toHaveBeenCalledWith({
+        source: 'modelscope',
+        modelId,
+        authToken: 'modelscope-token',
+      });
+      expect(fetchModelFilesDetailsFromSource).toHaveBeenCalledWith({
+        source: 'modelscope',
+        modelId,
+        authToken: 'modelscope-token',
+      });
+    });
+
+    it('keeps details loading until the current detail request completes', async () => {
+      hfStore.models = [mockHFModel1];
+      let resolveSpecs: (value: any) => void = () => {};
+
+      (fetchGGUFSpecsFromSource as jest.Mock).mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveSpecs = resolve;
+        }),
+      );
+      (fetchModelFilesDetailsFromSource as jest.Mock).mockResolvedValueOnce(
+        mockHFModelFiles1,
+      );
+
+      const request = hfStore.fetchModelData(mockHFModel1.id);
+      expect(hfStore.modelDetailsLoading).toBe(true);
+
+      resolveSpecs(mockGGUFSpecs1);
+      await request;
+
+      expect(hfStore.modelDetailsLoading).toBe(false);
+    });
+  });
+
+  describe('setSelectedSource', () => {
+    it('updates source and clears existing search results', () => {
+      hfStore.models = [mockHFModel1];
+      hfStore.nextPageLink = 'next-page-url';
+      hfStore.error = {
+        code: 'network',
+        context: 'search',
+        message: 'failed',
+        recoverable: true,
+      };
+
+      hfStore.setSelectedSource('modelscope');
+
+      expect(hfStore.selectedSource).toBe('modelscope');
+      expect(hfStore.models).toHaveLength(0);
+      expect(hfStore.nextPageLink).toBeNull();
+      expect(hfStore.error).toBeNull();
     });
   });
 
@@ -201,7 +345,7 @@ describe('HFStore', () => {
         models: [mockHFModel1],
         nextLink: null,
       };
-      (fetchModels as jest.Mock).mockResolvedValueOnce(mockResponse);
+      (fetchModelsFromSource as jest.Mock).mockResolvedValueOnce(mockResponse);
 
       await hfStore.fetchModels();
 
@@ -236,7 +380,9 @@ describe('HFStore', () => {
   describe('fetchAndSetGGUFSpecs', () => {
     it('should update model specs when successful', async () => {
       hfStore.models = [mockHFModel1];
-      (fetchGGUFSpecs as jest.Mock).mockResolvedValueOnce(mockGGUFSpecs2);
+      (fetchGGUFSpecsFromSource as jest.Mock).mockResolvedValueOnce(
+        mockGGUFSpecs2,
+      );
 
       await hfStore.fetchAndSetGGUFSpecs(mockHFModel1.id);
 
@@ -245,11 +391,13 @@ describe('HFStore', () => {
 
     it('should handle non-existent model', async () => {
       hfStore.models = [];
-      (fetchGGUFSpecs as jest.Mock).mockResolvedValueOnce(mockGGUFSpecs1);
+      (fetchGGUFSpecsFromSource as jest.Mock).mockResolvedValueOnce(
+        mockGGUFSpecs1,
+      );
 
       await hfStore.fetchAndSetGGUFSpecs('non-existent-id');
 
-      expect(fetchGGUFSpecs).toHaveBeenCalled();
+      expect(fetchGGUFSpecsFromSource).toHaveBeenCalled();
       // Should not throw error
     });
   });
@@ -261,7 +409,9 @@ describe('HFStore', () => {
         {path: 'hf-model-name-1.Q4_K_M.gguf', size: 1111, oid: 'abc123'},
       ];
 
-      (fetchModelFilesDetails as jest.Mock).mockResolvedValueOnce(fileDetails);
+      (fetchModelFilesDetailsFromSource as jest.Mock).mockResolvedValueOnce(
+        fileDetails,
+      );
 
       await hfStore.fetchModelFileDetails(mockHFModel1.id);
 
@@ -271,11 +421,11 @@ describe('HFStore', () => {
 
     it('should handle non-existent model', async () => {
       hfStore.models = [];
-      (fetchModelFilesDetails as jest.Mock).mockResolvedValueOnce([]);
+      (fetchModelFilesDetailsFromSource as jest.Mock).mockResolvedValueOnce([]);
 
       await hfStore.fetchModelFileDetails('non-existent-id');
 
-      expect(fetchModelFilesDetails).toHaveBeenCalled();
+      expect(fetchModelFilesDetailsFromSource).toHaveBeenCalled();
       // Should not throw error
     });
   });

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -31,9 +31,9 @@ jest.mock('../../utils/deviceCapabilities', () => ({
   isHighEndDevice: jest.fn().mockResolvedValue(false),
 }));
 
-// Mock the HF API
-jest.mock('../../api/hf', () => ({
-  fetchModelFilesDetails: jest.fn(),
+// Mock the model source API
+jest.mock('../../api/modelSources', () => ({
+  fetchModelFilesDetailsFromSource: jest.fn(),
 }));
 
 // Mock the download manager
@@ -422,7 +422,7 @@ describe('ModelStore', () => {
 
     it('should automatically cleanup orphaned projection model when LLM is deleted', async () => {
       // Mock RNFS.exists to return false so backwards compat checks use new path consistently
-      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+      (RNFS.exists as jest.Mock).mockResolvedValue(true);
 
       const projModel = {
         ...defaultModels[0],
@@ -873,6 +873,25 @@ describe('ModelStore', () => {
 
       expect(downloadManager.startDownload).toHaveBeenCalled();
     });
+
+    it('should not mark partial files as downloaded when size does not match', async () => {
+      const model = {
+        ...defaultModels[0],
+        id: 'partial-model',
+        filename: 'partial-model.gguf',
+        size: 1000,
+        isDownloaded: false,
+      };
+      modelStore.models = [model];
+
+      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+      (RNFS.stat as jest.Mock).mockResolvedValue({size: 100});
+      (downloadManager.isDownloading as jest.Mock).mockReturnValue(false);
+
+      await modelStore.checkFileExists(model);
+
+      expect(model.isDownloaded).toBe(false);
+    });
   });
 
   describe('computed properties', () => {
@@ -1012,6 +1031,42 @@ describe('ModelStore', () => {
       consoleErrorSpy.mockRestore();
       alertSpy.mockRestore();
       modelStore.addHFModel = originalAddHFModel;
+    });
+
+    it('should surface download start errors from HF model downloads', async () => {
+      const hfModel = {
+        ...mockHFModel1,
+        _id: 'hf-1',
+        author: 'test',
+        id: 'test/hf-model',
+        model_id: 'test/hf-model',
+        siblings: [
+          {
+            rfilename: 'model-01.gguf',
+            size: 1000,
+            url: 'test-url',
+            oid: 'test-oid',
+          },
+        ],
+      };
+      const modelFile = hfModel.siblings[0];
+      const error = new Error('download start failed');
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation();
+
+      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+      (downloadManager.startDownload as jest.Mock).mockRejectedValue(error);
+
+      await modelStore.downloadHFModel(hfModel as any, modelFile as any);
+
+      expect(downloadManager.startDownload).toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalledWith(
+        uiStore.l10n.errors.downloadSetupFailedTitle,
+        t(uiStore.l10n.errors.downloadSetupFailedMessage, {
+          message: 'download start failed',
+        }),
+      );
+
+      alertSpy.mockRestore();
     });
   });
 
@@ -1872,6 +1927,36 @@ describe('ModelStore', () => {
       // Should fallback to 'unknown'
       expect(path).toContain('/models/hf/bartowski/unknown/model.gguf');
     });
+
+    it('should use separate directories for non-official model sources', async () => {
+      const mirrorModel = {
+        origin: ModelOrigin.HF_MIRROR,
+        source: 'hf_mirror',
+        id: 'hf_mirror:bartowski/gemma-2-2b-it-GGUF/model.gguf',
+        filename: 'model.gguf',
+        author: 'bartowski',
+        repo: 'gemma-2-2b-it-GGUF',
+      };
+      const modelScopeModel = {
+        origin: ModelOrigin.MODELSCOPE,
+        source: 'modelscope',
+        id: 'modelscope:qwen/Qwen2.5-GGUF/model.gguf',
+        filename: 'model.gguf',
+        author: 'qwen',
+        repo: 'Qwen2.5-GGUF',
+      };
+
+      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        modelStore.getModelFullPath(mirrorModel as any),
+      ).resolves.toContain(
+        '/models/hf-mirror/bartowski/gemma-2-2b-it-GGUF/model.gguf',
+      );
+      await expect(
+        modelStore.getModelFullPath(modelScopeModel as any),
+      ).resolves.toContain('/models/modelscope/qwen/Qwen2.5-GGUF/model.gguf');
+    });
   });
 
   describe('mergeModelLists - repo inference for HF models', () => {
@@ -2342,7 +2427,9 @@ describe('ModelStore', () => {
 
   // Add tests for fetchAndUpdateModelFileDetails
   describe('fetchAndUpdateModelFileDetails', () => {
-    const {fetchModelFilesDetails} = require('../../api/hf');
+    const {
+      fetchModelFilesDetailsFromSource,
+    } = require('../../api/modelSources');
 
     beforeEach(() => {
       jest.clearAllMocks();
@@ -2357,7 +2444,7 @@ describe('ModelStore', () => {
       await modelStore.fetchAndUpdateModelFileDetails(model as any);
 
       // Should not throw or call any APIs
-      expect(fetchModelFilesDetails).not.toHaveBeenCalled();
+      expect(fetchModelFilesDetailsFromSource).not.toHaveBeenCalled();
     });
 
     it('should update model file details when matching file found', async () => {
@@ -2378,11 +2465,15 @@ describe('ModelStore', () => {
         },
       ];
 
-      fetchModelFilesDetails.mockResolvedValue(mockFileDetails);
+      fetchModelFilesDetailsFromSource.mockResolvedValue(mockFileDetails);
 
       await modelStore.fetchAndUpdateModelFileDetails(model as any);
 
-      expect(fetchModelFilesDetails).toHaveBeenCalledWith('test/model');
+      expect(fetchModelFilesDetailsFromSource).toHaveBeenCalledWith({
+        source: 'huggingface',
+        modelId: 'test/model',
+        authToken: 'mockPass',
+      });
       expect(model.hfModelFile.lfs).toEqual({oid: 'test-oid', size: 1000});
     });
 
@@ -2393,7 +2484,9 @@ describe('ModelStore', () => {
         hfModelFile: {rfilename: 'model.gguf', lfs: undefined},
       };
 
-      fetchModelFilesDetails.mockRejectedValue(new Error('API error'));
+      fetchModelFilesDetailsFromSource.mockRejectedValue(
+        new Error('API error'),
+      );
 
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
@@ -2421,11 +2514,15 @@ describe('ModelStore', () => {
         },
       ];
 
-      fetchModelFilesDetails.mockResolvedValue(mockFileDetails);
+      fetchModelFilesDetailsFromSource.mockResolvedValue(mockFileDetails);
 
       await modelStore.fetchAndUpdateModelFileDetails(model as any);
 
-      expect(fetchModelFilesDetails).toHaveBeenCalledWith('test/model');
+      expect(fetchModelFilesDetailsFromSource).toHaveBeenCalledWith({
+        source: 'huggingface',
+        modelId: 'test/model',
+        authToken: 'mockPass',
+      });
       expect(model.hfModelFile.lfs).toBeUndefined();
     });
 
@@ -2443,11 +2540,15 @@ describe('ModelStore', () => {
         },
       ];
 
-      fetchModelFilesDetails.mockResolvedValue(mockFileDetails);
+      fetchModelFilesDetailsFromSource.mockResolvedValue(mockFileDetails);
 
       await modelStore.fetchAndUpdateModelFileDetails(model as any);
 
-      expect(fetchModelFilesDetails).toHaveBeenCalledWith('test/model');
+      expect(fetchModelFilesDetailsFromSource).toHaveBeenCalledWith({
+        source: 'huggingface',
+        modelId: 'test/model',
+        authToken: 'mockPass',
+      });
       expect(model.hfModelFile.lfs).toBeUndefined();
     });
   });
@@ -2469,6 +2570,7 @@ describe('ModelStore', () => {
         modelStore.context = undefined;
         modelStore.activeModelId = undefined;
         modelStore.isContextLoading = false;
+        modelStore.modelLoadError = null;
       });
 
       // Get the mock function - use named export
@@ -2536,6 +2638,23 @@ describe('ModelStore', () => {
 
       // Flag should still be cleared
       expect(modelStore.isContextLoading).toBe(false);
+    });
+
+    it('should show a friendly error when llama JSI bindings are unavailable', async () => {
+      const model = basicModel;
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      initLlamaMock.mockReset();
+      initLlamaMock.mockRejectedValue(new Error('JSI bindings not installed'));
+
+      await expect(modelStore.initContext(model)).rejects.toThrow(
+        'JSI bindings not installed',
+      );
+
+      expect(modelStore.modelLoadError?.message).toBe(
+        uiStore.l10n.errors.modelNativeBindingError,
+      );
+      expect(modelStore.modelLoadError?.message).not.toMatch(/JSI bindings/i);
+      errorSpy.mockRestore();
     });
 
     it('should return existing context when same model is already loaded', async () => {
@@ -3187,6 +3306,27 @@ describe('ModelStore', () => {
       await modelStore.fetchAndPersistGGUFMetadata(model);
 
       expect(model.ggufMetadata).toBeUndefined();
+    });
+
+    it('should silently skip metadata when llama JSI bindings are unavailable', async () => {
+      const model = {
+        ...defaultModels[0],
+        isDownloaded: true,
+        ggufMetadata: undefined,
+      };
+      modelStore.models = [model];
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      (RNFS.exists as jest.Mock).mockResolvedValue(true);
+      (loadLlamaModelInfo as jest.Mock).mockRejectedValue(
+        new Error('JSI bindings not installed'),
+      );
+
+      await modelStore.fetchAndPersistGGUFMetadata(model);
+
+      expect(model.ggufMetadata).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it('should handle null response gracefully', async () => {

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -892,6 +892,90 @@ describe('ModelStore', () => {
 
       expect(model.isDownloaded).toBe(false);
     });
+
+    it('should check all split files relative to the repository root', async () => {
+      const model = {
+        ...defaultModels[0],
+        id: 'owner/repo/Q2_K/model.gguf-00001-of-00002.gguf',
+        filename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+        size: 300,
+        origin: ModelOrigin.HF,
+        author: 'owner',
+        repo: 'repo',
+        isDownloaded: false,
+        hfModelFile: {
+          rfilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+          size: 300,
+          split: {
+            entryRFilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+            displayRFilename: 'Q2_K/model.gguf',
+            totalSize: 300,
+            totalParts: 2,
+            parts: [
+              {
+                rfilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+                index: 1,
+                total: 2,
+                size: 100,
+              },
+              {
+                rfilename: 'Q2_K/model.gguf-00002-of-00002.gguf',
+                index: 2,
+                total: 2,
+                size: 200,
+              },
+            ],
+          },
+        },
+        splitDownload: {
+          entryRFilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+          displayRFilename: 'Q2_K/model.gguf',
+          totalSize: 300,
+          totalParts: 2,
+          parts: [
+            {
+              rfilename: 'Q2_K/model.gguf-00001-of-00002.gguf',
+              index: 1,
+              total: 2,
+              size: 100,
+            },
+            {
+              rfilename: 'Q2_K/model.gguf-00002-of-00002.gguf',
+              index: 2,
+              total: 2,
+              size: 200,
+            },
+          ],
+        },
+      };
+      modelStore.models = [model as any];
+      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+      (RNFS.exists as jest.Mock).mockImplementation(path =>
+        Promise.resolve(
+          [
+            '/path/to/documents/models/hf/owner/repo/Q2_K/model.gguf-00001-of-00002.gguf',
+            '/path/to/documents/models/hf/owner/repo/Q2_K/model.gguf-00002-of-00002.gguf',
+          ].includes(path),
+        ),
+      );
+      (RNFS.stat as jest.Mock)
+        .mockResolvedValueOnce({size: 100})
+        .mockResolvedValueOnce({size: 200});
+      (downloadManager.isDownloading as jest.Mock).mockReturnValue(false);
+
+      await modelStore.checkFileExists(model as any);
+
+      expect(RNFS.exists).toHaveBeenCalledWith(
+        '/path/to/documents/models/hf/owner/repo/Q2_K/model.gguf-00001-of-00002.gguf',
+      );
+      expect(RNFS.exists).toHaveBeenCalledWith(
+        '/path/to/documents/models/hf/owner/repo/Q2_K/model.gguf-00002-of-00002.gguf',
+      );
+      expect(RNFS.exists).not.toHaveBeenCalledWith(
+        '/path/to/documents/models/hf/owner/repo/Q2_K/Q2_K/model.gguf-00002-of-00002.gguf',
+      );
+      expect(model.isDownloaded).toBe(true);
+    });
   });
 
   describe('computed properties', () => {
@@ -2642,7 +2726,9 @@ describe('ModelStore', () => {
 
     it('should show a friendly error when llama JSI bindings are unavailable', async () => {
       const model = basicModel;
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
       initLlamaMock.mockReset();
       initLlamaMock.mockRejectedValue(new Error('JSI bindings not installed'));
 

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -24,6 +24,7 @@ jest.mock('../../store/UIStore', () => ({
         networkTimeout: 'Network timeout',
         hfNetworkError: 'HF network error',
         networkError: 'Network error',
+        modelNativeBindingError: 'Native model runtime unavailable',
       },
     },
   },
@@ -204,6 +205,17 @@ describe('errors.ts', () => {
       expect(errorState.code).toBe('unknown');
       expect(errorState.message).toBe('Native error: out of memory');
       expect(errorState.context).toBe('modelInit');
+    });
+
+    it('should map llama JSI binding failures to a user-friendly model init error', () => {
+      const error = new Error('JSI bindings not installed');
+
+      const errorState = createErrorState(error, 'modelInit');
+
+      expect(errorState.code).toBe('unknown');
+      expect(errorState.message).toBe('Native model runtime unavailable');
+      expect(errorState.message).not.toMatch(/JSI bindings/i);
+      expect(errorState.recoverable).toBe(false);
     });
 
     it('should use default message for null/undefined errors', () => {

--- a/src/utils/__tests__/memorySettings.test.ts
+++ b/src/utils/__tests__/memorySettings.test.ts
@@ -64,6 +64,19 @@ describe('memorySettings', () => {
       expect(result).toBe(false);
     });
 
+    it('should not warn when llama JSI bindings are unavailable', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockLoadLlamaModelInfo.mockRejectedValue(
+        new Error('JSI bindings not installed'),
+      );
+
+      const result = await isRepackableQuantization('/path/to/model.gguf');
+
+      expect(result).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
     it('should handle case-insensitive matching', async () => {
       mockLoadLlamaModelInfo.mockResolvedValue({
         'general.file_type': 'q4_0',

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -345,4 +345,24 @@ describe('hfAsModel', () => {
 
     expect(model.repo).toBe('');
   });
+
+  it('should preserve official HF ids and scope mirror ids', () => {
+    const mirrorModel = {
+      ...mockHFModel1,
+      source: 'hf_mirror',
+      sourceRepoId: mockHFModel1.id,
+    };
+
+    const official = hfAsModel(mockHFModel1, mockHFModelFiles1[0]);
+    const mirror = hfAsModel(mirrorModel, mockHFModelFiles1[0]);
+
+    expect(official.id).toBe(
+      `${mockHFModel1.id}/${mockHFModelFiles1[0].rfilename}`,
+    );
+    expect(mirror.id).toBe(
+      `hf_mirror:${mockHFModel1.id}/${mockHFModelFiles1[0].rfilename}`,
+    );
+    expect(mirror.source).toBe('hf_mirror');
+    expect(mirror.origin).toBe('hf_mirror');
+  });
 });

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -365,4 +365,158 @@ describe('hfAsModel', () => {
     expect(mirror.source).toBe('hf_mirror');
     expect(mirror.origin).toBe('hf_mirror');
   });
+
+  it('should use the first GGUF split as the loadable model entry', () => {
+    const splitFile = {
+      rfilename: 'model-Q2_K.gguf-00001-of-00002.gguf',
+      size: 300,
+      url: 'https://example.com/model-Q2_K.gguf-00001-of-00002.gguf',
+      split: {
+        entryRFilename: 'model-Q2_K.gguf-00001-of-00002.gguf',
+        displayRFilename: 'model-Q2_K.gguf',
+        totalSize: 300,
+        totalParts: 2,
+        parts: [
+          {
+            rfilename: 'model-Q2_K.gguf-00001-of-00002.gguf',
+            index: 1,
+            total: 2,
+            size: 100,
+            url: 'https://example.com/model-Q2_K.gguf-00001-of-00002.gguf',
+          },
+          {
+            rfilename: 'model-Q2_K.gguf-00002-of-00002.gguf',
+            index: 2,
+            total: 2,
+            size: 200,
+            url: 'https://example.com/model-Q2_K.gguf-00002-of-00002.gguf',
+          },
+        ],
+      },
+    };
+
+    const model = hfAsModel(mockHFModel1, splitFile);
+
+    expect(model.id).toBe(
+      `${mockHFModel1.id}/model-Q2_K.gguf-00001-of-00002.gguf`,
+    );
+    expect(model.filename).toBe('model-Q2_K.gguf-00001-of-00002.gguf');
+    expect(model.name).toBe('model-Q2_K');
+    expect(model.splitDownload?.parts).toHaveLength(2);
+  });
+});
+
+describe('normalizeGGUFModelFiles', () => {
+  const {
+    normalizeGGUFModelFiles,
+    normalizeModelSiblings,
+    isShardedGGUFFile,
+    isValidGGUFFile,
+  } = require('../hf');
+
+  it('aggregates complete GGUF split sets into one logical file', () => {
+    const files = normalizeGGUFModelFiles([
+      {rfilename: 'Q2_K/model.gguf-00002-of-00002.gguf', size: 20},
+      {rfilename: 'Q2_K/model.gguf-00001-of-00002.gguf', size: 10},
+      {rfilename: 'README.md', size: 1},
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].rfilename).toBe('Q2_K/model.gguf-00001-of-00002.gguf');
+    expect(files[0].size).toBe(30);
+    expect(files[0].split.displayRFilename).toBe('Q2_K/model.gguf');
+    expect(files[0].split.parts.map((part: any) => part.index)).toEqual([1, 2]);
+  });
+
+  it('does not expose incomplete GGUF split sets', () => {
+    const files = normalizeGGUFModelFiles([
+      {rfilename: 'model.gguf-00001-of-00002.gguf', size: 10},
+    ]);
+
+    expect(files).toEqual([]);
+  });
+
+  it('adds source URLs to each split part', () => {
+    const files = normalizeModelSiblings('owner/repo', [
+      {rfilename: 'model.gguf-00001-of-00002.gguf', size: 10},
+      {rfilename: 'model.gguf-00002-of-00002.gguf', size: 20},
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].url).toContain('model.gguf-00001-of-00002.gguf');
+    expect(files[0].split.parts[1].url).toContain(
+      'model.gguf-00002-of-00002.gguf',
+    );
+  });
+
+  it('preserves already aggregated split metadata when normalizing again', () => {
+    const files = normalizeGGUFModelFiles([
+      {
+        rfilename: 'model.gguf-00001-of-00002.gguf',
+        size: 30,
+        split: {
+          entryRFilename: 'model.gguf-00001-of-00002.gguf',
+          displayRFilename: 'model.gguf',
+          totalSize: 30,
+          totalParts: 2,
+          parts: [
+            {
+              rfilename: 'model.gguf-00001-of-00002.gguf',
+              index: 1,
+              total: 2,
+              size: 10,
+            },
+            {
+              rfilename: 'model.gguf-00002-of-00002.gguf',
+              index: 2,
+              total: 2,
+              size: 20,
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].rfilename).toBe('model.gguf-00001-of-00002.gguf');
+    expect(files[0].size).toBe(30);
+    expect(files[0].split.parts).toHaveLength(2);
+  });
+
+  it('recognizes split GGUF files without treating individual parts as single-file models', () => {
+    expect(isShardedGGUFFile('model.gguf-00001-of-00002.gguf')).toBe(true);
+    expect(isValidGGUFFile('model.gguf-00001-of-00002.gguf')).toBe(false);
+    expect(isValidGGUFFile('model.Q4_K_M.gguf')).toBe(true);
+  });
+
+  it('uses final split model size for required download space', () => {
+    const {getSplitDownloadRequiredSpace} = require('../hf');
+
+    expect(
+      getSplitDownloadRequiredSpace({
+        rfilename: 'model.gguf-00001-of-00002.gguf',
+        size: 300,
+        split: {
+          entryRFilename: 'model.gguf-00001-of-00002.gguf',
+          displayRFilename: 'model.gguf',
+          totalSize: 300,
+          totalParts: 2,
+          parts: [
+            {
+              rfilename: 'model.gguf-00001-of-00002.gguf',
+              index: 1,
+              total: 2,
+              size: 100,
+            },
+            {
+              rfilename: 'model.gguf-00002-of-00002.gguf',
+              index: 2,
+              total: 2,
+              size: 200,
+            },
+          ],
+        },
+      }),
+    ).toBe(300);
+  });
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -4,6 +4,10 @@
 
 import axios from 'axios';
 import {uiStore} from '../store/UIStore';
+import {
+  LLAMA_NATIVE_BINDINGS_UNAVAILABLE_MESSAGE,
+  isLlamaJsiBindingsError,
+} from './llamaErrors';
 /**
  * NetworkError - Used for connectivity-related errors
  * Examples: No internet connection, timeout, etc.
@@ -49,7 +53,7 @@ export interface ErrorState {
     | 'server'
     | 'multimodal'
     | 'unknown';
-  service?: 'huggingface' | 'firebase' | 'localapi';
+  service?: 'huggingface' | 'hf_mirror' | 'modelscope' | 'firebase' | 'localapi';
   message: string;
   context: 'search' | 'download' | 'modelDetails' | 'chat' | 'modelInit';
   recoverable: boolean;
@@ -75,8 +79,17 @@ export function createErrorState(
   let message = l10nObject.errors.unexpectedError;
   let recoverable = true;
   let errorService = service;
+  const isModelSourceService = () =>
+    errorService === 'huggingface' ||
+    errorService === 'hf_mirror' ||
+    errorService === 'modelscope';
 
-  if (axios.isAxiosError(error)) {
+  if (isLlamaJsiBindingsError(error)) {
+    message =
+      l10nObject.errors.modelNativeBindingError ||
+      LLAMA_NATIVE_BINDINGS_UNAVAILABLE_MESSAGE;
+    recoverable = false;
+  } else if (axios.isAxiosError(error)) {
     const statusCode = error.response?.status;
 
     // Check URL to determine service if not explicitly provided
@@ -84,13 +97,16 @@ export function createErrorState(
       const url = error.config?.url || '';
       if (url.includes('huggingface.co') || url.includes('hf.co')) {
         errorService = 'huggingface';
+      } else if (url.includes('hf-mirror.com')) {
+        errorService = 'hf_mirror';
+      } else if (url.includes('modelscope.cn')) {
+        errorService = 'modelscope';
       }
     }
-
     if (statusCode === 401) {
       code = 'authentication';
       message =
-        errorService === 'huggingface'
+        isModelSourceService()
           ? context === 'search'
             ? l10nObject.errors.hfAuthenticationErrorSearch
             : l10nObject.errors.hfAuthenticationError
@@ -98,25 +114,25 @@ export function createErrorState(
     } else if (statusCode === 403) {
       code = 'authorization';
       message =
-        errorService === 'huggingface'
+        isModelSourceService()
           ? l10nObject.errors.hfAuthorizationError
           : l10nObject.errors.authorizationError;
     } else if (statusCode && statusCode >= 500) {
       code = 'server';
       message =
-        errorService === 'huggingface'
+        isModelSourceService()
           ? l10nObject.errors.hfServerError
           : l10nObject.errors.serverError;
     } else if (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT') {
       code = 'network';
       message =
-        errorService === 'huggingface'
+        isModelSourceService()
           ? l10nObject.errors.hfNetworkTimeout
           : l10nObject.errors.networkTimeout;
     } else if (error.code === 'ERR_NETWORK') {
       code = 'network';
       message =
-        errorService === 'huggingface'
+        isModelSourceService()
           ? l10nObject.errors.hfNetworkError
           : l10nObject.errors.networkError;
     }
@@ -138,19 +154,19 @@ export function createErrorState(
         if (statusCode === 401) {
           code = 'authentication';
           message =
-            errorService === 'huggingface'
+            isModelSourceService()
               ? l10nObject.errors.hfAuthenticationError
               : l10nObject.errors.authenticationError;
         } else if (statusCode === 403) {
           code = 'authorization';
           message =
-            errorService === 'huggingface'
+            isModelSourceService()
               ? l10nObject.errors.hfAuthorizationError
               : l10nObject.errors.authorizationError;
         } else if (statusCode >= 500) {
           code = 'server';
           message =
-            errorService === 'huggingface'
+            isModelSourceService()
               ? l10nObject.errors.hfServerError
               : l10nObject.errors.serverError;
         } else {

--- a/src/utils/hf.ts
+++ b/src/utils/hf.ts
@@ -4,7 +4,7 @@
  */
 
 import {urls} from '../config';
-import type {HuggingFaceModel, ModelFile} from './types';
+import type {HuggingFaceModel, ModelFile, ModelSourceId} from './types';
 
 // Regex pattern for detecting sharded GGUF files
 const RE_GGUF_SHARD_FILE =
@@ -33,10 +33,13 @@ export function filterValidGGUFFiles(siblings: any[]): any[] {
 export function addModelFileDownloadUrls(
   modelId: string,
   siblings: any[],
+  domain?: string,
 ): ModelFile[] {
   return siblings.map(sibling => ({
     ...sibling,
-    url: urls.modelDownloadFile(modelId, sibling.rfilename),
+    url: domain
+      ? urls.hfCompatibleModelDownloadFile(domain, modelId, sibling.rfilename)
+      : urls.modelDownloadFile(modelId, sibling.rfilename),
   }));
 }
 
@@ -50,9 +53,47 @@ export function addModelFileDownloadUrls(
 export function normalizeModelSiblings(
   modelId: string,
   siblings: any[],
+  domain?: string,
 ): ModelFile[] {
   const filteredSiblings = filterValidGGUFFiles(siblings);
-  return addModelFileDownloadUrls(modelId, filteredSiblings);
+  return addModelFileDownloadUrls(modelId, filteredSiblings, domain);
+}
+
+function getString(value: any): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function firstString(...values: any[]): string | undefined {
+  for (const value of values) {
+    const text = getString(value);
+    if (text) {
+      return text;
+    }
+  }
+
+  return undefined;
+}
+
+function getHFModelAvatar(model: HuggingFaceModel): string | undefined {
+  const author = getString(model.author);
+
+  return firstString(
+    model.avatarUrl,
+    (model as any).avatar_url,
+    (model as any).avatar,
+    (model as any).authorData?.avatarUrl,
+    (model as any).authorData?.avatar_url,
+    (model as any).authorData?.avatar,
+    (model as any).owner?.avatarUrl,
+    (model as any).owner?.avatar_url,
+    (model as any).owner?.avatar,
+    author ? `${urls.modelWebPage(author)}.png` : undefined,
+  );
 }
 
 /**
@@ -64,11 +105,24 @@ export function normalizeModelSiblings(
  */
 export function processHFSearchResults(
   models: HuggingFaceModel[],
+  options?: {
+    source?: ModelSourceId;
+    domain?: string;
+  },
 ): HuggingFaceModel[] {
   return models.map(model => ({
     ...model,
-    url: urls.modelWebPage(model.id),
-    siblings: normalizeModelSiblings(model.id, model.siblings || []),
+    source: options?.source || model.source || 'huggingface',
+    sourceRepoId: model.sourceRepoId || model.id,
+    url: options?.domain
+      ? urls.hfCompatibleModelWebPage(options.domain, model.id)
+      : urls.modelWebPage(model.id),
+    avatarUrl: getHFModelAvatar(model),
+    siblings: normalizeModelSiblings(
+      model.id,
+      model.siblings || [],
+      options?.domain,
+    ),
   }));
 }
 
@@ -81,6 +135,7 @@ export function processHFSearchResults(
 export function createSiblingsFromFileDetails(
   modelId: string,
   fileDetails: any[],
+  domain?: string,
 ): ModelFile[] {
   // Convert file details to siblings format
   const siblings = fileDetails.map(file => ({
@@ -91,7 +146,7 @@ export function createSiblingsFromFileDetails(
   }));
 
   // Apply the same normalization as HFStore
-  return normalizeModelSiblings(modelId, siblings);
+  return normalizeModelSiblings(modelId, siblings, domain);
 }
 
 /**

--- a/src/utils/hf.ts
+++ b/src/utils/hf.ts
@@ -4,24 +4,218 @@
  */
 
 import {urls} from '../config';
-import type {HuggingFaceModel, ModelFile, ModelSourceId} from './types';
+import type {
+  HuggingFaceModel,
+  ModelFile,
+  SplitModelFile,
+  ModelSourceId,
+} from './types';
 
 // Regex pattern for detecting sharded GGUF files
 const RE_GGUF_SHARD_FILE =
-  /^(?<prefix>.*?)-(?<shard>\d{5})-of-(?<total>\d{5})\.gguf$/;
+  /^(?<prefix>.*?)-(?<shard>\d{5})-of-(?<total>\d{5})\.gguf$/i;
+
+type ParsedGGUFShard = {
+  prefix: string;
+  shard: number;
+  total: number;
+};
+
+function parseGGUFShardFilename(filename: string): ParsedGGUFShard | null {
+  const match = filename.match(RE_GGUF_SHARD_FILE);
+  if (!match?.groups) {
+    return null;
+  }
+
+  const shard = Number(match.groups.shard);
+  const total = Number(match.groups.total);
+  if (!Number.isInteger(shard) || !Number.isInteger(total)) {
+    return null;
+  }
+
+  if (shard < 1 || total < 2 || shard > total) {
+    return null;
+  }
+
+  return {
+    prefix: match.groups.prefix,
+    shard,
+    total,
+  };
+}
+
+function getShardGroupKey(filename: string, parsed: ParsedGGUFShard): string {
+  const slashIndex = filename.lastIndexOf('/');
+  const dir = slashIndex >= 0 ? filename.slice(0, slashIndex + 1) : '';
+  return `${dir}${parsed.prefix}|${parsed.total}`;
+}
+
+function getDisplayFilename(firstPartFilename: string): string {
+  const parsed = parseGGUFShardFilename(firstPartFilename);
+  if (!parsed) {
+    return firstPartFilename;
+  }
+
+  const suffix = `-00001-of-${String(parsed.total).padStart(5, '0')}.gguf`;
+  return firstPartFilename.endsWith(suffix)
+    ? firstPartFilename.slice(0, -suffix.length)
+    : firstPartFilename;
+}
+
+function sortShardFiles(files: ModelFile[]): ModelFile[] {
+  return [...files].sort((a, b) => {
+    const aShard = parseGGUFShardFilename(a.rfilename)?.shard ?? 0;
+    const bShard = parseGGUFShardFilename(b.rfilename)?.shard ?? 0;
+    return aShard - bShard;
+  });
+}
+
+export function getSplitDownloadRequiredSpace(file: ModelFile): number {
+  if (!file.split) {
+    return file.size || 0;
+  }
+
+  return file.split.totalSize || file.size || 0;
+}
+
+export function firstSplitPartFilename(file: ModelFile): string {
+  return file.split?.entryRFilename || file.rfilename;
+}
+
+export function expandSplitModelFile(file: ModelFile): ModelFile[] {
+  if (!file.split) {
+    return [file];
+  }
+
+  return file.split.parts.map(part => ({
+    rfilename: part.rfilename,
+    size: part.size,
+    url: part.url,
+    oid: part.oid,
+    lfs: part.lfs,
+  }));
+}
+
+export function normalizeGGUFModelFiles(files: ModelFile[]): ModelFile[] {
+  const regularFiles: ModelFile[] = [];
+  const splitFiles: ModelFile[] = [];
+  const shardGroups = new Map<
+    string,
+    {total: number; parts: Map<number, ModelFile>}
+  >();
+
+  for (const file of files || []) {
+    const filename = file.rfilename || '';
+    const lowerFilename = filename.toLowerCase();
+    if (!lowerFilename.endsWith('.gguf')) {
+      continue;
+    }
+
+    if (file.split) {
+      const sortedParts = [...file.split.parts].sort(
+        (a, b) => a.index - b.index,
+      );
+      if (sortedParts.length !== file.split.totalParts || !sortedParts[0]) {
+        continue;
+      }
+
+      const firstPart = sortedParts[0];
+      const entryRFilename =
+        file.split.entryRFilename || firstPart.rfilename || file.rfilename;
+      const totalSize =
+        file.split.totalSize ||
+        sortedParts.reduce(
+          (sum, part) => sum + (part.size || part.lfs?.size || 0),
+          0,
+        );
+
+      splitFiles.push({
+        ...file,
+        rfilename: entryRFilename,
+        size: totalSize || file.size,
+        url: firstPart.url || file.url,
+        oid: firstPart.oid || file.oid,
+        lfs: firstPart.lfs || file.lfs,
+        split: {
+          ...file.split,
+          entryRFilename,
+          displayRFilename:
+            file.split.displayRFilename || getDisplayFilename(entryRFilename),
+          totalSize: totalSize > 0 ? totalSize : file.split.totalSize,
+          parts: sortedParts,
+        },
+      });
+      continue;
+    }
+
+    const parsed = parseGGUFShardFilename(filename);
+    if (!parsed) {
+      regularFiles.push(file);
+      continue;
+    }
+
+    const key = getShardGroupKey(filename, parsed);
+    const group = shardGroups.get(key) || {
+      total: parsed.total,
+      parts: new Map<number, ModelFile>(),
+    };
+    if (group.total === parsed.total) {
+      group.parts.set(parsed.shard, file);
+      shardGroups.set(key, group);
+    }
+  }
+
+  for (const group of shardGroups.values()) {
+    if (group.parts.size !== group.total) {
+      continue;
+    }
+
+    const parts = Array.from(group.parts.values());
+    const sortedParts = sortShardFiles(parts);
+    const firstPart = sortedParts[0];
+    const totalSize = sortedParts.reduce(
+      (sum, part) => sum + (part.size || part.lfs?.size || 0),
+      0,
+    );
+    const split: SplitModelFile = {
+      entryRFilename: firstPart.rfilename,
+      displayRFilename: getDisplayFilename(firstPart.rfilename),
+      totalSize: totalSize > 0 ? totalSize : undefined,
+      totalParts: group.total,
+      parts: sortedParts.map(part => {
+        const parsed = parseGGUFShardFilename(part.rfilename)!;
+        return {
+          rfilename: part.rfilename,
+          index: parsed.shard,
+          total: parsed.total,
+          size: part.size || part.lfs?.size,
+          url: part.url,
+          oid: part.oid,
+          lfs: part.lfs,
+        };
+      }),
+    };
+
+    splitFiles.push({
+      rfilename: firstPart.rfilename,
+      size: split.totalSize,
+      url: firstPart.url,
+      oid: firstPart.oid,
+      lfs: firstPart.lfs,
+      split,
+    });
+  }
+
+  return [...regularFiles, ...splitFiles];
+}
 
 /**
- * Filters out non-GGUF and sharded GGUF files from model siblings
+ * Filters out non-GGUF files and aggregates complete GGUF split sets.
  * @param siblings - Array of model files/siblings
  * @returns Filtered array containing only valid GGUF files
  */
 export function filterValidGGUFFiles(siblings: any[]): any[] {
-  return (
-    siblings?.filter(sibling => {
-      const filename = sibling.rfilename?.toLowerCase() || '';
-      return filename.endsWith('.gguf') && !RE_GGUF_SHARD_FILE.test(filename);
-    }) || []
-  );
+  return normalizeGGUFModelFiles(siblings || []);
 }
 
 /**
@@ -40,6 +234,21 @@ export function addModelFileDownloadUrls(
     url: domain
       ? urls.hfCompatibleModelDownloadFile(domain, modelId, sibling.rfilename)
       : urls.modelDownloadFile(modelId, sibling.rfilename),
+    split: sibling.split
+      ? {
+          ...sibling.split,
+          parts: sibling.split.parts.map((part: any) => ({
+            ...part,
+            url: domain
+              ? urls.hfCompatibleModelDownloadFile(
+                  domain,
+                  modelId,
+                  part.rfilename,
+                )
+              : urls.modelDownloadFile(modelId, part.rfilename),
+          })),
+        }
+      : undefined,
   }));
 }
 
@@ -143,6 +352,7 @@ export function createSiblingsFromFileDetails(
     size: file.size,
     oid: file.oid,
     lfs: file.lfs,
+    split: file.split,
   }));
 
   // Apply the same normalization as HFStore

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,6 +38,7 @@ import {
   MODEL_SOURCE_ORIGIN,
   stripSourceScope,
 } from './modelSources';
+import {firstSplitPartFilename, getSplitDownloadRequiredSpace} from './hf';
 
 export const L10nContext = React.createContext<
   (typeof l10n)[keyof typeof l10n]
@@ -344,7 +345,15 @@ export const getModelDescription = (
 
 export async function hasEnoughSpace(model: Model): Promise<boolean> {
   try {
-    let requiredSpaceBytes = model.size;
+    let requiredSpaceBytes = model.splitDownload
+      ? getSplitDownloadRequiredSpace(
+          model.hfModelFile || {
+            rfilename: model.filename,
+            size: model.size,
+            split: model.splitDownload,
+          },
+        )
+      : model.size;
 
     // For vision models, consider the total size including projection model
     if (model.supportsMultimodal && model.hfModelFile && model.hfModel) {
@@ -408,7 +417,10 @@ export function extractHFModelType(modelId: string): string {
 export function extractHFModelTitle(modelId: string): string {
   const unscopedModelId = stripSourceScope(modelId);
   // Remove "GGUF", "-GGUF", or "_GGUF" at the end regardless of case
-  const sanitizedModelId = unscopedModelId.replace(/[-_]?[Gg][Gg][Uu][Ff]$/, '');
+  const sanitizedModelId = unscopedModelId.replace(
+    /(?:[-_.]?[Gg][Gg][Uu][Ff])$/,
+    '',
+  );
 
   // If there is no "/" in the modelId, ie owner is not included, return sanitizedModelId
   if (!sanitizedModelId.includes('/')) {
@@ -447,8 +459,8 @@ export function hfAsModel(
     const mmprojFiles = getMmprojFiles(hfModel.siblings || []);
 
     // Convert to model IDs
-    compatibleProjectionModels = mmprojFiles.map(
-      file => buildSourceModelId(source, repoId, file.rfilename),
+    compatibleProjectionModels = mmprojFiles.map(file =>
+      buildSourceModelId(source, repoId, file.rfilename),
     );
 
     // Set default projection model based on quantization matching
@@ -477,11 +489,13 @@ export function hfAsModel(
   const sourceWebUrl = hfModel.url ?? '';
 
   const _model: Model = {
-    id: `${scopedRepoId}/${modelFile.rfilename}`,
+    id: `${scopedRepoId}/${firstSplitPartFilename(modelFile)}`,
     type: extractHFModelType(repoId),
     author: hfModel.author,
     repo: repo,
-    name: extractHFModelTitle(modelFile.rfilename),
+    name: extractHFModelTitle(
+      modelFile.split?.displayRFilename || modelFile.rfilename,
+    ),
     size: modelFile.size ?? 0,
     params: hfModel.specs?.gguf?.total ?? 0,
     isDownloaded: false,
@@ -491,7 +505,7 @@ export function hfAsModel(
     sourceRepoId: repoId,
     sourceWebUrl,
     progress: 0,
-    filename: modelFile.rfilename,
+    filename: firstSplitPartFilename(modelFile),
     capabilities: isVisionLLM ? ['vision'] : undefined,
     //fullPath: '',
     isLocal: false,
@@ -504,6 +518,7 @@ export function hfAsModel(
     stopWords: defaultSettings.completionParams.stop,
     hfModelFile: modelFile,
     hfModel: hfModel,
+    splitDownload: modelFile.split,
 
     // Set multimodal fields
     supportsMultimodal: isVisionLLM,
@@ -572,11 +587,9 @@ export const checkModelFileIntegrity = async (
   try {
     // For HF models, if we don't have lfs details, fetch them
     if (
-      [
-        ModelOrigin.HF,
-        ModelOrigin.HF_MIRROR,
-        ModelOrigin.MODELSCOPE,
-      ].includes(model.origin) &&
+      [ModelOrigin.HF, ModelOrigin.HF_MIRROR, ModelOrigin.MODELSCOPE].includes(
+        model.origin,
+      ) &&
       !model.hfModelFile?.lfs?.size
     ) {
       await modelStore.fetchAndUpdateModelFileDetails(model);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,7 @@ import {
   Model,
   ModelFile,
   ModelOrigin,
+  ModelSourceId,
   ModelType,
   PreviewImage,
   User,
@@ -30,6 +31,13 @@ import {
   getRecommendedProjectionModel,
   getVisionModelSizeBreakdown,
 } from './multimodalHelpers';
+import {
+  buildSourceModelId,
+  getRepoNameFromModelId,
+  getSourceScopedRepoId,
+  MODEL_SOURCE_ORIGIN,
+  stripSourceScope,
+} from './modelSources';
 
 export const L10nContext = React.createContext<
   (typeof l10n)[keyof typeof l10n]
@@ -398,8 +406,9 @@ export function extractHFModelType(modelId: string): string {
 }
 
 export function extractHFModelTitle(modelId: string): string {
+  const unscopedModelId = stripSourceScope(modelId);
   // Remove "GGUF", "-GGUF", or "_GGUF" at the end regardless of case
-  const sanitizedModelId = modelId.replace(/[-_]?[Gg][Gg][Uu][Ff]$/, '');
+  const sanitizedModelId = unscopedModelId.replace(/[-_]?[Gg][Gg][Uu][Ff]$/, '');
 
   // If there is no "/" in the modelId, ie owner is not included, return sanitizedModelId
   if (!sanitizedModelId.includes('/')) {
@@ -416,6 +425,9 @@ export function hfAsModel(
   modelFile: ModelFile,
 ): Model {
   const defaultSettings = getHFDefaultSettings(hfModel);
+  const source: ModelSourceId = hfModel.source || 'huggingface';
+  const repoId = hfModel.sourceRepoId || hfModel.id;
+  const scopedRepoId = getSourceScopedRepoId(source, repoId);
 
   // Check if this is a vision repository
   const isVision = isVisionRepo(hfModel.siblings || []);
@@ -436,7 +448,7 @@ export function hfAsModel(
 
     // Convert to model IDs
     compatibleProjectionModels = mmprojFiles.map(
-      file => `${hfModel.id}/${file.rfilename}`,
+      file => buildSourceModelId(source, repoId, file.rfilename),
     );
 
     // Set default projection model based on quantization matching
@@ -451,18 +463,22 @@ export function hfAsModel(
       );
 
       if (recommendedFile) {
-        defaultProjectionModel = `${hfModel.id}/${recommendedFile}`;
+        defaultProjectionModel = buildSourceModelId(
+          source,
+          repoId,
+          recommendedFile,
+        );
       }
     }
   }
 
-  // Extract repo from hfModel.id (format: "author/repo-name")
-  const repoParts = hfModel.id.split('/');
-  const repo = repoParts.length >= 2 ? repoParts[1] : undefined;
+  // Extract repo from the source repository id (format: "author/repo-name")
+  const repo = getRepoNameFromModelId(repoId);
+  const sourceWebUrl = hfModel.url ?? '';
 
   const _model: Model = {
-    id: hfModel.id + '/' + modelFile.rfilename,
-    type: extractHFModelType(hfModel.id),
+    id: `${scopedRepoId}/${modelFile.rfilename}`,
+    type: extractHFModelType(repoId),
     author: hfModel.author,
     repo: repo,
     name: extractHFModelTitle(modelFile.rfilename),
@@ -470,13 +486,16 @@ export function hfAsModel(
     params: hfModel.specs?.gguf?.total ?? 0,
     isDownloaded: false,
     downloadUrl: modelFile.url ?? '',
-    hfUrl: hfModel.url ?? '',
+    hfUrl: sourceWebUrl,
+    source,
+    sourceRepoId: repoId,
+    sourceWebUrl,
     progress: 0,
     filename: modelFile.rfilename,
     capabilities: isVisionLLM ? ['vision'] : undefined,
     //fullPath: '',
     isLocal: false,
-    origin: ModelOrigin.HF,
+    origin: MODEL_SOURCE_ORIGIN[source],
     defaultChatTemplate: defaultSettings.chatTemplate,
     chatTemplate: _.cloneDeep(defaultSettings.chatTemplate),
     defaultCompletionSettings: defaultSettings.completionParams,
@@ -519,8 +538,8 @@ export function inferRepoFromModelId(modelId: string): string | undefined {
   if (!modelId) {
     return undefined;
   }
-  const parts = modelId.split('/');
-  // HF model IDs should have at least 3 parts: author/repo/filename
+
+  const parts = stripSourceScope(modelId).split('/');
   return parts.length >= 3 ? parts[1] : undefined;
 }
 
@@ -552,7 +571,14 @@ export const checkModelFileIntegrity = async (
 }> => {
   try {
     // For HF models, if we don't have lfs details, fetch them
-    if (model.origin === ModelOrigin.HF && !model.hfModelFile?.lfs?.size) {
+    if (
+      [
+        ModelOrigin.HF,
+        ModelOrigin.HF_MIRROR,
+        ModelOrigin.MODELSCOPE,
+      ].includes(model.origin) &&
+      !model.hfModelFile?.lfs?.size
+    ) {
       await modelStore.fetchAndUpdateModelFileDetails(model);
     }
 

--- a/src/utils/llamaErrors.ts
+++ b/src/utils/llamaErrors.ts
@@ -1,0 +1,28 @@
+export const LLAMA_NATIVE_BINDINGS_UNAVAILABLE_MESSAGE =
+  'The native model runtime is unavailable. Update or reinstall the app, then try again.';
+
+export function getErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String((error as {message: unknown}).message);
+  }
+
+  return undefined;
+}
+
+export function isLlamaJsiBindingsError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+
+  return (
+    !!message &&
+    (/JSI bindings not installed/i.test(message) ||
+      /Missing JSI bindings/i.test(message))
+  );
+}

--- a/src/utils/memorySettings.ts
+++ b/src/utils/memorySettings.ts
@@ -1,5 +1,6 @@
 import {Platform} from 'react-native';
 import {loadLlamaModelInfo} from 'llama.rn';
+import {isLlamaJsiBindingsError} from './llamaErrors';
 
 /**
  * Quantization types that are repackable and should use use_mmap=false
@@ -80,6 +81,10 @@ export async function isRepackableQuantization(
 
     return false;
   } catch (error) {
+    if (isLlamaJsiBindingsError(error)) {
+      return false;
+    }
+
     console.warn(
       'Failed to detect quantization type, defaulting to false:',
       error,

--- a/src/utils/modelSources.ts
+++ b/src/utils/modelSources.ts
@@ -1,0 +1,79 @@
+import {Model, ModelOrigin, ModelSourceId} from './types';
+
+export const DEFAULT_MODEL_SOURCE: ModelSourceId = 'huggingface';
+
+export const MODEL_SOURCE_IDS: ModelSourceId[] = [
+  'huggingface',
+  'hf_mirror',
+  'modelscope',
+];
+
+export const MODEL_SOURCE_STORAGE_DIR: Record<ModelSourceId, string> = {
+  huggingface: 'hf',
+  hf_mirror: 'hf-mirror',
+  modelscope: 'modelscope',
+};
+
+export const MODEL_SOURCE_ORIGIN: Record<ModelSourceId, ModelOrigin> = {
+  huggingface: ModelOrigin.HF,
+  hf_mirror: ModelOrigin.HF_MIRROR,
+  modelscope: ModelOrigin.MODELSCOPE,
+};
+
+export const MODEL_ORIGIN_SOURCE: Partial<Record<ModelOrigin, ModelSourceId>> =
+  {
+    [ModelOrigin.HF]: 'huggingface',
+    [ModelOrigin.HF_MIRROR]: 'hf_mirror',
+    [ModelOrigin.MODELSCOPE]: 'modelscope',
+  };
+
+export function getModelSourceFromOrigin(
+  origin?: ModelOrigin,
+): ModelSourceId {
+  return origin
+    ? MODEL_ORIGIN_SOURCE[origin] || DEFAULT_MODEL_SOURCE
+    : DEFAULT_MODEL_SOURCE;
+}
+
+export function getModelSource(model?: Partial<Model>): ModelSourceId {
+  return model?.source || getModelSourceFromOrigin(model?.origin);
+}
+
+export function getSourceScopedRepoId(
+  source: ModelSourceId,
+  repoId: string,
+): string {
+  return source === DEFAULT_MODEL_SOURCE ? repoId : `${source}:${repoId}`;
+}
+
+export function stripSourceScope(value: string): string {
+  const match = value.match(/^(huggingface|hf_mirror|modelscope):(.+)$/);
+  return match ? match[2] : value;
+}
+
+export function buildSourceModelId(
+  source: ModelSourceId,
+  repoId: string,
+  filename: string,
+): string {
+  return `${getSourceScopedRepoId(source, repoId)}/${filename}`;
+}
+
+export function getRepoIdFromModelId(modelId: string): string | undefined {
+  if (!modelId) {
+    return undefined;
+  }
+
+  const scoped = stripSourceScope(modelId);
+  const parts = scoped.split('/');
+  return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : undefined;
+}
+
+export function getRepoNameFromModelId(modelId: string): string | undefined {
+  const repoId = getRepoIdFromModelId(modelId);
+  return repoId?.split('/')[1];
+}
+
+export function getSourceStorageDir(source: ModelSourceId): string {
+  return MODEL_SOURCE_STORAGE_DIR[source];
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -446,8 +446,12 @@ export enum ModelOrigin {
   PRESET = 'preset',
   LOCAL = 'local',
   HF = 'hf',
+  HF_MIRROR = 'hf_mirror',
+  MODELSCOPE = 'modelscope',
   REMOTE = 'remote',
 }
+
+export type ModelSourceId = 'huggingface' | 'hf_mirror' | 'modelscope';
 
 export interface ServerConfig {
   id: string;
@@ -491,6 +495,9 @@ export interface Model {
   isDownloaded: boolean;
   downloadUrl: string;
   hfUrl: string;
+  source?: ModelSourceId;
+  sourceRepoId?: string;
+  sourceWebUrl?: string;
   progress: number; // Progress as a percentage
   downloadSpeed?: string;
   filename: string;
@@ -575,6 +582,11 @@ export interface HuggingFaceModel {
   model_id: string;
   siblings: ModelFile[];
   url?: string;
+  source?: ModelSourceId;
+  sourceRepoId?: string;
+  avatarUrl?: string;
+  description?: string;
+  modelSize?: number;
   specs?: GGUFSpecs;
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -531,6 +531,7 @@ export interface Model {
   completionSettings: CompletionParams;
   hfModelFile?: ModelFile;
   hfModel?: HuggingFaceModel;
+  splitDownload?: SplitModelFile;
   hash?: string;
 
   // Remote model fields (for models from OpenAI-compatible servers)
@@ -561,6 +562,29 @@ export interface ModelFile {
     pointerSize: number;
   };
   canFitInStorage?: boolean;
+  split?: SplitModelFile;
+}
+
+export interface SplitModelFilePart {
+  rfilename: string;
+  index: number;
+  total: number;
+  size?: number;
+  url?: string;
+  oid?: string;
+  lfs?: {
+    oid: string;
+    size: number;
+    pointerSize: number;
+  };
+}
+
+export interface SplitModelFile {
+  entryRFilename: string;
+  displayRFilename: string;
+  totalSize?: number;
+  totalParts: number;
+  parts: SplitModelFilePart[];
 }
 
 // Model data from HuggingFace search models
@@ -605,6 +629,7 @@ export interface ModelFileDetails {
     pointerSize: number;
   };
   path: string;
+  split?: SplitModelFile;
 }
 
 export interface GGUFSpecs {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "useDefineForClassFields": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
-  "exclude": ["node_modules", "e2e"]
+  "exclude": ["node_modules", "e2e", "pr-work"]
 }


### PR DESCRIPTION
## Summary
- Adds Hugging Face compatible model source plumbing, including ModelScope search/details and source-aware model IDs.
- Supports complete split GGUF model sets by showing them as one downloadable model, downloading every part, loading from the first part, validating all parts, and deleting all parts together.
- Improves Android download/build reliability with native download persistence, Tencent Gradle mirrors, configurable Metro worker count, ABI filtering, WatermelonDB JSI inclusion, and native-library packaging fixes.

## Verification
- npx tsc --noEmit
- npx jest --runTestsByPath src/utils/__tests__/utils.test.ts src/services/downloads/__tests__/DownloadManager.test.ts src/store/__tests__/ModelStore.test.ts src/store/__tests__/HFStore.test.ts src/api/modelSources/__tests__/modelSources.test.ts --runInBand --coverage=false
- npx prettier --check __mocks__/external/@dr.pogodin/react-native-fs.js jest.config.js package.json src/api/__tests__/hf.test.ts src/api/modelSources/modelscope.ts src/services/downloads/DownloadManager.ts src/services/downloads/__tests__/DownloadManager.test.ts src/services/downloads/types.ts src/store/HFStore.ts src/store/ModelStore.ts src/store/__tests__/ModelStore.test.ts src/utils/__tests__/utils.test.ts src/utils/hf.ts src/utils/index.ts src/utils/types.ts tsconfig.json
- git diff --check

## Notes
- Split GGUF files are not concatenated. The app stores every part in its repository-relative path and loads the first split file, letting llama.cpp resolve the remaining parts.
- The branch also keeps the earlier native-library fixes for Android runtime packaging, including WatermelonDB JSI, worklets pickFirst, and the onnxruntime 16 KB page-alignment patch.