### PR TITLE
[Bug]: Keep latest AI output visible when Android keyboard opens

### DIFF
--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -4,6 +4,7 @@ import {
   FlatListProps,
   InteractionManager,
   LayoutAnimation,
+  Platform,
   StatusBar,
   StatusBarProps,
   View,
@@ -1005,7 +1006,15 @@ export const ChatView = observer(
               {...unwrap(flatListProps)}
               data={chatMessages}
               inverted={chatMessages.length > 0}
-              keyboardDismissMode="interactive"
+              // iOS keeps the interactive (drag-to-dismiss) gesture. On Android,
+              // "interactive" makes a drag forcibly close the keyboard as the
+              // only outcome, so the user can never scroll the list to reveal
+              // content the keyboard is hiding; "none" lets the drag scroll
+              // while the input stays focused. Tap-to-dismiss on send is
+              // preserved via Keyboard.dismiss() in wrappedOnSendPress.
+              keyboardDismissMode={
+                Platform.OS === 'ios' ? 'interactive' : 'none'
+              }
               keyExtractor={keyExtractor}
               onEndReached={handleEndReached}
               ref={list}

--- a/src/components/ChatView/ChatView.tsx
+++ b/src/components/ChatView/ChatView.tsx
@@ -26,7 +26,6 @@ import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
   withTiming,
-  useAnimatedReaction,
   useAnimatedScrollHandler,
   useDerivedValue,
 } from 'react-native-reanimated';
@@ -411,11 +410,19 @@ export const ChatView = observer(
     // ============ KEYBOARD ANIMATION SETUP ============
     // Get real-time keyboard height from the keyboard controller
     const keyboard = useReanimatedKeyboardAnimation();
-    const trackingKeyboardMovement = useSharedValue(false);
-    const bottomOffset = -insets.bottom;
 
-    // Shared value that tracks the offset to apply when keyboard is moving up
-    const keyboardOffsetBottom = useSharedValue(0);
+    // One reconciled "keyboard occlusion above the input" value. The library
+    // reports a negative `keyboard.height` while the keyboard is up; the IME
+    // inset already spans the navigation bar (KeyboardProvider is configured
+    // navigationBarTranslucent), so the space the keyboard actually steals from
+    // the chat surface is the IME inset minus the safe-area bottom inset. One
+    // expression, correct on every API level — there is no version fork (the
+    // API ≤ 29 under-reservation is handled by the clamp, not a branch). The
+    // input translate, the suggested-prompts overlay, and the inverted-list
+    // bottom spacer all derive from THIS value so they never disagree.
+    const keyboardOcclusion = useDerivedValue(() =>
+      Math.max(0, Math.abs(keyboard.height.value) - insets.bottom),
+    );
 
     // Shared value to track if keyboard is visible (height > 0)
     const isKeyboardVisible = useSharedValue(false);
@@ -423,9 +430,7 @@ export const ChatView = observer(
     // Animated style for input container padding
     // Apply bottom padding (safe area inset) only when keyboard is NOT visible
     const inputContainerAnimatedStyle = useAnimatedStyle(() => ({
-      transform: [
-        {translateY: keyboard.height.value - keyboardOffsetBottom.value},
-      ],
+      transform: [{translateY: -keyboardOcclusion.value}],
       paddingBottom: isKeyboardVisible.value ? 0 : insets.bottom,
     }));
 
@@ -434,30 +439,8 @@ export const ChatView = observer(
     // home indicator). Applying it here would create a large empty gap
     // between the chips and the input when the keyboard is closed.
     const suggestedPromptsAnimatedStyle = useAnimatedStyle(() => ({
-      transform: [
-        {translateY: keyboard.height.value - keyboardOffsetBottom.value},
-      ],
+      transform: [{translateY: -keyboardOcclusion.value}],
     }));
-
-    // Monitor keyboard height changes and animate the offset value
-    useAnimatedReaction(
-      () => -keyboard.height.value,
-      (value, prevValue) => {
-        if (prevValue !== null && value !== prevValue) {
-          const isKeyboardMovingUp = value > prevValue;
-          if (isKeyboardMovingUp !== trackingKeyboardMovement.value) {
-            trackingKeyboardMovement.value = isKeyboardMovingUp;
-            keyboardOffsetBottom.value = withTiming(
-              isKeyboardMovingUp ? bottomOffset : 0,
-              {
-                duration: 200, // bottomOffset ? 150 : 400,
-              },
-            );
-          }
-        }
-      },
-      [keyboard, trackingKeyboardMovement, bottomOffset],
-    );
 
     // ============ SCROLL TRACKING & SCROLL-TO-BOTTOM ============
     // Shared values for tracking scroll position and content overflow
@@ -969,20 +952,15 @@ export const ChatView = observer(
     );
 
     // ListHeaderComponent as animated spacer (inverted list: header is at bottom)
-    // We use this to create a spacer at the bottom of the list to account for the keyboard height.
-    // So we can move up/down when the keyboard is shown/hidden.
-    const headerStyle = useAnimatedStyle(() => {
-      // only animate when not streaming
-      // if (isStreaming) return {height: 0};
-
-      // Only lift when keyboard is actively moving
-      const shouldLift = trackingKeyboardMovement.value;
-      return {
-        height: shouldLift
-          ? Math.abs(keyboard.height.value) - insets.bottom
-          : 0,
-      };
-    });
+    // We use this to create a spacer at the bottom of the list to account for the
+    // keyboard height, so the newest turn rises above the input when the keyboard
+    // opens. Reads the SAME reconciled occlusion value as the input translate, so
+    // the two can never disagree, and holds while the keyboard is settled-open
+    // (it returns to 0 only when the keyboard closes, not while it merely stops
+    // moving — the previous in-flight gate dropped it too early on API ≤ 29).
+    const headerStyle = useAnimatedStyle(() => ({
+      height: keyboardOcclusion.value,
+    }));
 
     // Render header (pending indicator + keyboard spacer). The
     // FlatList is `inverted={true}`, so the ListHeaderComponent renders

--- a/src/components/ChatView/__tests__/ChatView.keyboard.test.tsx
+++ b/src/components/ChatView/__tests__/ChatView.keyboard.test.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import {Platform} from 'react-native';
+
+import {textMessage, user} from '../../../../jest/fixtures';
+import {ChatView} from '../ChatView';
+import {render} from '../../../../jest/test-utils';
+
+jest.useFakeTimers();
+
+jest.mock('../../ChatEmptyPlaceholder', () => ({
+  ChatEmptyPlaceholder: jest.fn(() => null),
+}));
+
+// keyboardDismissMode is set once on the chat FlatList but the FlatList passes
+// it down to its inner ScrollView/VirtualizedList hosts, so several tree nodes
+// carry it. They all carry the SAME value, which is the contract under test.
+const dismissModes = (root: any) =>
+  root
+    .findAll((n: any) => n.props && n.props.keyboardDismissMode !== undefined)
+    .map((n: any) => n.props.keyboardDismissMode);
+
+// The chat FlatList is the node carrying BOTH keyboardDismissMode and the data
+// array — child message rows also carry `inverted` but not keyboardDismissMode.
+const chatFlatLists = (root: any) =>
+  root.findAll(
+    (n: any) =>
+      n.props &&
+      n.props.keyboardDismissMode !== undefined &&
+      Array.isArray(n.props.data),
+  );
+
+describe('ChatView keyboard occlusion', () => {
+  const originalOS = Platform.OS;
+
+  afterEach(() => {
+    Platform.OS = originalOS;
+  });
+
+  const messages = [
+    textMessage,
+    {
+      ...textMessage,
+      createdAt: 1,
+      id: 'assistant-turn',
+      author: {id: 'assistant-id'},
+      text: 'newest assistant output',
+      status: 'delivered' as const,
+    },
+  ];
+
+  it('keeps the iOS interactive drag-to-dismiss gesture', () => {
+    Platform.OS = 'ios';
+    const {UNSAFE_root} = render(
+      <ChatView messages={messages} onSendPress={jest.fn()} user={user} />,
+      {withSafeArea: true, withNavigation: true, withBottomSheetProvider: true},
+    );
+
+    const modes = dismissModes(UNSAFE_root);
+    expect(modes.length).toBeGreaterThan(0);
+    expect(modes.every((m: string) => m === 'interactive')).toBe(true);
+  });
+
+  it('relaxes Android keyboardDismissMode to none so a drag scrolls instead of dismissing', () => {
+    Platform.OS = 'android';
+    const {UNSAFE_root} = render(
+      <ChatView messages={messages} onSendPress={jest.fn()} user={user} />,
+      {withSafeArea: true, withNavigation: true, withBottomSheetProvider: true},
+    );
+
+    const modes = dismissModes(UNSAFE_root);
+    expect(modes.length).toBeGreaterThan(0);
+    expect(modes.every((m: string) => m === 'none')).toBe(true);
+  });
+
+  it('renders one inverted chat list when messages are present', () => {
+    Platform.OS = 'android';
+    const {UNSAFE_root} = render(
+      <ChatView messages={messages} onSendPress={jest.fn()} user={user} />,
+      {withSafeArea: true, withNavigation: true, withBottomSheetProvider: true},
+    );
+
+    const lists = chatFlatLists(UNSAFE_root);
+    expect(lists.length).toBeGreaterThan(0);
+    expect(lists.every((n: any) => n.props.inverted === true)).toBe(true);
+  });
+
+  it('renders without crashing on Android with an empty chat (empty-state gate)', () => {
+    Platform.OS = 'android';
+    const {UNSAFE_root} = render(
+      <ChatView messages={[]} onSendPress={jest.fn()} user={user} />,
+      {withSafeArea: true, withNavigation: true, withBottomSheetProvider: true},
+    );
+
+    // Empty chat is not inverted (inverted is gated on messages.length > 0).
+    const lists = chatFlatLists(UNSAFE_root);
+    expect(lists.length).toBeGreaterThan(0);
+    expect(lists.every((n: any) => n.props.inverted === false)).toBe(true);
+    // The Android dismiss-mode relaxation still applies in the empty state.
+    const modes = dismissModes(UNSAFE_root);
+    expect(modes.length).toBeGreaterThan(0);
+    expect(modes.every((m: string) => m === 'none')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #777. On Android 10 / API 29, opening the keyboard in chat hid the newest assistant turn behind the input, and a scroll attempt only dismissed the keyboard instead of revealing the hidden content. Not reproducible on Android API 30+ or iOS.

## Changes

- Derive the input translate, the suggested-prompts overlay, and the inverted-list bottom spacer from one reconciled keyboard-occlusion value (`max(0, abs(keyboard.height) - insets.bottom)`) instead of two separately-computed heights. The spacer now holds while the keyboard is settled-open rather than collapsing when the in-flight movement flag clears.
- A single cross-API expression with a `max(0, …)` clamp — no OS-version fork in the layout math.
- Relax Android `keyboardDismissMode` to `none` so a drag scrolls the list with the input still focused; iOS keeps the interactive drag-to-dismiss gesture. Tap-to-dismiss on send is preserved.
- Add tests for the per-platform `keyboardDismissMode` and the empty-state render.

## Verification

- `yarn lint`: pass (0 errors)
- `yarn typecheck`: pass
- `yarn test --coverage`: 3392 passed, 2 skipped; global coverage ~74.8%
- Native: N/A (JS-only change)
- On-device visual capture (Pixel 9 API 29 fix + Android 30+/iOS regression guards): pending; to be captured before merge.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
