### PR TITLE
[Bug]: PalsHub email sign-up/sign-in no longer claims success on failure

### DIFF
--- a/__mocks__/services/palshub/AuthService.js
+++ b/__mocks__/services/palshub/AuthService.js
@@ -19,16 +19,16 @@ const mockAuthService = {
   isInitialized: true,
 
   // Methods
-  signInWithEmail: jest.fn().mockResolvedValue(undefined),
+  signInWithEmail: jest.fn().mockResolvedValue(true),
 
-  signUpWithEmail: jest.fn().mockResolvedValue(undefined),
+  signUpWithEmail: jest.fn().mockResolvedValue(true),
 
   signInWithGoogle: jest.fn().mockResolvedValue({
     success: true,
     user: mockProfile,
   }),
 
-  resetPassword: jest.fn().mockResolvedValue(undefined),
+  resetPassword: jest.fn().mockResolvedValue(true),
 
   signOut: jest.fn().mockResolvedValue({
     success: true,

--- a/src/components/PalsHub/AuthSheet/AuthSheet.tsx
+++ b/src/components/PalsHub/AuthSheet/AuthSheet.tsx
@@ -58,21 +58,25 @@ export const AuthSheet: React.FC<AuthSheetProps> = observer(
         authService.clearError();
 
         if (isSignUp) {
-          await authService.signUpWithEmail(
+          const ok = await authService.signUpWithEmail(
             email.trim(),
             password,
             fullName.trim(),
           );
-          Alert.alert(
-            'Account Created',
-            'Please check your email to verify your account.',
-            [{text: 'OK', onPress: onClose}],
-          );
+          if (ok) {
+            Alert.alert(
+              'Account Created',
+              'Please check your email to verify your account.',
+              [{text: 'OK', onPress: onClose}],
+            );
+          }
         } else {
-          await authService.signInWithEmail(email.trim(), password);
-          Alert.alert('Welcome Back!', 'You have successfully signed in.', [
-            {text: 'OK', onPress: onClose},
-          ]);
+          const ok = await authService.signInWithEmail(email.trim(), password);
+          if (ok) {
+            Alert.alert('Welcome Back!', 'You have successfully signed in.', [
+              {text: 'OK', onPress: onClose},
+            ]);
+          }
         }
       } catch (error) {
         const errorInfo = PalsHubErrorHandler.handle(error);
@@ -105,12 +109,14 @@ export const AuthSheet: React.FC<AuthSheetProps> = observer(
 
       try {
         setIsLoading(true);
-        await authService.resetPassword(email.trim());
-        Alert.alert(
-          'Password Reset',
-          'Check your email for password reset instructions.',
-          [{text: 'OK'}],
-        );
+        const ok = await authService.resetPassword(email.trim());
+        if (ok) {
+          Alert.alert(
+            'Password Reset',
+            'Check your email for password reset instructions.',
+            [{text: 'OK'}],
+          );
+        }
       } catch (error) {
         const errorInfo = PalsHubErrorHandler.handle(error);
         Alert.alert('Error', errorInfo.userMessage);

--- a/src/components/PalsHub/AuthSheet/__tests__/AuthSheet.test.tsx
+++ b/src/components/PalsHub/AuthSheet/__tests__/AuthSheet.test.tsx
@@ -136,6 +136,25 @@ describe('AuthSheet', () => {
       });
     });
 
+    it('does not show "Welcome Back!" when sign-in fails', async () => {
+      (authService.signInWithEmail as jest.Mock).mockResolvedValueOnce(false);
+
+      const {getByTestId, getByText} = render(<AuthSheet {...defaultProps} />);
+
+      fireEvent.changeText(getByTestId('email-input'), 'test@example.com');
+      fireEvent.changeText(getByTestId('password-input'), 'wrongpass');
+      fireEvent.press(getByText('Sign In'));
+
+      await waitFor(() => {
+        expect(authService.signInWithEmail).toHaveBeenCalled();
+      });
+      expect(Alert.alert).not.toHaveBeenCalledWith(
+        'Welcome Back!',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
     it('shows error alert when email is empty', async () => {
       const {getByTestId, getByText} = render(<AuthSheet {...defaultProps} />);
 
@@ -263,6 +282,27 @@ describe('AuthSheet', () => {
           expect.any(Array),
         );
       });
+    });
+
+    it('does not show "Account Created" when sign-up fails', async () => {
+      (authService.signUpWithEmail as jest.Mock).mockResolvedValueOnce(false);
+
+      const {getByTestId, getByText} = render(<AuthSheet {...defaultProps} />);
+      fireEvent.press(getByText('Sign Up'));
+
+      fireEvent.changeText(getByTestId('full-name-input'), 'Test User');
+      fireEvent.changeText(getByTestId('email-input'), 'test@example.com');
+      fireEvent.changeText(getByTestId('password-input'), '123');
+      fireEvent.press(getByText('Create Account'));
+
+      await waitFor(() => {
+        expect(authService.signUpWithEmail).toHaveBeenCalled();
+      });
+      expect(Alert.alert).not.toHaveBeenCalledWith(
+        'Account Created',
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     it('shows error alert when full name is empty during sign up', async () => {

--- a/src/services/palshub/AuthService.ts
+++ b/src/services/palshub/AuthService.ts
@@ -288,12 +288,12 @@ class AuthService {
     }
   }
 
-  async signInWithEmail(email: string, password: string) {
+  async signInWithEmail(email: string, password: string): Promise<boolean> {
     if (!this.isSupabaseConfigured()) {
       runInAction(() => {
         this.error = 'Authentication not configured';
       });
-      return;
+      return false;
     }
 
     try {
@@ -312,12 +312,15 @@ class AuthService {
           this.error = error.message;
         });
         console.error('Email sign-in error:', error);
+        return false;
       }
+      return true;
     } catch (error) {
       runInAction(() => {
         this.error = 'Failed to sign in with email';
       });
       console.error('Email sign-in error:', error);
+      return false;
     } finally {
       runInAction(() => {
         this.isLoading = false;
@@ -325,12 +328,16 @@ class AuthService {
     }
   }
 
-  async signUpWithEmail(email: string, password: string, fullName?: string) {
+  async signUpWithEmail(
+    email: string,
+    password: string,
+    fullName?: string,
+  ): Promise<boolean> {
     if (!this.isSupabaseConfigured()) {
       runInAction(() => {
         this.error = 'Authentication not configured';
       });
-      return;
+      return false;
     }
 
     try {
@@ -354,12 +361,15 @@ class AuthService {
           this.error = error.message;
         });
         console.error('Email sign-up error:', error);
+        return false;
       }
+      return true;
     } catch (error) {
       runInAction(() => {
         this.error = 'Failed to sign up with email';
       });
       console.error('Email sign-up error:', error);
+      return false;
     } finally {
       runInAction(() => {
         this.isLoading = false;
@@ -401,12 +411,12 @@ class AuthService {
     }
   }
 
-  async resetPassword(email: string) {
+  async resetPassword(email: string): Promise<boolean> {
     if (!this.isSupabaseConfigured()) {
       runInAction(() => {
         this.error = 'Authentication not configured';
       });
-      return;
+      return false;
     }
 
     try {
@@ -424,12 +434,15 @@ class AuthService {
           this.error = error.message;
         });
         console.error('Password reset error:', error);
+        return false;
       }
+      return true;
     } catch (error) {
       runInAction(() => {
         this.error = 'Failed to send password reset email';
       });
       console.error('Password reset error:', error);
+      return false;
     } finally {
       runInAction(() => {
         this.isLoading = false;


### PR DESCRIPTION
## Problem

On the PalsHub Create Account / Sign In sheet, a failed email auth still showed a success alert. Entering a too-short password surfaced **all three at once**: the inline "Password should be at least 6 characters" banner, a toast error, **and** a false "Account Created — please check your email" alert. The account was never created.

## Cause

`AuthService.signUpWithEmail` / `signInWithEmail` / `resetPassword` swallowed the Supabase error into `this.error` and returned `void` — they never threw or signalled failure. `AuthSheet` then fired its success alert unconditionally after the `await` (its `catch` only catches thrown errors, and these methods never throw).

## Fix

- The three email-auth methods now return a `Promise<boolean>` (`true` on success, `false` on error).
- `AuthSheet` only shows the "Account Created" / "Welcome Back!" / "Password Reset" alert when the call actually succeeds. On failure the existing inline error banner remains the single error surface, and the sheet stays open so the user can correct the input.

## Tests

- Added false-case coverage: failed sign-in shows no "Welcome Back!", failed sign-up shows no "Account Created".
- Updated the centralized auth mock to reflect the new boolean contract.
- Full Jest suite green (3160 passed); no native changes.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)