### PR TITLE
[Bug]: Stopping a download no longer shows "Download Failed" dialog

### DIFF
--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -252,7 +252,8 @@ export const Selectors = {
     // Dynamic: model item by ID
     modelItem: (id: string): string => byTestId(`hf-model-item-${id}`),
     // Find model item by partial accessibilityLabel match (targets the TouchableOpacity)
-    modelItemByText: (text: string): string => byAccessibilityLabelContains(text),
+    modelItemByText: (text: string): string =>
+      byAccessibilityLabelContains(text),
   },
 
   // Model details/file cards
@@ -322,6 +323,22 @@ export const Selectors = {
       }
       // iOS: Use predicate string for nested element search
       return `-ios predicate string:name == "load-button"`;
+    },
+    // Download button element selector for use within a model card context
+    get downloadButtonElement(): string {
+      if (isAndroid()) {
+        return `.//android.widget.Button[contains(@resource-id, "download-button")]`;
+      }
+      return `-ios predicate string:name == "download-button"`;
+    },
+    // Cancel button element selector for use within a model card context.
+    // Filters to the Button class so it targets the clickable control rather
+    // than the surrounding "cancel-button-container" wrapper.
+    get cancelButtonElement(): string {
+      if (isAndroid()) {
+        return `.//android.widget.Button[contains(@resource-id, "cancel-button")]`;
+      }
+      return `-ios predicate string:name == "cancel-button"`;
     },
     get offloadButton(): string {
       return byTestId('offload-button');

--- a/e2e/specs/features/download-cancel.spec.ts
+++ b/e2e/specs/features/download-cancel.spec.ts
@@ -9,6 +9,11 @@
  * modelStore.downloadError and pop the DownloadErrorDialog ("Download has been
  * aborted" + "Try again").
  *
+ * Flow: download a default model straight from the Models screen and cancel on
+ * the same card. Download + cancel happen on one card with no navigation, so
+ * the in-progress window is caught reliably, and the card's cancel control is a
+ * Paper Button that resolves on both platforms.
+ *
  * Usage:
  *   yarn test:ios:local --spec specs/features/download-cancel.spec.ts
  *   yarn test:android:local --spec specs/features/download-cancel.spec.ts
@@ -20,34 +25,30 @@ import {expect} from '@wdio/globals';
 import {ChatPage} from '../../pages/ChatPage';
 import {DrawerPage} from '../../pages/DrawerPage';
 import {ModelsPage} from '../../pages/ModelsPage';
-import {HFSearchSheet} from '../../pages/HFSearchSheet';
-import {ModelDetailsSheet} from '../../pages/ModelDetailsSheet';
 import {Selectors} from '../../helpers/selectors';
-import {TEST_MODELS, TIMEOUTS, ModelTestConfig} from '../../fixtures/models';
+import {TIMEOUTS} from '../../fixtures/models';
 import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
 
 declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;
 
-// A mid-sized model so the download stays in progress long enough to cancel
-// (the cancel happens within ~1s of the cancel button appearing, so only a
-// small fraction is ever fetched before it is aborted).
-const CANCEL_TEST_MODEL: ModelTestConfig =
-  TEST_MODELS.find(m => m.id === 'qwen3-0.6b') ?? TEST_MODELS[0];
+// First default model on the Models screen — large enough (~2.15 GB) that the
+// download stays in progress through the cancel tap. The download is aborted
+// almost immediately, so only a small fraction is ever fetched.
+const TARGET_FILE = 'gemma-2-2b-it-Q6_K.gguf';
+// Default "Available to Download" group is collapsed on first load; its
+// accordion testID uses the localized display name.
+const AVAILABLE_GROUP = 'Available to Download';
 
 describe('Download cancel', () => {
   let chatPage: ChatPage;
   let drawerPage: DrawerPage;
   let modelsPage: ModelsPage;
-  let hfSearchSheet: HFSearchSheet;
-  let modelDetailsSheet: ModelDetailsSheet;
 
   beforeEach(async () => {
     chatPage = new ChatPage();
     drawerPage = new DrawerPage();
     modelsPage = new ModelsPage();
-    hfSearchSheet = new HFSearchSheet();
-    modelDetailsSheet = new ModelDetailsSheet();
 
     await chatPage.waitForReady(TIMEOUTS.appReady);
   });
@@ -70,33 +71,41 @@ describe('Download cancel', () => {
   });
 
   it('stopping an in-progress download shows no error dialog', async () => {
-    const model = CANCEL_TEST_MODEL;
-
-    // Navigate to Models screen
+    // Navigate to the Models screen
     await chatPage.openDrawer();
     await drawerPage.waitForOpen();
     await drawerPage.navigateToModels();
     await modelsPage.waitForReady();
 
-    // Open HuggingFace search and select the model
-    await modelsPage.openHuggingFaceSearch();
-    await hfSearchSheet.waitForReady();
-    await hfSearchSheet.search(model.searchQuery);
-    await hfSearchSheet.selectModel(model.selectorText);
-    await modelDetailsSheet.waitForReady();
+    // Expand the "Available to Download" group (collapsed by default) to reveal
+    // the bundled default models.
+    const accordion = browser.$(
+      Selectors.models.modelAccordion(AVAILABLE_GROUP),
+    );
+    await accordion.waitForDisplayed({timeout: 10000});
+    await accordion.click();
 
-    // Start the download for the target file
-    await modelDetailsSheet.scrollToFile(model.downloadFile);
-    await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+    // Locate the target model card and start its download.
+    const cardContainer = browser.$(
+      Selectors.modelCard.cardContainer(TARGET_FILE),
+    );
+    await cardContainer.waitForDisplayed({timeout: 10000});
+    const downloadButton = cardContainer.$(
+      Selectors.modelCard.downloadButtonElement,
+    );
+    await downloadButton.waitForDisplayed({timeout: 10000});
+    await downloadButton.click();
 
-    // Download started → the file card swaps its download button for a cancel
-    // button. Only one download is active in this test, so the testID is
-    // unambiguous on screen.
-    const cancelButton = browser.$(Selectors.modelDetails.cancelButton);
+    // Download started → the same card swaps its download button for a cancel
+    // button. Scope to the card and the Button class so we target the clickable
+    // control, not the surrounding "cancel-button-container" wrapper.
+    const cancelButton = cardContainer.$(
+      Selectors.modelCard.cancelButtonElement,
+    );
     await cancelButton.waitForDisplayed({timeout: 15000});
     console.log('[download-cancel] download in progress, tapping cancel');
 
-    // Tap Stop/Cancel — this is the user-initiated cancellation under test.
+    // Tap Stop/Cancel — the user-initiated cancellation under test.
     await cancelButton.click();
 
     // Core assertion: NO "Download Failed" dialog appears after cancelling.
@@ -118,12 +127,13 @@ describe('Download cancel', () => {
 
     expect(dialogSeen).toBe(false);
 
-    // The cancel must actually take effect: the cancel button disappears once
-    // the download is torn down (card reverts to the idle download state).
-    await cancelButton.waitForDisplayed({
-      reverse: true,
-      timeout: 10000,
-    });
+    // The cancel must actually take effect: the card reverts to the idle
+    // download state, so the cancel control goes away. Re-query from the root
+    // each poll (a chained element would hold a stale handle once the card
+    // re-renders) and assert no cancel control remains anywhere.
+    await browser
+      .$(Selectors.modelCard.cancelButton)
+      .waitForExist({reverse: true, timeout: 15000});
 
     console.log('[download-cancel] PASS — cancel silent, no error dialog');
   });

--- a/e2e/specs/features/download-cancel.spec.ts
+++ b/e2e/specs/features/download-cancel.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Download Cancel Test
+ *
+ * Verifies that stopping an in-progress model download does NOT surface a
+ * "Download Failed" error dialog. User-initiated cancellation is not a failure.
+ *
+ * Regression coverage for issue #770: on iOS, RNFS.stopDownload rejects the
+ * in-flight download promise; that rejection used to propagate to
+ * modelStore.downloadError and pop the DownloadErrorDialog ("Download has been
+ * aborted" + "Try again").
+ *
+ * Usage:
+ *   yarn test:ios:local --spec specs/features/download-cancel.spec.ts
+ *   yarn test:android:local --spec specs/features/download-cancel.spec.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {expect} from '@wdio/globals';
+import {ChatPage} from '../../pages/ChatPage';
+import {DrawerPage} from '../../pages/DrawerPage';
+import {ModelsPage} from '../../pages/ModelsPage';
+import {HFSearchSheet} from '../../pages/HFSearchSheet';
+import {ModelDetailsSheet} from '../../pages/ModelDetailsSheet';
+import {Selectors} from '../../helpers/selectors';
+import {TEST_MODELS, TIMEOUTS, ModelTestConfig} from '../../fixtures/models';
+import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
+
+declare const driver: WebdriverIO.Browser;
+declare const browser: WebdriverIO.Browser;
+
+// A mid-sized model so the download stays in progress long enough to cancel
+// (the cancel happens within ~1s of the cancel button appearing, so only a
+// small fraction is ever fetched before it is aborted).
+const CANCEL_TEST_MODEL: ModelTestConfig =
+  TEST_MODELS.find(m => m.id === 'qwen3-0.6b') ?? TEST_MODELS[0];
+
+describe('Download cancel', () => {
+  let chatPage: ChatPage;
+  let drawerPage: DrawerPage;
+  let modelsPage: ModelsPage;
+  let hfSearchSheet: HFSearchSheet;
+  let modelDetailsSheet: ModelDetailsSheet;
+
+  beforeEach(async () => {
+    chatPage = new ChatPage();
+    drawerPage = new DrawerPage();
+    modelsPage = new ModelsPage();
+    hfSearchSheet = new HFSearchSheet();
+    modelDetailsSheet = new ModelDetailsSheet();
+
+    await chatPage.waitForReady(TIMEOUTS.appReady);
+  });
+
+  afterEach(async function (this: Mocha.Context) {
+    if (this.currentTest?.state === 'failed') {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const testName = this.currentTest.title.replace(/\s+/g, '-');
+      try {
+        if (!fs.existsSync(SCREENSHOT_DIR)) {
+          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
+        }
+        await driver.saveScreenshot(
+          path.join(SCREENSHOT_DIR, `failure-${testName}-${timestamp}.png`),
+        );
+      } catch (e) {
+        console.error('Failed to capture screenshot:', (e as Error).message);
+      }
+    }
+  });
+
+  it('stopping an in-progress download shows no error dialog', async () => {
+    const model = CANCEL_TEST_MODEL;
+
+    // Navigate to Models screen
+    await chatPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToModels();
+    await modelsPage.waitForReady();
+
+    // Open HuggingFace search and select the model
+    await modelsPage.openHuggingFaceSearch();
+    await hfSearchSheet.waitForReady();
+    await hfSearchSheet.search(model.searchQuery);
+    await hfSearchSheet.selectModel(model.selectorText);
+    await modelDetailsSheet.waitForReady();
+
+    // Start the download for the target file
+    await modelDetailsSheet.scrollToFile(model.downloadFile);
+    await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+
+    // Download started → the file card swaps its download button for a cancel
+    // button. Only one download is active in this test, so the testID is
+    // unambiguous on screen.
+    const cancelButton = browser.$(Selectors.modelDetails.cancelButton);
+    await cancelButton.waitForDisplayed({timeout: 15000});
+    console.log('[download-cancel] download in progress, tapping cancel');
+
+    // Tap Stop/Cancel — this is the user-initiated cancellation under test.
+    await cancelButton.click();
+
+    // Core assertion: NO "Download Failed" dialog appears after cancelling.
+    // Poll for a few seconds to catch the async abort-promise rejection that
+    // used to surface the dialog (issue #770).
+    const errorDialog = browser.$(Selectors.common.downloadErrorDialog);
+    const POLL_MS = 600;
+    const WINDOW_MS = 5000;
+    const start = Date.now();
+    let dialogSeen = false;
+    while (Date.now() - start < WINDOW_MS) {
+      const visible = await errorDialog.isDisplayed().catch(() => false);
+      if (visible) {
+        dialogSeen = true;
+        break;
+      }
+      await browser.pause(POLL_MS);
+    }
+
+    expect(dialogSeen).toBe(false);
+
+    // The cancel must actually take effect: the cancel button disappears once
+    // the download is torn down (card reverts to the idle download state).
+    await cancelButton.waitForDisplayed({
+      reverse: true,
+      timeout: 10000,
+    });
+
+    console.log('[download-cancel] PASS — cancel silent, no error dialog');
+  });
+});

--- a/src/services/downloads/DownloadManager.ts
+++ b/src/services/downloads/DownloadManager.ts
@@ -21,9 +21,8 @@ import type {
 const TAG = 'DownloadManager';
 
 /**
- * Thrown when a download promise rejects because the user cancelled it, as
- * opposed to a genuine failure. Callers use this to distinguish a user cancel
- * (no error surface, no follow-on work) from a real download error.
+ * Signals a user-cancelled download (vs. a genuine failure) so callers can
+ * suppress it: no error surface, no follow-on work.
  */
 export class DownloadCancelledError extends Error {
   constructor(public readonly modelId: string) {
@@ -386,10 +385,8 @@ export class DownloadManager {
         throw new Error(`Download failed with status: ${result.statusCode}`);
       }
     } catch (error) {
-      // A user-initiated cancel rejects this promise (RNFS.stopDownload aborts
-      // the task). That is not a failure — signal it as a distinct cancellation
-      // so callers neither surface an error nor chain follow-on work (e.g. the
-      // projection-model download for multimodal models).
+      // RNFS.stopDownload aborts the task, rejecting this promise. A user
+      // cancel is not a failure — surface it as a distinct cancellation.
       if (this.cancelledModelIds.delete(model.id)) {
         console.log(`${TAG}: Download cancelled by user for ID: ${model.id}`);
         this.downloadJobs.delete(model.id);

--- a/src/services/downloads/DownloadManager.ts
+++ b/src/services/downloads/DownloadManager.ts
@@ -24,6 +24,7 @@ export class DownloadManager {
   private downloadJobs: DownloadMap;
   private callbacks: DownloadEventCallbacks = {};
   private eventEmitter: NativeEventEmitter | null = null;
+  private cancelledModelIds = new Set<string>();
 
   constructor() {
     console.log(`${TAG}: Initializing DownloadManager`);
@@ -370,6 +371,17 @@ export class DownloadManager {
         throw new Error(`Download failed with status: ${result.statusCode}`);
       }
     } catch (error) {
+      // A user-initiated cancel rejects this promise (RNFS.stopDownload aborts
+      // the task). That is not a failure — swallow it silently so it never
+      // reaches the user-facing download error surface.
+      if (this.cancelledModelIds.delete(model.id)) {
+        console.log(
+          `${TAG}: Download cancelled by user for ID: ${model.id}, suppressing error`,
+        );
+        this.downloadJobs.delete(model.id);
+        return;
+      }
+
       console.error(`${TAG}: Download failed for ID: ${model.id}:`, error);
       const job = this.downloadJobs.get(model.id);
       if (job) {
@@ -452,6 +464,9 @@ export class DownloadManager {
     console.log(`${TAG}: Attempting to cancel download:`, modelId);
     const job = this.downloadJobs.get(modelId);
     if (job) {
+      // Mark as user-cancelled so the iOS download promise rejection is
+      // recognised as a cancel, not surfaced as a "Download Failed" error.
+      this.cancelledModelIds.add(modelId);
       try {
         if (Platform.OS === 'ios') {
           console.log(
@@ -467,6 +482,9 @@ export class DownloadManager {
         ) {
           console.log(`${TAG}: Cancelling Android download:`, modelId);
           await NativeDownloadModule.cancelDownload(job.downloadId);
+          // Android cancel emits no failure event, so nothing consumes the
+          // cancelled-id marker — clear it here to avoid leaking entries.
+          this.cancelledModelIds.delete(modelId);
         }
 
         // Clean up the partial download file
@@ -507,6 +525,7 @@ export class DownloadManager {
           modelId,
           error: err instanceof Error ? err.message : String(err),
         });
+        this.cancelledModelIds.delete(modelId);
       }
     } else {
       console.warn(`${TAG}: No download job found to cancel:`, modelId);
@@ -522,6 +541,7 @@ export class DownloadManager {
       this.eventEmitter.removeAllListeners('onDownloadFailed');
     }
     this.downloadJobs.clear();
+    this.cancelledModelIds.clear();
     console.log(`${TAG}: Download jobs cleared`);
   }
 

--- a/src/services/downloads/DownloadManager.ts
+++ b/src/services/downloads/DownloadManager.ts
@@ -20,6 +20,18 @@ import type {
 
 const TAG = 'DownloadManager';
 
+/**
+ * Thrown when a download promise rejects because the user cancelled it, as
+ * opposed to a genuine failure. Callers use this to distinguish a user cancel
+ * (no error surface, no follow-on work) from a real download error.
+ */
+export class DownloadCancelledError extends Error {
+  constructor(public readonly modelId: string) {
+    super(`Download cancelled for ${modelId}`);
+    this.name = 'DownloadCancelledError';
+  }
+}
+
 export class DownloadManager {
   private downloadJobs: DownloadMap;
   private callbacks: DownloadEventCallbacks = {};
@@ -375,14 +387,13 @@ export class DownloadManager {
       }
     } catch (error) {
       // A user-initiated cancel rejects this promise (RNFS.stopDownload aborts
-      // the task). That is not a failure — swallow it silently so it never
-      // reaches the user-facing download error surface.
+      // the task). That is not a failure — signal it as a distinct cancellation
+      // so callers neither surface an error nor chain follow-on work (e.g. the
+      // projection-model download for multimodal models).
       if (this.cancelledModelIds.delete(model.id)) {
-        console.log(
-          `${TAG}: Download cancelled by user for ID: ${model.id}, suppressing error`,
-        );
+        console.log(`${TAG}: Download cancelled by user for ID: ${model.id}`);
         this.downloadJobs.delete(model.id);
-        return;
+        throw new DownloadCancelledError(model.id);
       }
 
       console.error(`${TAG}: Download failed for ID: ${model.id}:`, error);

--- a/src/services/downloads/DownloadManager.ts
+++ b/src/services/downloads/DownloadManager.ts
@@ -364,6 +364,9 @@ export class DownloadManager {
         );
         this.callbacks.onComplete?.(model.id);
         this.downloadJobs.delete(model.id);
+        // Cancel may race with a download that already completed; clear any
+        // stale marker so it can't suppress a later genuine failure.
+        this.cancelledModelIds.delete(model.id);
       } else {
         console.error(
           `${TAG}: Download failed with status: ${result.statusCode} for ID: ${model.id}`,

--- a/src/services/downloads/__tests__/DownloadManager.test.ts
+++ b/src/services/downloads/__tests__/DownloadManager.test.ts
@@ -354,6 +354,81 @@ describe('DownloadManager', () => {
     expect(iosDownloadManager.isDownloading('model-1')).toBe(false);
   });
 
+  it('does not surface an error when an iOS download is cancelled', async () => {
+    (Platform as any).OS = 'ios';
+
+    const iosDownloadManager = new DownloadManager();
+
+    const callbacks = {
+      onStart: jest.fn(),
+      onProgress: jest.fn(),
+      onComplete: jest.fn(),
+      onError: jest.fn(),
+    };
+
+    iosDownloadManager.setCallbacks(callbacks);
+
+    // A cancel aborts the RNFS task, rejecting the download promise.
+    let rejectDownload: (reason: Error) => void = () => {};
+    const downloadPromise = new Promise((_resolve, reject) => {
+      rejectDownload = reject;
+    });
+
+    (RNFS.downloadFile as jest.Mock).mockReturnValue({
+      jobId: 321,
+      promise: downloadPromise,
+    });
+
+    const startPromise = iosDownloadManager.startDownload(
+      basicModel,
+      '/path/to/model.bin',
+    );
+
+    // Let the async setup (mkdir, job registration) settle before cancelling.
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(iosDownloadManager.isDownloading('model-1')).toBe(true);
+
+    // User taps Stop, then the aborted task rejects the download promise.
+    await iosDownloadManager.cancelDownload('model-1');
+    rejectDownload(new Error('Download has been aborted'));
+
+    await expect(startPromise).resolves.toBeUndefined();
+
+    expect(callbacks.onError).not.toHaveBeenCalled();
+    expect(iosDownloadManager.isDownloading('model-1')).toBe(false);
+  });
+
+  it('still surfaces an error for a genuine iOS download failure', async () => {
+    (Platform as any).OS = 'ios';
+
+    const iosDownloadManager = new DownloadManager();
+
+    const callbacks = {
+      onStart: jest.fn(),
+      onProgress: jest.fn(),
+      onComplete: jest.fn(),
+      onError: jest.fn(),
+    };
+
+    iosDownloadManager.setCallbacks(callbacks);
+
+    (RNFS.downloadFile as jest.Mock).mockReturnValue({
+      jobId: 654,
+      promise: Promise.reject(new Error('Network connection lost')),
+    });
+
+    await expect(
+      iosDownloadManager.startDownload(basicModel, '/path/to/model.bin'),
+    ).rejects.toThrow('Network connection lost');
+
+    expect(callbacks.onError).toHaveBeenCalledWith(
+      'model-1',
+      expect.any(Error),
+    );
+    expect(iosDownloadManager.isDownloading('model-1')).toBe(false);
+  });
+
   it('sends the attribution User-Agent on the iOS RNFS download', async () => {
     (Platform as any).OS = 'ios';
 

--- a/src/services/downloads/__tests__/DownloadManager.test.ts
+++ b/src/services/downloads/__tests__/DownloadManager.test.ts
@@ -4,7 +4,7 @@ import * as RNFS from '@dr.pogodin/react-native-fs';
 
 import {basicModel} from '../../../../jest/fixtures/models';
 
-import {DownloadManager} from '../DownloadManager';
+import {DownloadManager, DownloadCancelledError} from '../DownloadManager';
 
 jest.mock('react-native', () => {
   // Create a shared mock for DownloadModule inside the factory
@@ -393,7 +393,9 @@ describe('DownloadManager', () => {
     await iosDownloadManager.cancelDownload('model-1');
     rejectDownload(new Error('Download has been aborted'));
 
-    await expect(startPromise).resolves.toBeUndefined();
+    // The cancel surfaces as a distinct DownloadCancelledError (not a generic
+    // failure), so onError is never called and callers can special-case it.
+    await expect(startPromise).rejects.toBeInstanceOf(DownloadCancelledError);
 
     expect(callbacks.onError).not.toHaveBeenCalled();
     expect(iosDownloadManager.isDownloading('model-1')).toBe(false);
@@ -460,7 +462,7 @@ describe('DownloadManager', () => {
     await new Promise(resolve => setImmediate(resolve));
     await iosDownloadManager.cancelDownload('model-1');
     rejectFirst(new Error('Download has been aborted'));
-    await expect(firstStart).resolves.toBeUndefined();
+    await expect(firstStart).rejects.toBeInstanceOf(DownloadCancelledError);
     expect(callbacks.onError).not.toHaveBeenCalled();
 
     // Second attempt for the SAME model genuinely fails. The cancelled-id

--- a/src/services/downloads/__tests__/DownloadManager.test.ts
+++ b/src/services/downloads/__tests__/DownloadManager.test.ts
@@ -429,6 +429,58 @@ describe('DownloadManager', () => {
     expect(iosDownloadManager.isDownloading('model-1')).toBe(false);
   });
 
+  it('still surfaces a later genuine failure after the same model was cancelled', async () => {
+    (Platform as any).OS = 'ios';
+
+    const iosDownloadManager = new DownloadManager();
+
+    const callbacks = {
+      onStart: jest.fn(),
+      onProgress: jest.fn(),
+      onComplete: jest.fn(),
+      onError: jest.fn(),
+    };
+
+    iosDownloadManager.setCallbacks(callbacks);
+
+    // First attempt: user cancels mid-download.
+    let rejectFirst: (reason: Error) => void = () => {};
+    const firstPromise = new Promise((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    (RNFS.downloadFile as jest.Mock).mockReturnValueOnce({
+      jobId: 111,
+      promise: firstPromise,
+    });
+
+    const firstStart = iosDownloadManager.startDownload(
+      basicModel,
+      '/path/to/model.bin',
+    );
+    await new Promise(resolve => setImmediate(resolve));
+    await iosDownloadManager.cancelDownload('model-1');
+    rejectFirst(new Error('Download has been aborted'));
+    await expect(firstStart).resolves.toBeUndefined();
+    expect(callbacks.onError).not.toHaveBeenCalled();
+
+    // Second attempt for the SAME model genuinely fails. The cancelled-id
+    // marker from the first attempt must not swallow this real failure.
+    (RNFS.downloadFile as jest.Mock).mockReturnValueOnce({
+      jobId: 222,
+      promise: Promise.reject(new Error('Network connection lost')),
+    });
+
+    await expect(
+      iosDownloadManager.startDownload(basicModel, '/path/to/model.bin'),
+    ).rejects.toThrow('Network connection lost');
+
+    expect(callbacks.onError).toHaveBeenCalledWith(
+      'model-1',
+      expect.any(Error),
+    );
+    expect(iosDownloadManager.isDownloading('model-1')).toBe(false);
+  });
+
   it('sends the attribution User-Agent on the iOS RNFS download', async () => {
     (Platform as any).OS = 'ios';
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -37,7 +37,7 @@ import {getRecommendedProjectionModel} from '../utils/multimodalHelpers';
 import {getOriginalModelName} from '../utils/formatters';
 import {defaultModels, MODEL_LIST_VERSION} from './defaultModels';
 
-import {downloadManager} from '../services/downloads';
+import {downloadManager, DownloadCancelledError} from '../services/downloads';
 
 import {
   getHFDefaultSettings,
@@ -1009,6 +1009,12 @@ class ModelStore {
       // For vision models, automatically download the projection model
       await this._downloadProjectionModelIfNeeded(model);
     } catch (err) {
+      if (err instanceof DownloadCancelledError) {
+        // User cancelled — not a failure. Don't surface an error and don't
+        // chain the projection-model download for multimodal models.
+        return;
+      }
+
       console.error('Failed to start download:', err);
 
       // Create proper error state for the snackbar system

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -895,6 +895,8 @@ describe('ModelStore', () => {
       );
 
       expect(downloadManager.startDownload).toHaveBeenCalled();
+      // Contrast with the cancel case: a genuine failure DOES surface an error.
+      expect(modelStore.downloadError).not.toBeNull();
     });
   });
 

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -5,7 +5,10 @@ import {Alert} from 'react-native';
 
 import {defaultModels} from '../defaultModels';
 
-import {downloadManager, DownloadCancelledError} from '../../services/downloads';
+import {
+  downloadManager,
+  DownloadCancelledError,
+} from '../../services/downloads';
 
 import {GGUFMetadata, ModelOrigin, ModelType} from '../../utils/types';
 import {
@@ -38,7 +41,7 @@ jest.mock('../../api/hf', () => ({
 
 // Mock the download manager
 jest.mock('../../services/downloads', () => {
-  class DownloadCancelledError extends Error {
+  class MockDownloadCancelledError extends Error {
     modelId: string;
     constructor(modelId: string) {
       super(`Download cancelled for ${modelId}`);
@@ -47,7 +50,7 @@ jest.mock('../../services/downloads', () => {
     }
   }
   return {
-    DownloadCancelledError,
+    DownloadCancelledError: MockDownloadCancelledError,
     downloadManager: {
       isDownloading: jest.fn(),
       startDownload: jest.fn(),

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -5,7 +5,7 @@ import {Alert} from 'react-native';
 
 import {defaultModels} from '../defaultModels';
 
-import {downloadManager} from '../../services/downloads';
+import {downloadManager, DownloadCancelledError} from '../../services/downloads';
 
 import {GGUFMetadata, ModelOrigin, ModelType} from '../../utils/types';
 import {
@@ -37,15 +37,26 @@ jest.mock('../../api/hf', () => ({
 }));
 
 // Mock the download manager
-jest.mock('../../services/downloads', () => ({
-  downloadManager: {
-    isDownloading: jest.fn(),
-    startDownload: jest.fn(),
-    cancelDownload: jest.fn(),
-    setCallbacks: jest.fn(),
-    syncWithActiveDownloads: jest.fn().mockResolvedValue(undefined),
-  },
-}));
+jest.mock('../../services/downloads', () => {
+  class DownloadCancelledError extends Error {
+    modelId: string;
+    constructor(modelId: string) {
+      super(`Download cancelled for ${modelId}`);
+      this.name = 'DownloadCancelledError';
+      this.modelId = modelId;
+    }
+  }
+  return {
+    DownloadCancelledError,
+    downloadManager: {
+      isDownloading: jest.fn(),
+      startDownload: jest.fn(),
+      cancelDownload: jest.fn(),
+      setCallbacks: jest.fn(),
+      syncWithActiveDownloads: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
 
 // Mock the HF store
 // jest.mock('../HFStore', () => ({
@@ -865,13 +876,59 @@ describe('ModelStore', () => {
         modelStore.downloadError = null;
       });
 
-      // A user-initiated cancel resolves startDownload without throwing, so
-      // the error surface must stay clean.
-      (downloadManager.startDownload as jest.Mock).mockResolvedValue(undefined);
+      // A user-initiated cancel rejects startDownload with a DownloadCancelledError;
+      // checkSpaceAndDownload must recognise it, keep the error surface clean,
+      // and not re-throw.
+      (downloadManager.startDownload as jest.Mock).mockRejectedValue(
+        new DownloadCancelledError(model.id),
+      );
 
-      await modelStore.checkSpaceAndDownload(model.id);
+      await expect(
+        modelStore.checkSpaceAndDownload(model.id),
+      ).resolves.toBeUndefined();
 
       expect(downloadManager.startDownload).toHaveBeenCalled();
+      expect(modelStore.downloadError).toBeNull();
+    });
+
+    it('does not auto-download the projection model when a vision model download is cancelled', async () => {
+      const projModel = {
+        ...defaultModels[0],
+        id: 'proj-model',
+        modelType: ModelType.PROJECTION,
+        isDownloaded: false,
+        isLocal: false,
+        origin: ModelOrigin.PRESET,
+        downloadUrl: 'https://example.com/proj.gguf',
+      };
+      const visionModel = {
+        ...defaultModels[0],
+        id: 'vision-model',
+        downloadUrl: 'https://example.com/vision.gguf',
+        isDownloaded: false,
+        isLocal: false,
+        origin: ModelOrigin.PRESET,
+        supportsMultimodal: true,
+        defaultProjectionModel: 'proj-model',
+      };
+      modelStore.models = [visionModel, projModel];
+      (downloadManager.isDownloading as jest.Mock).mockReturnValue(false);
+
+      // The main model download is cancelled by the user.
+      (downloadManager.startDownload as jest.Mock).mockRejectedValue(
+        new DownloadCancelledError(visionModel.id),
+      );
+
+      await modelStore.checkSpaceAndDownload(visionModel.id);
+
+      // Only the (cancelled) main model download was attempted — the projection
+      // model must NOT be chained off a user cancel.
+      expect(downloadManager.startDownload).toHaveBeenCalledTimes(1);
+      expect(downloadManager.startDownload).toHaveBeenCalledWith(
+        expect.objectContaining({id: 'vision-model'}),
+        expect.anything(),
+        expect.anything(),
+      );
       expect(modelStore.downloadError).toBeNull();
     });
 

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -852,6 +852,29 @@ describe('ModelStore', () => {
       expect(model.isDownloaded).toBe(false);
     });
 
+    it('should not set downloadError when a download is cancelled', async () => {
+      const model = {
+        ...defaultModels[0],
+        downloadUrl: 'https://example.com/model.gguf',
+        isDownloaded: false,
+        isLocal: false,
+        origin: ModelOrigin.PRESET,
+      };
+      modelStore.models = [model];
+      runInAction(() => {
+        modelStore.downloadError = null;
+      });
+
+      // A user-initiated cancel resolves startDownload without throwing, so
+      // the error surface must stay clean.
+      (downloadManager.startDownload as jest.Mock).mockResolvedValue(undefined);
+
+      await modelStore.checkSpaceAndDownload(model.id);
+
+      expect(downloadManager.startDownload).toHaveBeenCalled();
+      expect(modelStore.downloadError).toBeNull();
+    });
+
     it('should handle download failure due to insufficient space', async () => {
       const model = {
         ...defaultModels[0],


### PR DESCRIPTION
Fixes #770

## Summary

Tapping **Stop** on an in-progress model download surfaced a "Download Failed" dialog with the message *"Download has been aborted"* and a **Try again** action — even though the user intentionally cancelled.

On iOS, `RNFS.stopDownload` aborts the task, which rejects the in-flight download promise. That rejection propagated up through the download error path to `modelStore.downloadError`, surfacing as a user-facing failure.

## Fix

`DownloadManager` now tracks user-cancelled model IDs. When a download promise rejects, the catch block first checks whether the model was cancelled by the user — if so it cleans up the job and returns silently, without firing `onError` or re-throwing. Genuine failures are untouched and still surface the error dialog.

- The cancelled-id marker is cleared on every path (consumed by the iOS catch, cleared explicitly on the Android cancel path which emits no failure event, on the cancel-error path, and in `clearDownloads`) to avoid leaks.
- A genuine failure for a model that was previously cancelled still surfaces, because the marker is single-use.

## Verification

- Lint clean, typecheck clean.
- Tests: full related-suite green (2442 passed).
- New unit coverage as substitute visual evidence (the change suppresses a dialog; the behavioral contract is asserted at both layers):
  - iOS cancel → `onError` is not called, download stops.
  - Genuine iOS failure → `onError` still fires.
  - Re-download after cancel that genuinely fails → still surfaces.
  - `ModelStore`: cancel leaves `downloadError` null; genuine failure sets it.

No native changes.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)