### PR TITLE
[Feat]: Reasoning model detection + user override (local + remote)

### DIFF
--- a/__mocks__/stores/chatSessionStore.ts
+++ b/__mocks__/stores/chatSessionStore.ts
@@ -36,6 +36,7 @@ export const mockChatSessionStore = {
   activeSessionId: 'session-1',
   newChatCompletionSettings: mockDefaultCompletionSettings,
   newChatThinkingOverride: undefined as boolean | undefined,
+  newChatReasoningEffort: undefined as string | undefined,
   isMigrating: false,
   migrationComplete: true,
   // Draft autosave

--- a/__mocks__/stores/modelStore.ts
+++ b/__mocks__/stores/modelStore.ts
@@ -67,6 +67,8 @@ class MockModelStore {
   setNoExtraBufts: jest.Mock;
   enterBenchmarkMode: jest.Mock;
   exitBenchmarkMode: jest.Mock;
+  recordReasoningObserved: jest.Mock;
+  setReasoningOverride: jest.Mock;
   benchmarkActive: boolean = false;
   isContextLoading: boolean = false;
   loadingModel: Model | undefined;
@@ -113,6 +115,8 @@ class MockModelStore {
       setNoExtraBufts: false,
       enterBenchmarkMode: false,
       exitBenchmarkMode: false,
+      recordReasoningObserved: false,
+      setReasoningOverride: false,
       contextId: computed,
       lastUsedModel: computed,
       activeModel: computed,
@@ -165,6 +169,8 @@ class MockModelStore {
     this.setNoExtraBufts = jest.fn();
     this.enterBenchmarkMode = jest.fn().mockResolvedValue(undefined);
     this.exitBenchmarkMode = jest.fn();
+    this.recordReasoningObserved = jest.fn();
+    this.setReasoningOverride = jest.fn();
   }
 
   setActiveModel = (modelId: string) => {

--- a/__mocks__/stores/modelStore.ts
+++ b/__mocks__/stores/modelStore.ts
@@ -170,7 +170,17 @@ class MockModelStore {
     this.enterBenchmarkMode = jest.fn().mockResolvedValue(undefined);
     this.exitBenchmarkMode = jest.fn();
     this.recordReasoningObserved = jest.fn();
-    this.setReasoningOverride = jest.fn();
+    // Mirror the real writer so tests exercise the live override → resolver →
+    // pill reactive chain. Local ids mutate Model.reasoning on the observable
+    // model; remote ids route to ServerStore (kept as a spy fallback here).
+    this.setReasoningOverride = jest.fn((modelId: string, cap: any) => {
+      const localModel = this.models.find(m => m.id === modelId);
+      if (!localModel) {
+        return;
+      }
+      localModel.reasoning = cap;
+      localModel.supportsThinking = cap.isReasoning === 'yes';
+    });
   }
 
   setActiveModel = (modelId: string) => {

--- a/__mocks__/stores/serverStore.ts
+++ b/__mocks__/stores/serverStore.ts
@@ -1,12 +1,14 @@
 import {makeAutoObservable, observable} from 'mobx';
 
 import {ServerConfig} from '../../src/utils/types';
+import {ReasoningCapability} from '../../src/utils/reasoningCapability';
 import {RemoteModelInfo} from '../../src/api/openai';
 
 class MockServerStore {
   servers: ServerConfig[] = [];
   serverModels: Map<string, RemoteModelInfo[]> = observable.map();
   userSelectedModels: Array<{serverId: string; remoteModelId: string}> = [];
+  remoteReasoning: Record<string, ReasoningCapability> = {};
   isLoading = false;
   error: string | null = null;
   privacyNoticeAcknowledged = false;
@@ -26,6 +28,8 @@ class MockServerStore {
   removeServerIfOrphaned: jest.Mock;
   getModelsNotYetAdded: jest.Mock;
   getUserSelectedModelsForServer: jest.Mock;
+  recordRemoteReasoningObserved: jest.Mock;
+  setRemoteReasoningOverride: jest.Mock;
 
   constructor() {
     makeAutoObservable(this, {
@@ -44,6 +48,8 @@ class MockServerStore {
       removeServerIfOrphaned: false,
       getModelsNotYetAdded: false,
       getUserSelectedModelsForServer: false,
+      recordRemoteReasoningObserved: false,
+      setRemoteReasoningOverride: false,
     });
     this.addServer = jest.fn().mockReturnValue('mock-server-id');
     this.updateServer = jest.fn();
@@ -62,6 +68,8 @@ class MockServerStore {
     this.removeServerIfOrphaned = jest.fn();
     this.getModelsNotYetAdded = jest.fn().mockReturnValue([]);
     this.getUserSelectedModelsForServer = jest.fn().mockReturnValue([]);
+    this.recordRemoteReasoningObserved = jest.fn();
+    this.setRemoteReasoningOverride = jest.fn();
   }
 }
 

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -634,9 +634,7 @@ export const Selectors = {
     get supportsEffortSwitch(): string {
       return byTestId('reasoning-supports-effort-switch');
     },
-    get effortValuesInput(): string {
-      return byTestId('reasoning-effort-values-input');
-    },
+    effortChip: (level: string): string => byTestId(`effort-chip-${level}`),
   },
 
   // User-selectable server-type dropdown (server details + remote model sheets)

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -639,9 +639,10 @@ export const Selectors = {
     },
   },
 
-  // User-selectable server-type chips (server details + remote model sheets)
+  // User-selectable server-type dropdown (server details + remote model sheets)
   serverType: {
-    chip: (option: string): string => byTestId(`server-type-${option}`),
+    dropdown: (): string => byTestId('server-type-dropdown'),
+    option: (value: string): string => byTestId(`server-type-option-${value}`),
   },
 
   // Remote model sheet (add model from server)

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -505,17 +505,31 @@ export const Selectors = {
 
   // Thinking / generation settings
   thinking: {
+    // The toggle carries testID "thinking-toggle" AND a state-dependent
+    // accessibilityLabel. On iOS the testID becomes the element `name`, so the
+    // accessibility-id (`~label`) match no longer resolves — match the `label`
+    // attribute via predicate instead. On Android the label stays as
+    // content-desc, so `~label` still works.
     /** "Think" toggle button - when thinking is currently enabled */
     get toggleEnabled(): string {
-      return byAccessibilityLabel('Disable thinking mode');
+      if (isAndroid()) {
+        return byAccessibilityLabel('Disable thinking mode');
+      }
+      return '-ios predicate string:name == "thinking-toggle" AND label == "Disable thinking mode"';
     },
     /** "Think" toggle button - when thinking is currently disabled */
     get toggleDisabled(): string {
-      return byAccessibilityLabel('Enable thinking mode');
+      if (isAndroid()) {
+        return byAccessibilityLabel('Enable thinking mode');
+      }
+      return '-ios predicate string:name == "thinking-toggle" AND label == "Enable thinking mode"';
     },
+    // The ThinkingBubble header reads "Reasoning". Once content streams in, iOS
+    // may merge the header into a combined accessibility name alongside the
+    // reasoning text, so match by partial text rather than an exact label.
     /** "Reasoning" header text inside the ThinkingBubble */
     get bubble(): string {
-      return byText('Reasoning');
+      return byPartialText('Reasoning');
     },
     /** Chevron icon inside the ThinkingBubble */
     get chevronIcon(): string {
@@ -610,6 +624,24 @@ export const Selectors = {
     get clearAllButton(): string {
       return byTestId('clear-all-button');
     },
+  },
+
+  // Per-model settings sheet (opened from a model card's settings button)
+  modelSettings: {
+    get isReasoningSwitch(): string {
+      return byTestId('reasoning-is-reasoning-switch');
+    },
+    get supportsEffortSwitch(): string {
+      return byTestId('reasoning-supports-effort-switch');
+    },
+    get effortValuesInput(): string {
+      return byTestId('reasoning-effort-values-input');
+    },
+  },
+
+  // User-selectable server-type chips (server details + remote model sheets)
+  serverType: {
+    chip: (option: string): string => byTestId(`server-type-${option}`),
   },
 
   // Remote model sheet (add model from server)

--- a/e2e/pages/ModelsPage.ts
+++ b/e2e/pages/ModelsPage.ts
@@ -142,6 +142,20 @@ export class ModelsPage extends BasePage {
   }
 
   /**
+   * Open the per-model settings sheet for a model card, found by its
+   * download filename. Scopes the settings button to the card container so
+   * the right card's button is tapped when several cards are present.
+   */
+  async openModelSettings(downloadFile: string): Promise<void> {
+    const container = browser.$(Selectors.modelCard.cardContainer(downloadFile));
+    await container.waitForDisplayed({timeout: 30000});
+    const settingsBtn = container.$(Selectors.modelCard.settingsButton);
+    await settingsBtn.waitForDisplayed({timeout: 10000});
+    await settingsBtn.click();
+    await browser.pause(800);
+  }
+
+  /**
    * Dismiss keyboard (exposed from BasePage for use in tests)
    */
   async hideKeyboard(): Promise<void> {

--- a/e2e/specs/features/graded-effort-override.spec.ts
+++ b/e2e/specs/features/graded-effort-override.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Local Graded-Effort Override E2E (PR #783 repro guard)
+ *
+ * Reproduces the user-reported flow: open the card of the loaded, active local
+ * reasoning model, declare it a reasoning model with graded effort, select all
+ * three effort grades (low/medium/high), save, return to chat, and verify the
+ * chat-input pill becomes a graded cycle (Think → low → medium → high → Think)
+ * rather than staying a binary on/off toggle.
+ *
+ * Usage:
+ *   npx ts-node scripts/run-e2e.ts --platform ios \
+ *     --spec graded-effort-override --devices iphone-17-pro-sim --skip-build
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {expect} from '@wdio/globals';
+import {ChatPage} from '../../pages/ChatPage';
+import {DrawerPage} from '../../pages/DrawerPage';
+import {ModelsPage} from '../../pages/ModelsPage';
+import {Selectors} from '../../helpers/selectors';
+import {Gestures} from '../../helpers/gestures';
+import {
+  downloadAndLoadModel,
+  dismissPerformanceWarningIfPresent,
+} from '../../helpers/model-actions';
+import {TIMEOUTS} from '../../fixtures/models';
+import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
+
+declare const driver: WebdriverIO.Browser;
+declare const browser: WebdriverIO.Browser;
+
+/** Qwen3-0.6B: small reasoning-capable model — matches thinking.spec.ts. */
+const THINKING_MODEL = {
+  id: 'qwen3-0.6b',
+  searchQuery: 'bartowski Qwen_Qwen3-0.6B',
+  selectorText: 'Qwen_Qwen3-0.6B',
+  downloadFile: 'Qwen_Qwen3-0.6B-Q4_0.gguf',
+  prompts: [{input: "What's up?", description: 'Casual greeting'}],
+};
+
+/**
+ * The pill TouchableOpacity is accessible on iOS, which collapses its inner
+ * effort/"Think" Text node — so the grade word is not directly readable from
+ * the accessibility tree. Instead we read the pill's on/off state from its
+ * accessibilityLabel ("Disable thinking mode" = ON, "Enable thinking mode" =
+ * OFF) and distinguish graded from binary by the transition pattern:
+ *   binary  : every tap flips on↔off.
+ *   graded  : from OFF the pill stays ON for each effort grade (low, medium,
+ *             high) before returning to OFF — i.e. several consecutive ON taps.
+ */
+async function isPillOn(): Promise<boolean> {
+  return browser
+    .$(Selectors.thinking.toggleEnabled)
+    .isExisting()
+    .catch(() => false);
+}
+
+/**
+ * Single raw tap on the pill. Unlike ChatPage.tapThinkingToggle (which retries
+ * until the on/off state flips, and so cannot drive a graded pill that stays ON
+ * across grades), this taps the clear part of the toggle exactly once and
+ * dismisses any TTS sheet that the VoiceChip overlap may open.
+ */
+async function tapPillOnce(chatPage: ChatPage): Promise<void> {
+  await chatPage.dismissVoicesSheetIfPresent();
+  const sel = (await browser.$(Selectors.thinking.toggleEnabled).isExisting())
+    ? Selectors.thinking.toggleEnabled
+    : Selectors.thinking.toggleDisabled;
+  const el = browser.$(sel);
+  if (!(await el.isExisting())) {
+    return;
+  }
+  const loc = await el.getLocation();
+  const size = await el.getSize();
+  const x = Math.round(loc.x + 8);
+  const y = Math.round(loc.y + size.height / 2);
+  await browser
+    .action('pointer', {parameters: {pointerType: 'touch'}})
+    .move({x, y})
+    .down()
+    .pause(60)
+    .up()
+    .perform();
+  await browser.pause(350);
+  await chatPage.dismissVoicesSheetIfPresent();
+}
+
+describe('Local Graded-Effort Override', () => {
+  let chatPage: ChatPage;
+  let drawerPage: DrawerPage;
+  let modelsPage: ModelsPage;
+
+  before(async () => {
+    chatPage = new ChatPage();
+    drawerPage = new DrawerPage();
+    modelsPage = new ModelsPage();
+
+    await chatPage.waitForReady(TIMEOUTS.appReady);
+    // Settle after the fresh app launch before driving the drawer; tapping the
+    // menu button too early after relaunch can miss the open animation.
+    await browser.pause(1500);
+
+    await downloadAndLoadModel(THINKING_MODEL);
+    await dismissPerformanceWarningIfPresent();
+    await chatPage.waitForReady();
+  });
+
+  afterEach(async function (this: Mocha.Context) {
+    if (this.currentTest?.state === 'failed') {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const testName = this.currentTest.title.replace(/\s+/g, '-');
+      try {
+        if (!fs.existsSync(SCREENSHOT_DIR)) {
+          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
+        }
+        await driver.saveScreenshot(
+          path.join(SCREENSHOT_DIR, `failure-${testName}-${timestamp}.png`),
+        );
+      } catch (e) {
+        console.error('Failed to capture screenshot:', (e as Error).message);
+      }
+    }
+  });
+
+  it('graded-effort override on the active model makes the pill cycle low/medium/high', async () => {
+    // Open the active model's card and declare graded effort.
+    await chatPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToModels();
+    await modelsPage.waitForReady();
+    await modelsPage.openModelSettings(THINKING_MODEL.downloadFile);
+
+    // The reasoning section sits at the bottom of the settings ScrollView;
+    // scroll it into view before driving the controls.
+    await Gestures.scrollToElement(Selectors.modelSettings.isReasoningSwitch, 6);
+    const isReasoning = browser.$(Selectors.modelSettings.isReasoningSwitch);
+    await isReasoning.waitForDisplayed({timeout: 10000});
+
+    // Ensure axis-1 is ON (reveals the axis-2 controls). The switch exposes its
+    // value via the "value" attribute ("1"/"0" on iOS); only toggle when off.
+    const isOn = await isReasoning.getAttribute('value').catch(() => null);
+    if (isOn === '0' || isOn === 'false' || isOn === null) {
+      await isReasoning.click();
+      await browser.pause(400);
+    }
+
+    await Gestures.scrollToElement(
+      Selectors.modelSettings.supportsEffortSwitch,
+      6,
+    );
+    const supportsEffort = browser.$(Selectors.modelSettings.supportsEffortSwitch);
+    await supportsEffort.waitForDisplayed({timeout: 10000});
+    const effortOn = await supportsEffort.getAttribute('value').catch(() => null);
+    if (effortOn === '0' || effortOn === 'false' || effortOn === null) {
+      await supportsEffort.click();
+      await browser.pause(400);
+    }
+
+    for (const level of ['low', 'medium', 'high']) {
+      await Gestures.scrollToElement(
+        Selectors.modelSettings.effortChip(level),
+        4,
+      );
+      const chip = browser.$(Selectors.modelSettings.effortChip(level));
+      await chip.waitForDisplayed({timeout: 10000});
+      await chip.click();
+      await browser.pause(200);
+    }
+
+    const save = browser.$(Selectors.generationSettings.saveChangesButton);
+    await save.waitForDisplayed({timeout: 10000});
+    await save.click();
+    await browser.pause(600);
+
+    // Back to chat. resetChat from the models flow is unreliable (gesture
+    // conflicts), so navigate via the drawer.
+    await modelsPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToChat();
+    await chatPage.waitForReady();
+
+    expect(await chatPage.isThinkingToggleVisible()).toBe(true);
+
+    // Drive the pill to a known OFF state first (the inner Text is collapsed by
+    // iOS accessibility, so we steer by the on/off accessibilityLabel).
+    if (await isPillOn()) {
+      // From any on-state, a graded pill needs up to 3 taps to wrap to OFF; a
+      // binary pill needs 1. Tap until OFF.
+      for (let i = 0; i < 4 && (await isPillOn()); i++) {
+        await tapPillOnce(chatPage);
+      }
+    }
+    expect(await isPillOn()).toBe(false);
+
+    // Record the on/off state after each of four taps from OFF.
+    //   graded  : ON, ON, ON, OFF   (low → medium → high → off)
+    //   binary  : ON, OFF, ON, OFF  (on → off → on → off)
+    const states: boolean[] = [];
+    for (let i = 0; i < 4; i++) {
+      await tapPillOnce(chatPage);
+      const on = await isPillOn();
+      states.push(on);
+      console.log(`pill state after tap ${i + 1}: ${on ? 'ON' : 'OFF'}`);
+    }
+
+    // A graded pill stays ON across the three effort grades before wrapping to
+    // OFF. A binary pill (the bug) alternates every tap and never holds ON for
+    // three consecutive taps.
+    expect(states).toEqual([true, true, true, false]);
+  });
+});

--- a/e2e/specs/features/graded-effort-override.spec.ts
+++ b/e2e/specs/features/graded-effort-override.spec.ts
@@ -18,7 +18,7 @@ import {expect} from '@wdio/globals';
 import {ChatPage} from '../../pages/ChatPage';
 import {DrawerPage} from '../../pages/DrawerPage';
 import {ModelsPage} from '../../pages/ModelsPage';
-import {Selectors} from '../../helpers/selectors';
+import {Selectors, byTestId, isAndroid} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
 import {
   downloadAndLoadModel,
@@ -40,20 +40,53 @@ const THINKING_MODEL = {
 };
 
 /**
- * The pill TouchableOpacity is accessible on iOS, which collapses its inner
- * effort/"Think" Text node — so the grade word is not directly readable from
- * the accessibility tree. Instead we read the pill's on/off state from its
- * accessibilityLabel ("Disable thinking mode" = ON, "Enable thinking mode" =
- * OFF) and distinguish graded from binary by the transition pattern:
- *   binary  : every tap flips on↔off.
- *   graded  : from OFF the pill stays ON for each effort grade (low, medium,
- *             high) before returning to OFF — i.e. several consecutive ON taps.
+ * A GRADED pill carries a different accessibilityLabel than a binary one:
+ * "Reasoning effort: {Level}. Double tap to cycle effort level" — where {Level}
+ * is the active grade (Low/Medium/High) when ON and EMPTY when OFF. (A binary
+ * pill instead reads "Disable thinking mode" / "Enable thinking mode".) The
+ * pill is always present via testID "thinking-toggle"; we read its state from
+ * that label rather than the binary-only "Disable/Enable thinking mode"
+ * selectors, which never match a graded pill.
+ *
+ * On iOS the testID becomes the element `name`, but when an accessibilityLabel
+ * is also present the `~accessibility-id` strategy may resolve to the label
+ * instead — so match by `name` via predicate. On Android the testID maps to
+ * resource-id.
  */
+const pillSelector = (): string =>
+  isAndroid()
+    ? byTestId('thinking-toggle')
+    : '-ios predicate string:name == "thinking-toggle"';
+
+/** Read the pill's accessibilityLabel ("label" on iOS, "content-desc" on Android). */
+async function pillLabel(): Promise<string> {
+  const el = browser.$(pillSelector());
+  if (!(await el.isExisting().catch(() => false))) {
+    return '';
+  }
+  const attr = isAndroid() ? 'content-desc' : 'label';
+  return (await el.getAttribute(attr).catch(() => null)) ?? '';
+}
+
+/**
+ * The active effort grade as shown on the pill (e.g. "Low"/"Medium"/"High"),
+ * or "" when the pill is OFF. The label format is "Reasoning effort: {Level}.
+ * Double tap to cycle effort level"; OFF renders an empty level. A binary pill
+ * (the bug this test guards against) instead reads "Disable/Enable thinking
+ * mode" — reported here as "ON"/"" so the cycle never holds across grades.
+ */
+async function pillEffort(): Promise<string> {
+  const label = await pillLabel();
+  const match = label.match(/Reasoning effort:\s*([^.]*)\./);
+  if (match) {
+    return match[1].trim();
+  }
+  return /Disable thinking mode/.test(label) ? 'ON' : '';
+}
+
+/** The pill is ON when it shows a non-empty effort grade. */
 async function isPillOn(): Promise<boolean> {
-  return browser
-    .$(Selectors.thinking.toggleEnabled)
-    .isExisting()
-    .catch(() => false);
+  return (await pillEffort()).length > 0;
 }
 
 /**
@@ -64,10 +97,7 @@ async function isPillOn(): Promise<boolean> {
  */
 async function tapPillOnce(chatPage: ChatPage): Promise<void> {
   await chatPage.dismissVoicesSheetIfPresent();
-  const sel = (await browser.$(Selectors.thinking.toggleEnabled).isExisting())
-    ? Selectors.thinking.toggleEnabled
-    : Selectors.thinking.toggleDisabled;
-  const el = browser.$(sel);
+  const el = browser.$(pillSelector());
   if (!(await el.isExisting())) {
     return;
   }
@@ -137,10 +167,17 @@ describe('Local Graded-Effort Override', () => {
     const isReasoning = browser.$(Selectors.modelSettings.isReasoningSwitch);
     await isReasoning.waitForDisplayed({timeout: 10000});
 
-    // Ensure axis-1 is ON (reveals the axis-2 controls). The switch exposes its
-    // value via the "value" attribute ("1"/"0" on iOS); only toggle when off.
-    const isOn = await isReasoning.getAttribute('value').catch(() => null);
-    if (isOn === '0' || isOn === 'false' || isOn === null) {
+    // Ensure axis-1 is ON (it reveals the axis-2 effort controls). The paper
+    // Switch does not expose a reliable "value" attribute on iOS (returns null),
+    // so a blind value-based click would toggle an already-ON reasoning model
+    // OFF and unmount the effort switch. Steer by presence of the dependent
+    // axis-2 control instead: only click axis-1 if the effort switch is absent.
+    const effortSwitchPresent = async (): Promise<boolean> =>
+      browser
+        .$(Selectors.modelSettings.supportsEffortSwitch)
+        .isExisting()
+        .catch(() => false);
+    if (!(await effortSwitchPresent())) {
       await isReasoning.click();
       await browser.pause(400);
     }
@@ -151,12 +188,28 @@ describe('Local Graded-Effort Override', () => {
     );
     const supportsEffort = browser.$(Selectors.modelSettings.supportsEffortSwitch);
     await supportsEffort.waitForDisplayed({timeout: 10000});
-    const effortOn = await supportsEffort.getAttribute('value').catch(() => null);
-    if (effortOn === '0' || effortOn === 'false' || effortOn === null) {
+
+    // Ensure axis-2 is ON (it reveals the effort chips). Same paper-Switch
+    // limitation as axis-1: steer by presence of the dependent effort chips
+    // rather than the unreliable "value" attribute. Only click if absent.
+    const effortChipsPresent = async (): Promise<boolean> =>
+      browser
+        .$(Selectors.modelSettings.effortChip('low'))
+        .isExisting()
+        .catch(() => false);
+    if (!(await effortChipsPresent())) {
       await supportsEffort.click();
       await browser.pause(400);
     }
 
+    // Enabling axis-2 pre-selects the standard low/medium/high subset — exactly
+    // the graded set this test wants. The chip is a toggle, so TAPPING a
+    // pre-selected chip would DESELECT it and persist an empty effort set (a
+    // binary pill). The chip's selected state is also not reliably readable
+    // across platforms (paper Chip's accessibilityState.selected surfaces as
+    // selected="true" on iOS but selected="false" on Android even when chosen),
+    // so a read-then-tap approach is unsafe. Instead we rely on the pre-applied
+    // selection and only confirm the chips are present — no tapping.
     for (const level of ['low', 'medium', 'high']) {
       await Gestures.scrollToElement(
         Selectors.modelSettings.effortChip(level),
@@ -164,8 +217,6 @@ describe('Local Graded-Effort Override', () => {
       );
       const chip = browser.$(Selectors.modelSettings.effortChip(level));
       await chip.waitForDisplayed({timeout: 10000});
-      await chip.click();
-      await browser.pause(200);
     }
 
     const save = browser.$(Selectors.generationSettings.saveChangesButton);
@@ -180,10 +231,18 @@ describe('Local Graded-Effort Override', () => {
     await drawerPage.navigateToChat();
     await chatPage.waitForReady();
 
-    expect(await chatPage.isThinkingToggleVisible()).toBe(true);
+    // The pill is present via testID "thinking-toggle" regardless of binary vs
+    // graded state — but ChatPage.isThinkingToggleVisible() keys off the
+    // BINARY "Disable/Enable thinking mode" labels, which a graded pill never
+    // carries. Assert pill presence by testID instead. The chat re-render after
+    // the settings save + drawer navigation can lag a beat, so wait for it.
+    const pill = browser.$(pillSelector());
+    await pill.waitForDisplayed({timeout: 15000});
+    expect(await pill.isDisplayed()).toBe(true);
 
-    // Drive the pill to a known OFF state first (the inner Text is collapsed by
-    // iOS accessibility, so we steer by the on/off accessibilityLabel).
+    // Drive the pill to a known OFF state first. We steer by the graded
+    // accessibilityLabel ("Reasoning effort: {Level}.") rather than the inner
+    // Text, which iOS collapses into the toggle.
     if (await isPillOn()) {
       // From any on-state, a graded pill needs up to 3 taps to wrap to OFF; a
       // binary pill needs 1. Tap until OFF.
@@ -193,20 +252,34 @@ describe('Local Graded-Effort Override', () => {
     }
     expect(await isPillOn()).toBe(false);
 
-    // Record the on/off state after each of four taps from OFF.
-    //   graded  : ON, ON, ON, OFF   (low → medium → high → off)
-    //   binary  : ON, OFF, ON, OFF  (on → off → on → off)
+    // Advance the pill one cycle step: tap until the effort label CHANGES. The
+    // first pill interaction after navigation can be swallowed by the TTS
+    // VoiceChip overlap, so a single blind tap is unreliable — retry until the
+    // label moves (or we exhaust the attempt budget).
+    const advance = async (from: string): Promise<string> => {
+      for (let attempt = 0; attempt < 4; attempt++) {
+        await tapPillOnce(chatPage);
+        const now = await pillEffort();
+        if (now !== from) {
+          return now;
+        }
+      }
+      return pillEffort();
+    };
+
+    // Record the on/off state across one full cycle from OFF. A graded pill
+    // cycles off → low → medium → high → off, so the four steps read
+    // ON, ON, ON, OFF. A binary pill (the bug) flips on↔off every tap
+    // (ON, OFF, ON, OFF) and never holds ON across three consecutive grades.
     const states: boolean[] = [];
+    let current = '';
     for (let i = 0; i < 4; i++) {
-      await tapPillOnce(chatPage);
-      const on = await isPillOn();
+      current = await advance(current);
+      const on = current.length > 0;
       states.push(on);
-      console.log(`pill state after tap ${i + 1}: ${on ? 'ON' : 'OFF'}`);
+      console.log(`pill state after step ${i + 1}: ${on ? `ON (${current})` : 'OFF'}`);
     }
 
-    // A graded pill stays ON across the three effort grades before wrapping to
-    // OFF. A binary pill (the bug) alternates every tap and never holds ON for
-    // three consecutive taps.
     expect(states).toEqual([true, true, true, false]);
   });
 });

--- a/e2e/specs/features/remote-reasoning.spec.ts
+++ b/e2e/specs/features/remote-reasoning.spec.ts
@@ -78,24 +78,24 @@ function pingModelsEndpoint(timeoutMs = 4000): Promise<boolean> {
 }
 
 /**
- * Read whether a server-type chip is currently selected. react-native-paper's
- * Chip sets accessibilityState.selected, which iOS surfaces via the "selected"
- * attribute and Android via "selected"/"checked". Reads the attribute off the
- * EXISTING element — chips deep in a bottom sheet report isDisplayed=false on
+ * Read the value shown on the server-type dropdown trigger. The ui Dropdown
+ * renders the selected option's label as the trigger text and exposes that on
+ * the trigger element's "label"/"name"/"value"/text. Reads off the EXISTING
+ * element — the trigger deep in a bottom sheet can report isDisplayed=false on
  * iOS even when present, so we do not gate on visibility here.
  */
-async function isServerTypeChipSelected(option: string): Promise<boolean> {
-  const chip = browser.$(Selectors.serverType.chip(option));
-  if (!(await chip.isExisting().catch(() => false))) {
-    return false;
+async function readServerTypeValue(): Promise<string> {
+  const trigger = browser.$(Selectors.serverType.dropdown());
+  if (!(await trigger.isExisting().catch(() => false))) {
+    return '';
   }
-  for (const attr of ['selected', 'checked']) {
-    const raw = await chip.getAttribute(attr).catch(() => null);
-    if (raw === 'true' || raw === '1') {
-      return true;
+  for (const attr of ['label', 'name', 'value']) {
+    const raw = await trigger.getAttribute(attr).catch(() => null);
+    if (raw) {
+      return raw;
     }
   }
-  return false;
+  return (await trigger.getText().catch(() => '')) || '';
 }
 
 /** Dump the current page source to debug-output for diagnosis. */
@@ -174,11 +174,11 @@ describe('Remote Reasoning Features', () => {
     console.log(`Entered server URL: ${SERVER_URL}`);
 
     // Dismiss the keyboard so it does not cover the lower sheet (it blocks
-    // both the probe-revealed fields and scrolling to the chip row).
+    // both the probe-revealed fields and scrolling to the dropdown).
     await modelsPage.hideKeyboard();
     await browser.pause(4000);
 
-    // The probe reveals the server fields incl. the server-type chip row.
+    // The probe reveals the server fields incl. the server-type dropdown.
     const connectedText = browser.$(byPartialText('Connected'));
     const isConnected = await connectedText
       .waitForDisplayed({timeout: 12000})
@@ -186,19 +186,20 @@ describe('Remote Reasoning Features', () => {
       .catch(() => false);
     expect(isConnected).toBe(true);
 
-    // Scroll the chip row into the rendered region. On iOS, chips deep in a
-    // bottom sheet report isDisplayed=false, so scroll by existence.
+    // Scroll the dropdown trigger into the rendered region. On iOS, controls
+    // deep in a bottom sheet report isDisplayed=false, so scroll by existence.
     await Gestures.scrollInSheetToElementExists(
-      Selectors.serverType.chip('llama.cpp'),
+      Selectors.serverType.dropdown(),
       6,
     );
-    const llamaChip = browser.$(Selectors.serverType.chip('llama.cpp'));
-    await llamaChip.waitForExist({timeout: 5000});
+    const trigger = browser.$(Selectors.serverType.dropdown());
+    await trigger.waitForExist({timeout: 5000});
 
-    // detectServerType -> seedServerType should pre-select "llama.cpp".
-    const selected = await isServerTypeChipSelected('llama.cpp');
-    expect(selected).toBe(true);
-    console.log('Server type auto-selected: llama.cpp');
+    // detectServerType -> seedServerType should pre-select "llama.cpp"; the
+    // dropdown trigger shows that seeded value.
+    const value = await readServerTypeValue();
+    expect(value).toContain('llama.cpp');
+    console.log(`Server type auto-selected: ${value}`);
   });
 
   it('adds the remote model, selects it, and activates it in chat', async () => {

--- a/e2e/specs/features/remote-reasoning.spec.ts
+++ b/e2e/specs/features/remote-reasoning.spec.ts
@@ -34,7 +34,12 @@ import {expect} from '@wdio/globals';
 import {ChatPage} from '../../pages/ChatPage';
 import {DrawerPage} from '../../pages/DrawerPage';
 import {ModelsPage} from '../../pages/ModelsPage';
-import {Selectors, byPartialText} from '../../helpers/selectors';
+import {
+  Selectors,
+  byPartialText,
+  isAndroid,
+  nativeTextElement,
+} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
 import {TIMEOUTS} from '../../fixtures/models';
 import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
@@ -79,23 +84,40 @@ function pingModelsEndpoint(timeoutMs = 4000): Promise<boolean> {
 
 /**
  * Read the value shown on the server-type dropdown trigger. The ui Dropdown
- * renders the selected option's label as the trigger text and exposes that on
- * the trigger element's "label"/"name"/"value"/text. Reads off the EXISTING
- * element — the trigger deep in a bottom sheet can report isDisplayed=false on
- * iOS even when present, so we do not gate on visibility here.
+ * renders the selected option's label as both the trigger's accessibilityLabel
+ * and a child Text node. Reads off the EXISTING element — the trigger deep in a
+ * bottom sheet can report isDisplayed=false on iOS even when present, so we do
+ * not gate on visibility here.
+ *
+ * Cross-platform read: on iOS the accessibilityLabel surfaces via the trigger's
+ * "label"/"name"/"value" attributes. On Android (UiAutomator2) it maps to
+ * content-desc, and the trigger's own "text" is empty because the visible value
+ * lives in a child TextView — so we also try content-desc and the child Text.
  */
 async function readServerTypeValue(): Promise<string> {
   const trigger = browser.$(Selectors.serverType.dropdown());
   if (!(await trigger.isExisting().catch(() => false))) {
     return '';
   }
-  for (const attr of ['label', 'name', 'value']) {
+  const attrs = isAndroid()
+    ? ['content-desc', 'label', 'name', 'value']
+    : ['label', 'name', 'value'];
+  for (const attr of attrs) {
     const raw = await trigger.getAttribute(attr).catch(() => null);
     if (raw) {
       return raw;
     }
   }
-  return (await trigger.getText().catch(() => '')) || '';
+  const direct = (await trigger.getText().catch(() => '')) || '';
+  if (direct) {
+    return direct;
+  }
+  // Fall back to the child Text node (Android renders the value there).
+  const childText = await trigger
+    .$(nativeTextElement())
+    .getText()
+    .catch(() => '');
+  return childText || '';
 }
 
 /** Dump the current page source to debug-output for diagnosis. */

--- a/e2e/specs/features/remote-reasoning.spec.ts
+++ b/e2e/specs/features/remote-reasoning.spec.ts
@@ -1,0 +1,348 @@
+/**
+ * Remote Reasoning Feature Tests
+ *
+ * Exercises the remote (OpenAI-compatible) thinking/reasoning controls:
+ *   1. Add a remote server; the probe seeds the server-type selector to
+ *      "llama.cpp" (detectServerType -> seedServerType).
+ *   2. Save the server and select the remote reasoning model.
+ *   3. The thinking pill is reachable for the remote model (the headline fix —
+ *      the pill was previously gated on a native context the remote path lacks,
+ *      so it was never shown).
+ *   4. Thinking ON -> a reasoning bubble renders.
+ *   5. Thinking OFF -> no reasoning bubble (the server honors the off hint).
+ *
+ * Backend-gated, mirroring purchase-flow.spec.ts: the suite self-skips when the
+ * server is unreachable so CI without the LAN server stays green.
+ *
+ * Requires a real llama.cpp server with a reasoning model loaded.
+ *
+ * Environment:
+ *   E2E_LLAMACPP_SERVER_URL - server base URL
+ *                             (default http://192.168.0.92:8080)
+ *   E2E_LLAMACPP_MODEL_HINT - partial model name to find in pickers
+ *                             (default "Qwen3-1.7B")
+ *
+ * Usage:
+ *   npx ts-node scripts/run-e2e.ts --platform ios --spec remote-reasoning \
+ *     --devices iphone-17-pro-sim --skip-build
+ */
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
+import {expect} from '@wdio/globals';
+import {ChatPage} from '../../pages/ChatPage';
+import {DrawerPage} from '../../pages/DrawerPage';
+import {ModelsPage} from '../../pages/ModelsPage';
+import {Selectors, byPartialText} from '../../helpers/selectors';
+import {Gestures} from '../../helpers/gestures';
+import {TIMEOUTS} from '../../fixtures/models';
+import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
+
+declare const driver: WebdriverIO.Browser;
+declare const browser: WebdriverIO.Browser;
+
+const SERVER_URL =
+  process.env.E2E_LLAMACPP_SERVER_URL || 'http://192.168.0.92:8080';
+const MODEL_HINT = process.env.E2E_LLAMACPP_MODEL_HINT || 'Qwen3-1.7B';
+
+/**
+ * Ping GET {SERVER_URL}/v1/models from the test host. Resolves true when the
+ * server answers 2xx, false on any error or non-2xx. Used to backend-gate the
+ * suite (self-skip when the server is down).
+ */
+function pingModelsEndpoint(timeoutMs = 4000): Promise<boolean> {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (!settled) {
+        settled = true;
+        resolve(ok);
+      }
+    };
+    try {
+      const req = http.get(`${SERVER_URL}/v1/models`, res => {
+        const status = res.statusCode || 0;
+        res.resume();
+        finish(status >= 200 && status < 300);
+      });
+      req.setTimeout(timeoutMs, () => {
+        req.destroy();
+        finish(false);
+      });
+      req.on('error', () => finish(false));
+    } catch {
+      finish(false);
+    }
+  });
+}
+
+/**
+ * Read whether a server-type chip is currently selected. react-native-paper's
+ * Chip sets accessibilityState.selected, which iOS surfaces via the "selected"
+ * attribute and Android via "selected"/"checked". Reads the attribute off the
+ * EXISTING element — chips deep in a bottom sheet report isDisplayed=false on
+ * iOS even when present, so we do not gate on visibility here.
+ */
+async function isServerTypeChipSelected(option: string): Promise<boolean> {
+  const chip = browser.$(Selectors.serverType.chip(option));
+  if (!(await chip.isExisting().catch(() => false))) {
+    return false;
+  }
+  for (const attr of ['selected', 'checked']) {
+    const raw = await chip.getAttribute(attr).catch(() => null);
+    if (raw === 'true' || raw === '1') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Dump the current page source to debug-output for diagnosis. */
+async function dumpPageSource(name: string): Promise<void> {
+  try {
+    const dir = path.join(__dirname, '../../debug-output');
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, {recursive: true});
+    }
+    fs.writeFileSync(path.join(dir, name), await driver.getPageSource());
+    console.log(`Page source dumped to ${name}`);
+  } catch (e) {
+    console.log(`Failed to dump page source: ${(e as Error).message}`);
+  }
+}
+
+describe('Remote Reasoning Features', () => {
+  let chatPage: ChatPage;
+  let drawerPage: DrawerPage;
+  let modelsPage: ModelsPage;
+
+  before(async function (this: Mocha.Context) {
+    const reachable = await pingModelsEndpoint();
+    if (!reachable) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[remote-reasoning] Skipping: ${SERVER_URL}/v1/models unreachable. ` +
+          'Set E2E_LLAMACPP_SERVER_URL to a running llama.cpp server.',
+      );
+      this.skip();
+      return;
+    }
+
+    chatPage = new ChatPage();
+    drawerPage = new DrawerPage();
+    modelsPage = new ModelsPage();
+    await chatPage.waitForReady(TIMEOUTS.appReady);
+  });
+
+  beforeEach(async () => {
+    chatPage = new ChatPage();
+    drawerPage = new DrawerPage();
+    modelsPage = new ModelsPage();
+  });
+
+  afterEach(async function (this: Mocha.Context) {
+    if (this.currentTest?.state === 'failed') {
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const name = this.currentTest.title.replace(/\s+/g, '-');
+      try {
+        if (!fs.existsSync(SCREENSHOT_DIR)) {
+          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
+        }
+        await driver.saveScreenshot(
+          path.join(SCREENSHOT_DIR, `failure-${name}-${stamp}.png`),
+        );
+      } catch (e) {
+        console.error('Failed to capture screenshot:', (e as Error).message);
+      }
+    }
+  });
+
+  it('probe auto-selects the "llama.cpp" server type', async () => {
+    await chatPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToModels();
+    await modelsPage.waitForReady();
+
+    await modelsPage.openAddRemoteModel();
+
+    // Enter server URL and let the auto-probe fire (debounce + network).
+    const urlInput = browser.$(Selectors.remoteModel.urlInput);
+    await urlInput.waitForDisplayed({timeout: 5000});
+    await urlInput.clearValue();
+    await urlInput.setValue(SERVER_URL);
+    console.log(`Entered server URL: ${SERVER_URL}`);
+
+    // Dismiss the keyboard so it does not cover the lower sheet (it blocks
+    // both the probe-revealed fields and scrolling to the chip row).
+    await modelsPage.hideKeyboard();
+    await browser.pause(4000);
+
+    // The probe reveals the server fields incl. the server-type chip row.
+    const connectedText = browser.$(byPartialText('Connected'));
+    const isConnected = await connectedText
+      .waitForDisplayed({timeout: 12000})
+      .then(() => true)
+      .catch(() => false);
+    expect(isConnected).toBe(true);
+
+    // Scroll the chip row into the rendered region. On iOS, chips deep in a
+    // bottom sheet report isDisplayed=false, so scroll by existence.
+    await Gestures.scrollInSheetToElementExists(
+      Selectors.serverType.chip('llama.cpp'),
+      6,
+    );
+    const llamaChip = browser.$(Selectors.serverType.chip('llama.cpp'));
+    await llamaChip.waitForExist({timeout: 5000});
+
+    // detectServerType -> seedServerType should pre-select "llama.cpp".
+    const selected = await isServerTypeChipSelected('llama.cpp');
+    expect(selected).toBe(true);
+    console.log('Server type auto-selected: llama.cpp');
+  });
+
+  it('adds the remote model, selects it, and activates it in chat', async () => {
+    // Scroll the reasoning model row into view, then select it. The server
+    // exposes many models, so the target row is well below the fold.
+    await Gestures.scrollInSheetToElementExists(byPartialText(MODEL_HINT), 12);
+    const modelEl = browser.$(byPartialText(MODEL_HINT));
+    const modelExists = await modelEl
+      .waitForExist({timeout: 8000})
+      .then(() => true)
+      .catch(() => false);
+    expect(modelExists).toBe(true);
+    await modelEl.click();
+    console.log(`Selected model matching "${MODEL_HINT}" in add sheet`);
+    await browser.pause(500);
+
+    // Scroll to and tap "Add Model" (enabled once a model is selected).
+    await Gestures.scrollInSheetToElementExists(
+      Selectors.remoteModel.addModelButton,
+      6,
+    );
+    const addButton = browser.$(Selectors.remoteModel.addModelButton);
+    await addButton.waitForExist({timeout: 5000});
+    await addButton.waitForEnabled({timeout: 8000});
+    await addButton.click();
+    await browser.pause(1000);
+    console.log('Remote reasoning model added');
+
+    // Open chat and select the remote model from the picker.
+    await chatPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToChat();
+    await browser.pause(2000);
+
+    const selectModelBtn = browser.$(byPartialText('Select Model'));
+    const needsPick = await selectModelBtn
+      .waitForDisplayed({timeout: 8000})
+      .then(() => true)
+      .catch(() => false);
+    if (needsPick) {
+      await selectModelBtn.click();
+      await browser.pause(1000);
+
+      // Picker opens on the Pals tab; swipe to the Models tab.
+      const {width, height} = await driver.getWindowSize();
+      await driver
+        .action('pointer', {parameters: {pointerType: 'touch'}})
+        .move({x: Math.round(width * 0.8), y: Math.round(height * 0.65)})
+        .down()
+        .move({
+          x: Math.round(width * 0.2),
+          y: Math.round(height * 0.65),
+          duration: 300,
+        })
+        .up()
+        .perform();
+      await browser.pause(1000);
+
+      const pickerModel = browser.$(byPartialText(MODEL_HINT));
+      await pickerModel.waitForExist({timeout: 10000});
+      await pickerModel.click();
+    }
+
+    // Activation (setRemoteModel) is async: it releases any context and reads
+    // the API key from the keychain before activeModel resolves and the chat
+    // input renders. Poll until the chat input appears.
+    const chatInput = browser.$(Selectors.chat.input);
+    const activated = await chatInput
+      .waitForDisplayed({timeout: 20000})
+      .then(() => true)
+      .catch(() => false);
+    if (!activated) {
+      await dumpPageSource('remote-not-activated.xml');
+    }
+    expect(activated).toBe(true);
+    console.log('Remote reasoning model activated in chat');
+  });
+
+  it('exposes the thinking pill for the remote model', async () => {
+    // The headline fix: the pill is reachable for a remote model whose
+    // reasoning capability is "unknown" (fail-open), not gated on a native
+    // context the remote path lacks. Poll because activation just settled.
+    let visible = false;
+    await browser.waitUntil(
+      async () => {
+        visible = await chatPage.isThinkingToggleVisible();
+        return visible;
+      },
+      {timeout: 15000, interval: 1000, timeoutMsg: 'thinking pill not shown'},
+    ).catch(() => undefined);
+    if (!visible) {
+      await dumpPageSource('remote-pill-missing.xml');
+    }
+    expect(visible).toBe(true);
+    console.log('Thinking pill reachable for remote model');
+  });
+
+  it('renders a reasoning bubble when thinking is ON', async () => {
+    await chatPage.resetChat();
+
+    // A fresh session defaults the toggle ON; ensure it is on.
+    if (!(await chatPage.isThinkingEnabled())) {
+      await chatPage.tapThinkingToggle();
+    }
+    expect(await chatPage.isThinkingEnabled()).toBe(true);
+
+    await chatPage.sendMessage('What is 17*23?');
+
+    // The reasoning bubble renders as the assistant turn begins streaming, so
+    // assert it during early stream — well before completion. (A reasoning
+    // model on a real server returns reasoning_content first.)
+    const thinkingVisible = await chatPage.isThinkingBubbleVisible(45000);
+    if (!thinkingVisible) {
+      await dumpPageSource('remote-reasoning-on-missing.xml');
+    }
+    expect(thinkingVisible).toBe(true);
+    console.log('Reasoning bubble rendered with thinking ON');
+  });
+
+  it('renders no reasoning bubble when thinking is OFF', async () => {
+    await chatPage.resetChat();
+
+    // Guard against a false pass: the OFF assertion is only meaningful if the
+    // pill is actually present and starts enabled (default on).
+    expect(await chatPage.isThinkingEnabled()).toBe(true);
+
+    // Disable thinking and confirm the toggle actually flipped.
+    await chatPage.tapThinkingToggle();
+    expect(await chatPage.isThinkingEnabled()).toBe(false);
+
+    await chatPage.sendMessage('What is 17*23?');
+
+    // Wait for the assistant turn to begin streaming so the absence check is
+    // meaningful (not asserting before any reply has started).
+    const aiMessageEl = browser.$(Selectors.chat.aiMessage);
+    await aiMessageEl.waitForExist({timeout: TIMEOUTS.inference});
+    await browser.pause(3000);
+
+    // The server honors the off hint -> no reasoning_content -> no bubble.
+    const thinkingVisible = await chatPage.isThinkingBubbleVisible(3000);
+    if (thinkingVisible) {
+      await dumpPageSource('remote-reasoning-off-present.xml');
+    }
+    expect(thinkingVisible).toBe(false);
+    console.log('No reasoning bubble with thinking OFF (off hint honored)');
+  });
+});

--- a/src/api/__tests__/completionEngines.test.ts
+++ b/src/api/__tests__/completionEngines.test.ts
@@ -140,12 +140,14 @@ describe('OpenAICompletionEngine', () => {
         max_tokens: 200,
         stop: ['</s>'],
         stream: true,
+        reasoning: undefined,
       },
       'http://localhost:1234',
       'sk-key',
       expect.any(Object), // AbortSignal
       onToken,
       undefined, // timeoutMs
+      undefined, // serverType
     );
 
     expect(result).toEqual(mockResult);
@@ -188,6 +190,7 @@ describe('OpenAICompletionEngine', () => {
       expect.any(Object),
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -218,6 +221,7 @@ describe('OpenAICompletionEngine', () => {
       expect.any(Object),
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -246,6 +250,7 @@ describe('OpenAICompletionEngine', () => {
       'http://localhost:1234',
       'sk-key',
       expect.any(Object),
+      undefined,
       undefined,
       undefined,
     );
@@ -299,6 +304,7 @@ describe('OpenAICompletionEngine', () => {
       expect.any(Object), // AbortSignal
       undefined, // callback
       600000, // raw timeoutMs forwarded, not normalized
+      undefined, // serverType
     );
   });
 
@@ -319,6 +325,33 @@ describe('OpenAICompletionEngine', () => {
       expect.any(Object),
       undefined,
       undefined,
+      undefined,
+    );
+  });
+
+  it('forwards params.reasoning and the constructed serverType', async () => {
+    const typedEngine = new OpenAICompletionEngine(
+      'http://localhost:1234',
+      'test-model',
+      'sk-key',
+      undefined,
+      'Ollama',
+    );
+    mockedStreamChat.mockResolvedValueOnce({text: '', content: ''});
+
+    await typedEngine.completion({
+      messages: [{role: 'user', content: 'Hi'}],
+      reasoning: {enabled: false},
+    } as any);
+
+    expect(mockedStreamChat).toHaveBeenCalledWith(
+      expect.objectContaining({reasoning: {enabled: false}}),
+      'http://localhost:1234',
+      'sk-key',
+      expect.any(Object),
+      undefined,
+      undefined,
+      'Ollama',
     );
   });
 });

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -1272,9 +1272,9 @@ describe('buildReasoningPayload (per-serverType gating)', () => {
     });
   });
 
-  it('llama.cpp OFF sends enable_thinking:false + reasoning_format none', () => {
+  it('llama.cpp OFF sends enable_thinking:false + reasoning_format auto', () => {
     expect(buildReasoningPayload('llama.cpp', {enabled: false})).toEqual({
-      reasoning_format: 'none',
+      reasoning_format: 'auto',
       chat_template_kwargs: {enable_thinking: false},
     });
   });
@@ -1362,7 +1362,7 @@ describe('streamChatCompletion reasoning payload', () => {
     );
     const xhr = MockXHR.instances[0];
     const body = JSON.parse(xhr.requestBody);
-    expect(body.reasoning_format).toBe('none');
+    expect(body.reasoning_format).toBe('auto');
     expect(body.chat_template_kwargs).toEqual({enable_thinking: false});
     // The internal carrier is never sent on the wire.
     expect(body).not.toHaveProperty('reasoning');

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -1263,6 +1263,15 @@ describe('buildReasoningPayload (per-serverType gating)', () => {
     });
   });
 
+  it('llama.cpp ON+effort sends reasoning_format auto + reasoning_effort', () => {
+    expect(
+      buildReasoningPayload('llama.cpp', {enabled: true, effort: 'high'}),
+    ).toEqual({
+      reasoning_format: 'auto',
+      chat_template_kwargs: {reasoning_effort: 'high'},
+    });
+  });
+
   it('llama.cpp OFF sends enable_thinking:false + reasoning_format none', () => {
     expect(buildReasoningPayload('llama.cpp', {enabled: false})).toEqual({
       reasoning_format: 'none',
@@ -1270,14 +1279,29 @@ describe('buildReasoningPayload (per-serverType gating)', () => {
     });
   });
 
-  it('LM Studio OFF sends enable_thinking:false, ON sends nothing', () => {
+  it('LM Studio is on/off only — no graded effort', () => {
     expect(buildReasoningPayload('LM Studio', {enabled: false})).toEqual({
       chat_template_kwargs: {enable_thinking: false},
     });
     expect(buildReasoningPayload('LM Studio', {enabled: true})).toEqual({});
+    // Even when an effort is set, LM Studio never sends reasoning_effort.
+    const onEffort = buildReasoningPayload('LM Studio', {
+      enabled: true,
+      effort: 'high',
+    });
+    expect(onEffort).toEqual({});
+    expect(onEffort).not.toHaveProperty('reasoning_effort');
   });
 
-  it('vLLM behaves like LM Studio', () => {
+  it('vLLM ON+effort sends chat_template_kwargs.reasoning_effort', () => {
+    expect(
+      buildReasoningPayload('vLLM', {enabled: true, effort: 'max'}),
+    ).toEqual({chat_template_kwargs: {reasoning_effort: 'max'}});
+    // ON without an effort sends nothing.
+    expect(buildReasoningPayload('vLLM', {enabled: true})).toEqual({});
+  });
+
+  it('vLLM OFF sends enable_thinking:false', () => {
     expect(buildReasoningPayload('vLLM', {enabled: false})).toEqual({
       chat_template_kwargs: {enable_thinking: false},
     });

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -4,6 +4,7 @@ import {
   detectServerType,
   testConnection,
   streamChatCompletion,
+  buildReasoningPayload,
 } from '../openai';
 
 /** Build a minimal Headers-like object for fetch mocks. */
@@ -1248,5 +1249,134 @@ describe('streamChatCompletion', () => {
         await expect(resultPromise).rejects.toThrow('Connection timed out');
       });
     });
+  });
+});
+
+describe('buildReasoningPayload (per-serverType gating)', () => {
+  it('returns empty when no reasoning intent', () => {
+    expect(buildReasoningPayload('llama.cpp', undefined)).toEqual({});
+  });
+
+  it('llama.cpp ON sends reasoning_format auto', () => {
+    expect(buildReasoningPayload('llama.cpp', {enabled: true})).toEqual({
+      reasoning_format: 'auto',
+    });
+  });
+
+  it('llama.cpp OFF sends enable_thinking:false + reasoning_format none', () => {
+    expect(buildReasoningPayload('llama.cpp', {enabled: false})).toEqual({
+      reasoning_format: 'none',
+      chat_template_kwargs: {enable_thinking: false},
+    });
+  });
+
+  it('LM Studio OFF sends enable_thinking:false, ON sends nothing', () => {
+    expect(buildReasoningPayload('LM Studio', {enabled: false})).toEqual({
+      chat_template_kwargs: {enable_thinking: false},
+    });
+    expect(buildReasoningPayload('LM Studio', {enabled: true})).toEqual({});
+  });
+
+  it('vLLM behaves like LM Studio', () => {
+    expect(buildReasoningPayload('vLLM', {enabled: false})).toEqual({
+      chat_template_kwargs: {enable_thinking: false},
+    });
+  });
+
+  it('Ollama OFF sends only reasoning_effort none and never think:true', () => {
+    const off = buildReasoningPayload('Ollama', {enabled: false});
+    expect(off).toEqual({reasoning_effort: 'none'});
+    expect(off).not.toHaveProperty('think');
+    // ON sends nothing — never think:true, never a non-none effort.
+    const on = buildReasoningPayload('Ollama', {enabled: true, effort: 'high'});
+    expect(on).toEqual({});
+    expect(on).not.toHaveProperty('think');
+    expect(on).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('OpenAI sends reasoning_effort only when effort is known', () => {
+    expect(
+      buildReasoningPayload('OpenAI', {enabled: true, effort: 'medium'}),
+    ).toEqual({reasoning_effort: 'medium'});
+    // No effort known → omit everything (no enable_thinking, no 400 bait).
+    expect(buildReasoningPayload('OpenAI', {enabled: true})).toEqual({});
+    expect(buildReasoningPayload('OpenAI', {enabled: false})).toEqual({});
+  });
+
+  it('unknown serverType omits everything', () => {
+    expect(buildReasoningPayload(undefined, {enabled: false})).toEqual({});
+    expect(
+      buildReasoningPayload('something-else', {enabled: false, effort: 'low'}),
+    ).toEqual({});
+  });
+});
+
+describe('streamChatCompletion reasoning payload', () => {
+  let originalXHR: typeof XMLHttpRequest;
+  beforeEach(() => {
+    originalXHR = global.XMLHttpRequest;
+    (global as any).XMLHttpRequest = MockXHR;
+    MockXHR.instances = [];
+  });
+  afterEach(() => {
+    global.XMLHttpRequest = originalXHR;
+  });
+
+  it('attaches the gated payload by serverType', async () => {
+    const resultPromise = streamChatCompletion(
+      {
+        messages: [{role: 'user', content: 'Hi'}],
+        model: 'm',
+        reasoning: {enabled: false},
+      },
+      'http://localhost:1234',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'llama.cpp',
+    );
+    const xhr = MockXHR.instances[0];
+    const body = JSON.parse(xhr.requestBody);
+    expect(body.reasoning_format).toBe('none');
+    expect(body.chat_template_kwargs).toEqual({enable_thinking: false});
+    // The internal carrier is never sent on the wire.
+    expect(body).not.toHaveProperty('reasoning');
+
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+    );
+    xhr.simulateLoad();
+    await resultPromise;
+  });
+
+  it('omits reasoning controls for an unknown serverType', async () => {
+    const resultPromise = streamChatCompletion(
+      {
+        messages: [{role: 'user', content: 'Hi'}],
+        model: 'm',
+        reasoning: {enabled: false, effort: 'high'},
+      },
+      'http://localhost:1234',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+    const xhr = MockXHR.instances[0];
+    const body = JSON.parse(xhr.requestBody);
+    expect(body).not.toHaveProperty('reasoning_format');
+    expect(body).not.toHaveProperty('chat_template_kwargs');
+    expect(body).not.toHaveProperty('reasoning_effort');
+    expect(body).not.toHaveProperty('think');
+
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+    );
+    xhr.simulateLoad();
+    await resultPromise;
   });
 });

--- a/src/api/completionEngines.ts
+++ b/src/api/completionEngines.ts
@@ -68,6 +68,7 @@ export class OpenAICompletionEngine implements CompletionEngine {
     private modelId: string,
     private apiKey?: string,
     private timeoutMs?: number,
+    private serverType?: string,
   ) {}
 
   async completion(
@@ -91,12 +92,15 @@ export class OpenAICompletionEngine implements CompletionEngine {
         tools: (params as any).tools,
         tool_choice: (params as any).tool_choice,
         response_format: (params as any).response_format,
+        // Reasoning intent carried on the params; openai.ts owns the wire shape.
+        reasoning: params.reasoning,
       },
       this.serverUrl,
       this.apiKey,
       this.abortController.signal,
       callback,
       this.timeoutMs,
+      this.serverType,
     );
   }
 

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -353,9 +353,13 @@ export async function detectServerType(
  * is keyed on the PERSISTED serverType (never live detection). An unknown /
  * strict server receives no reasoning controls — omit beats a 400.
  *
- * - llama.cpp: OFF → enable_thinking:false + reasoning_format:none; ON →
- *   reasoning_format:auto. (ignores unknown → safe)
- * - LM Studio / vLLM (modern): OFF → enable_thinking:false. (ignores unknown)
+ * - llama.cpp: ON+effort → reasoning_format:auto + chat_template_kwargs:
+ *   {reasoning_effort}; ON → reasoning_format:auto; OFF → reasoning_format:none
+ *   + chat_template_kwargs:{enable_thinking:false}. (ignores unknown → safe)
+ * - vLLM (modern): ON+effort → chat_template_kwargs:{reasoning_effort}; ON →
+ *   nothing; OFF → chat_template_kwargs:{enable_thinking:false}. (ignores unknown)
+ * - LM Studio: on/off only — its chat API ignores reasoning_effort. ON →
+ *   nothing; OFF → chat_template_kwargs:{enable_thinking:false}.
  * - Ollama (/v1): OFF → reasoning_effort:'none' (safe no-op). NEVER think:true,
  *   NEVER a non-'none' effort (hard-400 risk). Graded effort deferred.
  * - OpenAI: reasoning_effort:<value> only when axis-2 effort is known for the
@@ -372,14 +376,25 @@ export function buildReasoningPayload(
   const {enabled, effort} = reasoning;
   switch (serverType) {
     case 'llama.cpp':
-      return enabled
-        ? {reasoning_format: 'auto'}
-        : {
-            reasoning_format: 'none',
-            chat_template_kwargs: {enable_thinking: false},
-          };
-    case 'LM Studio':
+      if (!enabled) {
+        return {
+          reasoning_format: 'none',
+          chat_template_kwargs: {enable_thinking: false},
+        };
+      }
+      return effort
+        ? {
+            reasoning_format: 'auto',
+            chat_template_kwargs: {reasoning_effort: effort},
+          }
+        : {reasoning_format: 'auto'};
     case 'vLLM':
+      if (!enabled) {
+        return {chat_template_kwargs: {enable_thinking: false}};
+      }
+      return effort ? {chat_template_kwargs: {reasoning_effort: effort}} : {};
+    case 'LM Studio':
+      // On/off only; the LM Studio chat API ignores reasoning_effort.
       return enabled ? {} : {chat_template_kwargs: {enable_thinking: false}};
     case 'Ollama':
       // OFF sends a safe no-op; ON sends nothing (never think:true).

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -353,9 +353,10 @@ export async function detectServerType(
  * is keyed on the PERSISTED serverType (never live detection). An unknown /
  * strict server receives no reasoning controls — omit beats a 400.
  *
- * - llama.cpp: ON+effort → reasoning_format:auto + chat_template_kwargs:
- *   {reasoning_effort}; ON → reasoning_format:auto; OFF → reasoning_format:none
- *   + chat_template_kwargs:{enable_thinking:false}. (ignores unknown → safe)
+ * - llama.cpp: reasoning_format always 'auto' (no-op for non-reasoning models;
+ *   prevents raw channel/think markers leaking into content). ON+effort →
+ *   + chat_template_kwargs:{reasoning_effort}; OFF → + chat_template_kwargs:
+ *   {enable_thinking:false}. (ignores unknown → safe)
  * - vLLM (modern): ON+effort → chat_template_kwargs:{reasoning_effort}; ON →
  *   nothing; OFF → chat_template_kwargs:{enable_thinking:false}. (ignores unknown)
  * - LM Studio: on/off only — its chat API ignores reasoning_effort. ON →
@@ -376,9 +377,14 @@ export function buildReasoningPayload(
   const {enabled, effort} = reasoning;
   switch (serverType) {
     case 'llama.cpp':
+      // reasoning_format is always 'auto': a no-op for non-reasoning models and
+      // the value that extracts reasoning into reasoning_content instead of
+      // leaking raw channel/think markers into content (e.g. gemma-4 emits an
+      // empty <|channel>thought block even when thinking is off). On/off is
+      // carried solely by enable_thinking.
       if (!enabled) {
         return {
-          reasoning_format: 'none',
+          reasoning_format: 'auto',
           chat_template_kwargs: {enable_thinking: false},
         };
       }

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -2,6 +2,7 @@ import {SSEParser} from './sseParser';
 import {
   CompletionResult,
   CompletionStreamData,
+  ReasoningIntent,
   ToolCall,
 } from '../utils/completionTypes';
 
@@ -67,6 +68,8 @@ export interface StreamChatParams {
   tools?: OpenAIToolDefinition[];
   tool_choice?: OpenAIToolChoice;
   response_format?: OpenAIResponseFormat;
+  /** Reasoning on/off + effort intent; translated to a per-serverType payload. */
+  reasoning?: ReasoningIntent;
 }
 
 /**
@@ -345,6 +348,50 @@ export async function detectServerType(
  * React Native's fetch does not expose response.body (ReadableStream), so
  * XMLHttpRequest with onprogress is the standard approach for SSE streaming.
  */
+/**
+ * Translate the reasoning intent into the per-serverType wire payload. Gating
+ * is keyed on the PERSISTED serverType (never live detection). An unknown /
+ * strict server receives no reasoning controls — omit beats a 400.
+ *
+ * - llama.cpp: OFF → enable_thinking:false + reasoning_format:none; ON →
+ *   reasoning_format:auto. (ignores unknown → safe)
+ * - LM Studio / vLLM (modern): OFF → enable_thinking:false. (ignores unknown)
+ * - Ollama (/v1): OFF → reasoning_effort:'none' (safe no-op). NEVER think:true,
+ *   NEVER a non-'none' effort (hard-400 risk). Graded effort deferred.
+ * - OpenAI: reasoning_effort:<value> only when axis-2 effort is known for the
+ *   model id; nothing for on/off (400 on misapplied params).
+ * - unknown / old vLLM: omit everything.
+ */
+export function buildReasoningPayload(
+  serverType: string | undefined,
+  reasoning: ReasoningIntent | undefined,
+): Record<string, any> {
+  if (!reasoning) {
+    return {};
+  }
+  const {enabled, effort} = reasoning;
+  switch (serverType) {
+    case 'llama.cpp':
+      return enabled
+        ? {reasoning_format: 'auto'}
+        : {
+            reasoning_format: 'none',
+            chat_template_kwargs: {enable_thinking: false},
+          };
+    case 'LM Studio':
+    case 'vLLM':
+      return enabled ? {} : {chat_template_kwargs: {enable_thinking: false}};
+    case 'Ollama':
+      // OFF sends a safe no-op; ON sends nothing (never think:true).
+      return enabled ? {} : {reasoning_effort: 'none'};
+    case 'OpenAI':
+      return effort ? {reasoning_effort: effort} : {};
+    default:
+      // unknown / old vLLM — omit everything.
+      return {};
+  }
+}
+
 export async function streamChatCompletion(
   params: StreamChatParams,
   serverUrl: string,
@@ -352,6 +399,7 @@ export async function streamChatCompletion(
   signal?: AbortSignal,
   onToken?: (data: CompletionStreamData) => void,
   timeoutMs?: number,
+  serverType?: string,
 ): Promise<CompletionResult> {
   const url = `${normalizeUrl(serverUrl)}/v1/chat/completions`;
   const connectionTimeoutMs = resolveTimeout(timeoutMs, CONNECTION_TIMEOUT_MS);
@@ -734,6 +782,22 @@ export async function streamChatCompletion(
         };
       } else {
         requestBody.response_format = params.response_format;
+      }
+    }
+    // Per-serverType reasoning controls. Merge chat_template_kwargs rather than
+    // overwrite so a future caller-supplied kwarg is preserved.
+    const reasoningPayload = buildReasoningPayload(
+      serverType,
+      params.reasoning,
+    );
+    for (const [key, value] of Object.entries(reasoningPayload)) {
+      if (key === 'chat_template_kwargs') {
+        requestBody.chat_template_kwargs = {
+          ...requestBody.chat_template_kwargs,
+          ...value,
+        };
+      } else {
+        requestBody[key] = value;
       }
     }
     xhr.send(JSON.stringify(requestBody));

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -71,6 +71,14 @@ export interface ChatInputTopLevelProps {
   isThinkingEnabled?: boolean;
   /** Callback when thinking toggle is pressed */
   onThinkingToggle?: (enabled: boolean) => void;
+  /** Whether the model supports graded reasoning effort (axis 2) */
+  supportsEffort?: boolean;
+  /** The graded effort value set, e.g. ['low','medium','high'] */
+  effortValues?: string[];
+  /** Currently selected reasoning effort (when graded) */
+  reasoningEffort?: string;
+  /** Callback to cycle the graded effort state (off -> values -> off) */
+  onEffortCycle?: () => void;
 }
 
 export interface ChatInputAdditionalProps {
@@ -88,6 +96,14 @@ export interface ChatInputAdditionalProps {
   isThinkingEnabled?: boolean;
   /** Callback when thinking toggle is pressed */
   onThinkingToggle?: (enabled: boolean) => void;
+  /** Whether the model supports graded reasoning effort (axis 2) */
+  supportsEffort?: boolean;
+  /** The graded effort value set, e.g. ['low','medium','high'] */
+  effortValues?: string[];
+  /** Currently selected reasoning effort (when graded) */
+  reasoningEffort?: string;
+  /** Callback to cycle the graded effort state (off -> values -> off) */
+  onEffortCycle?: () => void;
 }
 
 export type ChatInputProps = ChatInputTopLevelProps & ChatInputAdditionalProps;
@@ -122,6 +138,10 @@ export const ChatInput = observer(
     showThinkingToggle = false,
     isThinkingEnabled = false,
     onThinkingToggle,
+    supportsEffort = false,
+    effortValues = [],
+    reasoningEffort,
+    onEffortCycle,
   }: ChatInputProps) => {
     const l10n = React.useContext(L10nContext);
     const theme = useTheme();
@@ -542,15 +562,22 @@ export const ChatInput = observer(
                 )}
               </View>
 
-              {/* Thinking Toggle Button */}
+              {/* Thinking Toggle Button. Graded models (axis-2) cycle
+                  off -> low -> medium -> high; effortless models toggle
+                  on/off. The label shows the current effort when graded. */}
               {showThinkingToggle && !isCameraActive && (
                 <TouchableOpacity
+                  testID="thinking-toggle"
                   style={[
                     styles.thinkingToggleLeft,
                     isThinkingEnabled && {backgroundColor: onSurfaceColor},
                     {borderColor: onSurfaceColorVariant},
                   ]}
-                  onPress={() => onThinkingToggle?.(!isThinkingEnabled)}
+                  onPress={() =>
+                    supportsEffort && effortValues.length > 0
+                      ? onEffortCycle?.()
+                      : onThinkingToggle?.(!isThinkingEnabled)
+                  }
                   accessibilityLabel={
                     isThinkingEnabled
                       ? l10n.components.chatInput.thinkingToggle.disableThinking
@@ -574,7 +601,9 @@ export const ChatInput = observer(
                         ? {color: inputBackgroundColor}
                         : {color: onSurfaceColorVariant},
                     ]}>
-                    {l10n.components.chatInput.thinkingToggle.thinkText}
+                    {supportsEffort && isThinkingEnabled && reasoningEffort
+                      ? reasoningEffort
+                      : l10n.components.chatInput.thinkingToggle.thinkText}
                   </Text>
                 </TouchableOpacity>
               )}

--- a/src/components/ChatInput/ChatInput.tsx
+++ b/src/components/ChatInput/ChatInput.tsx
@@ -33,6 +33,7 @@ import {chatSessionStore, modelStore, palStore, uiStore} from '../../store';
 
 import {MessageType} from '../../utils/types';
 import {L10nContext, UserContext} from '../../utils';
+import {t} from '../../locales';
 
 import {SendButton, StopButton, Menu, VoiceChip} from '..';
 
@@ -366,6 +367,14 @@ export const ChatInput = observer(
       ? onSurfaceColor
       : onSurfaceColorVariant;
 
+    // Localize the current graded-effort tier through the same table the
+    // model-settings chips use; fall back to the raw token for an unlisted one.
+    const effortLevelLabels = l10n.components.modelSettingsSheet.effortLevels;
+    const localizedEffort =
+      reasoningEffort && reasoningEffort in effortLevelLabels
+        ? effortLevelLabels[reasoningEffort as keyof typeof effortLevelLabels]
+        : reasoningEffort;
+
     return (
       <View style={styles.container}>
         <View style={styles.inputContainer}>
@@ -579,9 +588,18 @@ export const ChatInput = observer(
                       : onThinkingToggle?.(!isThinkingEnabled)
                   }
                   accessibilityLabel={
-                    isThinkingEnabled
-                      ? l10n.components.chatInput.thinkingToggle.disableThinking
-                      : l10n.components.chatInput.thinkingToggle.enableThinking
+                    supportsEffort && effortValues.length > 0
+                      ? t(
+                          l10n.components.chatInput.thinkingToggle.cycleEffort,
+                          {
+                            level: localizedEffort ?? '',
+                          },
+                        )
+                      : isThinkingEnabled
+                        ? l10n.components.chatInput.thinkingToggle
+                            .disableThinking
+                        : l10n.components.chatInput.thinkingToggle
+                            .enableThinking
                   }
                   accessibilityRole="button">
                   <AtomIcon
@@ -602,7 +620,7 @@ export const ChatInput = observer(
                         : {color: onSurfaceColorVariant},
                     ]}>
                     {supportsEffort && isThinkingEnabled && reasoningEffort
-                      ? reasoningEffort
+                      ? localizedEffort
                       : l10n.components.chatInput.thinkingToggle.thinkText}
                   </Text>
                 </TouchableOpacity>

--- a/src/components/ChatInput/__tests__/ChatInputThinking.test.tsx
+++ b/src/components/ChatInput/__tests__/ChatInputThinking.test.tsx
@@ -266,6 +266,25 @@ describe('ChatInput Thinking Toggle', () => {
     expect(queryByText('minimal')).toBeNull();
   });
 
+  it('degrades an unlisted tier to the raw string instead of dropping it', () => {
+    const {getByText} = render(
+      <UserContext.Provider value={mockUser}>
+        <ChatInput
+          {...defaultProps}
+          showThinkingToggle={true}
+          isThinkingEnabled={true}
+          onThinkingToggle={jest.fn()}
+          supportsEffort={true}
+          effortValues={['low', 'medium', 'high']}
+          reasoningEffort="turbo"
+          onEffortCycle={jest.fn()}
+        />
+      </UserContext.Provider>,
+    );
+
+    expect(getByText('turbo')).toBeTruthy();
+  });
+
   it('announces the active tier and that the control cycles on a graded pill', () => {
     const {getByLabelText, queryByLabelText} = render(
       <UserContext.Provider value={mockUser}>

--- a/src/components/ChatInput/__tests__/ChatInputThinking.test.tsx
+++ b/src/components/ChatInput/__tests__/ChatInputThinking.test.tsx
@@ -226,6 +226,91 @@ describe('ChatInput Thinking Toggle', () => {
     expect(getByLabelText('Enable thinking mode')).toBeTruthy();
   });
 
+  it('renders the localized effort tier on the graded pill, not the raw token', () => {
+    const {getByText, queryByText} = render(
+      <UserContext.Provider value={mockUser}>
+        <ChatInput
+          {...defaultProps}
+          showThinkingToggle={true}
+          isThinkingEnabled={true}
+          onThinkingToggle={jest.fn()}
+          supportsEffort={true}
+          effortValues={['low', 'medium', 'high']}
+          reasoningEffort="high"
+          onEffortCycle={jest.fn()}
+        />
+      </UserContext.Provider>,
+    );
+
+    expect(getByText('High')).toBeTruthy();
+    expect(queryByText('high')).toBeNull();
+  });
+
+  it('looks the tier up in the table rather than hardcoding a single value', () => {
+    const {getByText, queryByText} = render(
+      <UserContext.Provider value={mockUser}>
+        <ChatInput
+          {...defaultProps}
+          showThinkingToggle={true}
+          isThinkingEnabled={true}
+          onThinkingToggle={jest.fn()}
+          supportsEffort={true}
+          effortValues={['minimal', 'low', 'medium']}
+          reasoningEffort="minimal"
+          onEffortCycle={jest.fn()}
+        />
+      </UserContext.Provider>,
+    );
+
+    expect(getByText('Minimal')).toBeTruthy();
+    expect(queryByText('minimal')).toBeNull();
+  });
+
+  it('announces the active tier and that the control cycles on a graded pill', () => {
+    const {getByLabelText, queryByLabelText} = render(
+      <UserContext.Provider value={mockUser}>
+        <ChatInput
+          {...defaultProps}
+          showThinkingToggle={true}
+          isThinkingEnabled={true}
+          onThinkingToggle={jest.fn()}
+          supportsEffort={true}
+          effortValues={['low', 'medium', 'high']}
+          reasoningEffort="high"
+          onEffortCycle={jest.fn()}
+        />
+      </UserContext.Provider>,
+    );
+
+    expect(getByLabelText(/Reasoning effort: High/i)).toBeTruthy();
+    expect(getByLabelText(/cycle/i)).toBeTruthy();
+    expect(queryByLabelText('Disable thinking mode')).toBeNull();
+  });
+
+  it('cycles effort instead of toggling when the graded pill is pressed', () => {
+    const mockOnEffortCycle = jest.fn();
+    const mockOnThinkingToggle = jest.fn();
+    const {getByLabelText} = render(
+      <UserContext.Provider value={mockUser}>
+        <ChatInput
+          {...defaultProps}
+          showThinkingToggle={true}
+          isThinkingEnabled={true}
+          onThinkingToggle={mockOnThinkingToggle}
+          supportsEffort={true}
+          effortValues={['low', 'medium', 'high']}
+          reasoningEffort="high"
+          onEffortCycle={mockOnEffortCycle}
+        />
+      </UserContext.Provider>,
+    );
+
+    fireEvent.press(getByLabelText(/Reasoning effort: High/i));
+
+    expect(mockOnEffortCycle).toHaveBeenCalledTimes(1);
+    expect(mockOnThinkingToggle).not.toHaveBeenCalled();
+  });
+
   it('should handle missing onThinkingToggle callback gracefully', () => {
     const {getByLabelText} = render(
       <UserContext.Provider value={mockUser}>

--- a/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
+++ b/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
@@ -4,7 +4,7 @@ import {Button, Text, Divider, Switch, Chip} from 'react-native-paper';
 import {ModelSettings} from '../../screens/ModelsScreen/ModelSettings';
 import {Sheet} from '../Sheet';
 import {ProjectionModelSelector} from '../ProjectionModelSelector';
-import {Model} from '../../utils/types';
+import {Model, ModelOrigin} from '../../utils/types';
 import {modelStore, serverStore} from '../../store';
 import {chatTemplates} from '../../utils/chat';
 import {
@@ -33,6 +33,10 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
       model?.stopWords || [],
     );
     const l10n = useContext(L10nContext);
+
+    // Remote models have no local-only settings (chat template, stop words,
+    // tokens) — only the reasoning override applies to them.
+    const isRemote = model?.origin === ModelOrigin.REMOTE;
 
     // Reasoning override (seeded from the resolver so the controls show the
     // effective state). Axis-1 is reasoning yes/no; axis-2 graded effort + set.
@@ -104,9 +108,11 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
 
     const handleSaveSettings = () => {
       if (model) {
-        modelStore.updateModelName(model.id, tempModelName);
-        modelStore.updateModelChatTemplate(model.id, tempChatTemplate);
-        modelStore.updateModelStopWords(model.id, tempStopWords);
+        if (!isRemote) {
+          modelStore.updateModelName(model.id, tempModelName);
+          modelStore.updateModelChatTemplate(model.id, tempChatTemplate);
+          modelStore.updateModelStopWords(model.id, tempStopWords);
+        }
         // Persist a source:'user' reasoning override only when the user
         // actually touched a reasoning control. Otherwise leave the existing
         // capability (detected/unknown/learned) intact.
@@ -136,7 +142,7 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
     };
 
     const handleReset = () => {
-      if (model) {
+      if (model && !isRemote) {
         // Reset to model default values
         modelStore.resetModelName(model.id);
         modelStore.resetModelChatTemplate(model.id);
@@ -160,14 +166,18 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
         <Sheet.ScrollView
           bottomOffset={16}
           contentContainerStyle={styles.sheetScrollViewContainer}>
-          <ModelSettings
-            modelName={tempModelName}
-            chatTemplate={tempChatTemplate}
-            stopWords={tempStopWords}
-            onChange={handleSettingsUpdate}
-            onStopWordsChange={value => setTempStopWords(value || [])}
-            onModelNameChange={handleModelNameChange}
-          />
+          {/* Chat template, stop words and token settings are local-only and
+              don't apply to remote models. */}
+          {!isRemote && (
+            <ModelSettings
+              modelName={tempModelName}
+              chatTemplate={tempChatTemplate}
+              stopWords={tempStopWords}
+              onChange={handleSettingsUpdate}
+              onStopWordsChange={value => setTempStopWords(value || [])}
+              onModelNameChange={handleModelNameChange}
+            />
+          )}
 
           {/* Multimodal Settings Section */}
           {model.supportsMultimodal && (
@@ -239,9 +249,11 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
         </Sheet.ScrollView>
         <Sheet.Actions>
           <View style={styles.secondaryButtons}>
-            <Button mode="text" onPress={handleReset}>
-              {l10n.common.reset}
-            </Button>
+            {!isRemote && (
+              <Button mode="text" onPress={handleReset}>
+                {l10n.common.reset}
+              </Button>
+            )}
             <Button mode="text" onPress={handleCancelSettings}>
               {l10n.common.cancel}
             </Button>

--- a/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
+++ b/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
@@ -10,6 +10,7 @@ import {chatTemplates} from '../../utils/chat';
 import {
   resolveReasoningCapability,
   EFFORT_LEVELS,
+  DEFAULT_EFFORT_VALUES,
   orderEffortValues,
 } from '../../utils/reasoningCapability';
 
@@ -65,6 +66,11 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
     const onSupportsEffortChange = (value: boolean) => {
       setReasoningDirty(true);
       setSupportsEffort(value);
+      // Pre-select the standard subset on first enable so the chips read as
+      // togglable (selected/unselected contrast) instead of an all-blank row.
+      if (value && effortSet.length === 0) {
+        setEffortSet(DEFAULT_EFFORT_VALUES);
+      }
     };
     const onEffortLevelToggle = (level: string) => {
       setReasoningDirty(true);

--- a/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
+++ b/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
@@ -43,6 +43,23 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
     const [effortValuesText, setEffortValuesText] = useState(() =>
       seedReasoning().effortValues.join(', '),
     );
+    // Whether the user touched any reasoning control this session. A save
+    // persists a source:'user' override only when dirty, so an unrelated save
+    // (e.g. rename) never overwrites a 'detected'/'unknown'/'learned' capability.
+    const [reasoningDirty, setReasoningDirty] = useState(false);
+
+    const onIsReasoningModelChange = (value: boolean) => {
+      setReasoningDirty(true);
+      setIsReasoningModel(value);
+    };
+    const onSupportsEffortChange = (value: boolean) => {
+      setReasoningDirty(true);
+      setSupportsEffort(value);
+    };
+    const onEffortValuesTextChange = (value: string) => {
+      setReasoningDirty(true);
+      setEffortValuesText(value);
+    };
 
     // Reset temp settings when model changes
     useEffect(() => {
@@ -57,6 +74,7 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
         setIsReasoningModel(cap.isReasoning === 'yes');
         setSupportsEffort(cap.supportsEffort);
         setEffortValuesText(cap.effortValues.join(', '));
+        setReasoningDirty(false);
       }
     }, [model]);
 
@@ -77,17 +95,23 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
         modelStore.updateModelName(model.id, tempModelName);
         modelStore.updateModelChatTemplate(model.id, tempChatTemplate);
         modelStore.updateModelStopWords(model.id, tempStopWords);
-        const effortValues = effortValuesText
-          .split(',')
-          .map(v => v.trim())
-          .filter(v => v.length > 0);
-        modelStore.setReasoningOverride(model.id, {
-          isReasoning: isReasoningModel ? 'yes' : 'no',
-          source: 'user',
-          supportsEffort: isReasoningModel && supportsEffort,
-          effortValues: isReasoningModel && supportsEffort ? effortValues : [],
-          effortSource: isReasoningModel && supportsEffort ? 'user' : 'none',
-        });
+        // Persist a source:'user' reasoning override only when the user
+        // actually touched a reasoning control. Otherwise leave the existing
+        // capability (detected/unknown/learned) intact.
+        if (reasoningDirty) {
+          const effortValues = effortValuesText
+            .split(',')
+            .map(v => v.trim())
+            .filter(v => v.length > 0);
+          modelStore.setReasoningOverride(model.id, {
+            isReasoning: isReasoningModel ? 'yes' : 'no',
+            source: 'user',
+            supportsEffort: isReasoningModel && supportsEffort,
+            effortValues:
+              isReasoningModel && supportsEffort ? effortValues : [],
+            effortSource: isReasoningModel && supportsEffort ? 'user' : 'none',
+          });
+        }
         onClose();
       }
     };
@@ -166,7 +190,7 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
             <Switch
               testID="reasoning-is-reasoning-switch"
               value={isReasoningModel}
-              onValueChange={setIsReasoningModel}
+              onValueChange={onIsReasoningModelChange}
             />
           </View>
           <Text variant="bodySmall" style={styles.reasoningHelp}>
@@ -179,7 +203,7 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
                 <Switch
                   testID="reasoning-supports-effort-switch"
                   value={supportsEffort}
-                  onValueChange={setSupportsEffort}
+                  onValueChange={onSupportsEffortChange}
                 />
               </View>
               {supportsEffort && (
@@ -191,7 +215,7 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
                     l10n.components.modelSettingsSheet.effortValuesPlaceholder
                   }
                   value={effortValuesText}
-                  onChangeText={setEffortValuesText}
+                  onChangeText={onEffortValuesTextChange}
                   autoCapitalize="none"
                 />
               )}

--- a/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
+++ b/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, memo, useContext} from 'react';
-import {Button, Text, Divider, Switch, TextInput} from 'react-native-paper';
+import {Button, Text, Divider, Switch, Chip} from 'react-native-paper';
 
 import {ModelSettings} from '../../screens/ModelsScreen/ModelSettings';
 import {Sheet} from '../Sheet';
@@ -7,7 +7,11 @@ import {ProjectionModelSelector} from '../ProjectionModelSelector';
 import {Model} from '../../utils/types';
 import {modelStore, serverStore} from '../../store';
 import {chatTemplates} from '../../utils/chat';
-import {resolveReasoningCapability} from '../../utils/reasoningCapability';
+import {
+  resolveReasoningCapability,
+  EFFORT_LEVELS,
+  orderEffortValues,
+} from '../../utils/reasoningCapability';
 
 import {styles} from './styles';
 import {View} from 'react-native';
@@ -40,8 +44,10 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
     const [supportsEffort, setSupportsEffort] = useState(
       () => seedReasoning().supportsEffort,
     );
-    const [effortValuesText, setEffortValuesText] = useState(() =>
-      seedReasoning().effortValues.join(', '),
+    // Selected effort levels (subset of EFFORT_LEVELS), persisted ordered
+    // low→medium→high so the pill cycle stays consistent.
+    const [effortSet, setEffortSet] = useState<string[]>(() =>
+      orderEffortValues(seedReasoning().effortValues),
     );
     // Whether the user touched any reasoning control this session. A save
     // persists a source:'user' override only when dirty, so an unrelated save
@@ -56,9 +62,15 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
       setReasoningDirty(true);
       setSupportsEffort(value);
     };
-    const onEffortValuesTextChange = (value: string) => {
+    const onEffortLevelToggle = (level: string) => {
       setReasoningDirty(true);
-      setEffortValuesText(value);
+      setEffortSet(prev =>
+        orderEffortValues(
+          prev.includes(level)
+            ? prev.filter(v => v !== level)
+            : [...prev, level],
+        ),
+      );
     };
 
     // Reset temp settings when model changes
@@ -73,7 +85,7 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
         );
         setIsReasoningModel(cap.isReasoning === 'yes');
         setSupportsEffort(cap.supportsEffort);
-        setEffortValuesText(cap.effortValues.join(', '));
+        setEffortSet(orderEffortValues(cap.effortValues));
         setReasoningDirty(false);
       }
     }, [model]);
@@ -99,10 +111,7 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
         // actually touched a reasoning control. Otherwise leave the existing
         // capability (detected/unknown/learned) intact.
         if (reasoningDirty) {
-          const effortValues = effortValuesText
-            .split(',')
-            .map(v => v.trim())
-            .filter(v => v.length > 0);
+          const effortValues = orderEffortValues(effortSet);
           modelStore.setReasoningOverride(model.id, {
             isReasoning: isReasoningModel ? 'yes' : 'no',
             source: 'user',
@@ -207,17 +216,23 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
                 />
               </View>
               {supportsEffort && (
-                <TextInput
-                  testID="reasoning-effort-values-input"
-                  mode="outlined"
-                  label={l10n.components.modelSettingsSheet.effortValues}
-                  placeholder={
-                    l10n.components.modelSettingsSheet.effortValuesPlaceholder
-                  }
-                  value={effortValuesText}
-                  onChangeText={onEffortValuesTextChange}
-                  autoCapitalize="none"
-                />
+                <>
+                  <Text variant="bodySmall" style={styles.reasoningHelp}>
+                    {l10n.components.modelSettingsSheet.effortValues}
+                  </Text>
+                  <View style={styles.effortChipsRow}>
+                    {EFFORT_LEVELS.map(level => (
+                      <Chip
+                        key={level}
+                        testID={`effort-chip-${level}`}
+                        selected={effortSet.includes(level)}
+                        showSelectedCheck
+                        onPress={() => onEffortLevelToggle(level)}>
+                        {l10n.components.modelSettingsSheet.effortLevels[level]}
+                      </Chip>
+                    ))}
+                  </View>
+                </>
               )}
             </>
           )}

--- a/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
+++ b/src/components/ModelSettingsSheet/ModelSettingsSheet.tsx
@@ -1,12 +1,13 @@
 import React, {useState, useEffect, memo, useContext} from 'react';
-import {Button, Text, Divider} from 'react-native-paper';
+import {Button, Text, Divider, Switch, TextInput} from 'react-native-paper';
 
 import {ModelSettings} from '../../screens/ModelsScreen/ModelSettings';
 import {Sheet} from '../Sheet';
 import {ProjectionModelSelector} from '../ProjectionModelSelector';
 import {Model} from '../../utils/types';
-import {modelStore} from '../../store';
+import {modelStore, serverStore} from '../../store';
 import {chatTemplates} from '../../utils/chat';
+import {resolveReasoningCapability} from '../../utils/reasoningCapability';
 
 import {styles} from './styles';
 import {View} from 'react-native';
@@ -29,12 +30,33 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
     );
     const l10n = useContext(L10nContext);
 
+    // Reasoning override (seeded from the resolver so the controls show the
+    // effective state). Axis-1 is reasoning yes/no; axis-2 graded effort + set.
+    const seedReasoning = () =>
+      resolveReasoningCapability(model, serverStore.remoteReasoning);
+    const [isReasoningModel, setIsReasoningModel] = useState(
+      () => seedReasoning().isReasoning === 'yes',
+    );
+    const [supportsEffort, setSupportsEffort] = useState(
+      () => seedReasoning().supportsEffort,
+    );
+    const [effortValuesText, setEffortValuesText] = useState(() =>
+      seedReasoning().effortValues.join(', '),
+    );
+
     // Reset temp settings when model changes
     useEffect(() => {
       if (model) {
         setTempModelName(model.name);
         setTempChatTemplate(model.chatTemplate);
         setTempStopWords(model.stopWords || []);
+        const cap = resolveReasoningCapability(
+          model,
+          serverStore.remoteReasoning,
+        );
+        setIsReasoningModel(cap.isReasoning === 'yes');
+        setSupportsEffort(cap.supportsEffort);
+        setEffortValuesText(cap.effortValues.join(', '));
       }
     }, [model]);
 
@@ -55,6 +77,17 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
         modelStore.updateModelName(model.id, tempModelName);
         modelStore.updateModelChatTemplate(model.id, tempChatTemplate);
         modelStore.updateModelStopWords(model.id, tempStopWords);
+        const effortValues = effortValuesText
+          .split(',')
+          .map(v => v.trim())
+          .filter(v => v.length > 0);
+        modelStore.setReasoningOverride(model.id, {
+          isReasoning: isReasoningModel ? 'yes' : 'no',
+          source: 'user',
+          supportsEffort: isReasoningModel && supportsEffort,
+          effortValues: isReasoningModel && supportsEffort ? effortValues : [],
+          effortSource: isReasoningModel && supportsEffort ? 'user' : 'none',
+        });
         onClose();
       }
     };
@@ -119,6 +152,49 @@ export const ModelSettingsSheet: React.FC<ModelSettingsSheetProps> = memo(
                   );
                 }}
               />
+            </>
+          )}
+
+          {/* Reasoning override (axis 1 + axis 2). Manual escape hatch when
+              detection is wrong or impossible (remote models). */}
+          <Divider style={styles.multimodalDivider} />
+          <Text style={styles.multimodalSectionTitle}>
+            {l10n.components.modelSettingsSheet.reasoningSection}
+          </Text>
+          <View style={styles.reasoningRow}>
+            <Text>{l10n.components.modelSettingsSheet.isReasoningModel}</Text>
+            <Switch
+              testID="reasoning-is-reasoning-switch"
+              value={isReasoningModel}
+              onValueChange={setIsReasoningModel}
+            />
+          </View>
+          <Text variant="bodySmall" style={styles.reasoningHelp}>
+            {l10n.components.modelSettingsSheet.isReasoningModelHelp}
+          </Text>
+          {isReasoningModel && (
+            <>
+              <View style={styles.reasoningRow}>
+                <Text>{l10n.components.modelSettingsSheet.supportsEffort}</Text>
+                <Switch
+                  testID="reasoning-supports-effort-switch"
+                  value={supportsEffort}
+                  onValueChange={setSupportsEffort}
+                />
+              </View>
+              {supportsEffort && (
+                <TextInput
+                  testID="reasoning-effort-values-input"
+                  mode="outlined"
+                  label={l10n.components.modelSettingsSheet.effortValues}
+                  placeholder={
+                    l10n.components.modelSettingsSheet.effortValuesPlaceholder
+                  }
+                  value={effortValuesText}
+                  onChangeText={setEffortValuesText}
+                  autoCapitalize="none"
+                />
+              )}
             </>
           )}
         </Sheet.ScrollView>

--- a/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
+++ b/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
@@ -255,7 +255,9 @@ describe('ModelSettingsSheet', () => {
         <ModelSettingsSheet {...defaultProps} />,
       );
 
-      // Turn on axis-1, then axis-2, then pick the supported effort levels.
+      // Turn on axis-1, then axis-2. Enabling graded effort pre-selects the
+      // standard low/medium/high subset, so saving without touching any chip
+      // persists exactly that default.
       await act(async () => {
         fireEvent(
           getByTestId('reasoning-is-reasoning-switch'),
@@ -269,15 +271,6 @@ describe('ModelSettingsSheet', () => {
           'valueChange',
           true,
         );
-      });
-      await act(async () => {
-        fireEvent.press(getByTestId('effort-chip-low'));
-      });
-      await act(async () => {
-        fireEvent.press(getByTestId('effort-chip-medium'));
-      });
-      await act(async () => {
-        fireEvent.press(getByTestId('effort-chip-high'));
       });
       await act(async () => {
         fireEvent.press(getByText('Save Changes'));
@@ -314,12 +307,13 @@ describe('ModelSettingsSheet', () => {
           true,
         );
       });
-      // Tap out of order; the saved set must still be canonically ordered.
+      // Add levels out of order on top of the pre-selected low/medium/high;
+      // the saved set must still be canonically ordered.
       await act(async () => {
-        fireEvent.press(getByTestId('effort-chip-high'));
+        fireEvent.press(getByTestId('effort-chip-xhigh'));
       });
       await act(async () => {
-        fireEvent.press(getByTestId('effort-chip-low'));
+        fireEvent.press(getByTestId('effort-chip-minimal'));
       });
       await act(async () => {
         fireEvent.press(getByText('Save Changes'));
@@ -329,7 +323,7 @@ describe('ModelSettingsSheet', () => {
         mockModel.id,
         expect.objectContaining({
           supportsEffort: true,
-          effortValues: ['low', 'high'],
+          effortValues: ['minimal', 'low', 'medium', 'high', 'xhigh'],
         }),
       );
     });
@@ -353,12 +347,9 @@ describe('ModelSettingsSheet', () => {
           true,
         );
       });
+      // Pre-selected set is low/medium/high; tapping 'low' removes just it.
       await act(async () => {
-        fireEvent.press(getByTestId('effort-chip-medium'));
-      });
-      // Tap again to deselect.
-      await act(async () => {
-        fireEvent.press(getByTestId('effort-chip-medium'));
+        fireEvent.press(getByTestId('effort-chip-low'));
       });
       await act(async () => {
         fireEvent.press(getByText('Save Changes'));
@@ -368,7 +359,7 @@ describe('ModelSettingsSheet', () => {
         mockModel.id,
         expect.objectContaining({
           supportsEffort: true,
-          effortValues: [],
+          effortValues: ['medium', 'high'],
         }),
       );
     });

--- a/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
+++ b/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
@@ -215,4 +215,70 @@ describe('ModelSettingsSheet', () => {
     // The state updates are handled by useEffect, which is tested implicitly
     // through the save/cancel/reset tests
   });
+
+  describe('reasoning override', () => {
+    it('renders the axis-1 reasoning toggle', () => {
+      const {getByTestId} = render(<ModelSettingsSheet {...defaultProps} />);
+      expect(getByTestId('reasoning-is-reasoning-switch')).toBeTruthy();
+    });
+
+    it('save writes a user-sourced override beating detection', async () => {
+      const {getByTestId, getByText} = render(
+        <ModelSettingsSheet {...defaultProps} />,
+      );
+
+      // Turn on axis-1, then axis-2, then set the value set.
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-is-reasoning-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-supports-effort-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent.changeText(
+          getByTestId('reasoning-effort-values-input'),
+          'low, medium, high',
+        );
+      });
+      await act(async () => {
+        fireEvent.press(getByText('Save Changes'));
+      });
+
+      expect(modelStore.setReasoningOverride).toHaveBeenCalledWith(
+        mockModel.id,
+        {
+          isReasoning: 'yes',
+          source: 'user',
+          supportsEffort: true,
+          effortValues: ['low', 'medium', 'high'],
+          effortSource: 'user',
+        },
+      );
+    });
+
+    it("saving axis-1 'no' clears axis-2 (inert)", async () => {
+      const {getByText} = render(<ModelSettingsSheet {...defaultProps} />);
+      await act(async () => {
+        fireEvent.press(getByText('Save Changes'));
+      });
+      expect(modelStore.setReasoningOverride).toHaveBeenCalledWith(
+        mockModel.id,
+        expect.objectContaining({
+          isReasoning: 'no',
+          source: 'user',
+          supportsEffort: false,
+          effortValues: [],
+          effortSource: 'none',
+        }),
+      );
+    });
+  });
 });

--- a/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
+++ b/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
@@ -222,6 +222,34 @@ describe('ModelSettingsSheet', () => {
       expect(getByTestId('reasoning-is-reasoning-switch')).toBeTruthy();
     });
 
+    it('renders all six effort chips when graded effort is on', async () => {
+      const {getByTestId} = render(<ModelSettingsSheet {...defaultProps} />);
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-is-reasoning-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-supports-effort-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      for (const level of [
+        'minimal',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+        'max',
+      ]) {
+        expect(getByTestId(`effort-chip-${level}`)).toBeTruthy();
+      }
+    });
+
     it('save writes a user-sourced override beating detection', async () => {
       const {getByTestId, getByText} = render(
         <ModelSettingsSheet {...defaultProps} />,
@@ -388,6 +416,48 @@ describe('ModelSettingsSheet', () => {
       // An unrelated save must not stamp a source:'user' override onto a
       // fail-open 'unknown' model — that would kill detection + learn-from-stream.
       expect(modelStore.setReasoningOverride).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remote model', () => {
+    const remoteModel: Model = {
+      ...mockModel,
+      id: 'server-1/remote-x',
+      origin: ModelOrigin.REMOTE,
+    };
+    const remoteProps = {...defaultProps, model: remoteModel};
+
+    it('hides the local-only chat template / stop words section', () => {
+      const {queryByTestId, getByTestId} = render(
+        <ModelSettingsSheet {...remoteProps} />,
+      );
+      expect(queryByTestId('model-settings')).toBeNull();
+      // The reasoning section is still shown.
+      expect(getByTestId('reasoning-is-reasoning-switch')).toBeTruthy();
+    });
+
+    it('save writes a reasoning override and skips local-only writers', async () => {
+      const {getByTestId, getByText} = render(
+        <ModelSettingsSheet {...remoteProps} />,
+      );
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-is-reasoning-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent.press(getByText('Save Changes'));
+      });
+
+      expect(modelStore.setReasoningOverride).toHaveBeenCalledWith(
+        remoteModel.id,
+        expect.objectContaining({isReasoning: 'yes', source: 'user'}),
+      );
+      expect(modelStore.updateModelChatTemplate).not.toHaveBeenCalled();
+      expect(modelStore.updateModelStopWords).not.toHaveBeenCalled();
+      expect(modelStore.updateModelName).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
+++ b/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
@@ -227,7 +227,7 @@ describe('ModelSettingsSheet', () => {
         <ModelSettingsSheet {...defaultProps} />,
       );
 
-      // Turn on axis-1, then axis-2, then set the value set.
+      // Turn on axis-1, then axis-2, then pick the supported effort levels.
       await act(async () => {
         fireEvent(
           getByTestId('reasoning-is-reasoning-switch'),
@@ -243,10 +243,13 @@ describe('ModelSettingsSheet', () => {
         );
       });
       await act(async () => {
-        fireEvent.changeText(
-          getByTestId('reasoning-effort-values-input'),
-          'low, medium, high',
-        );
+        fireEvent.press(getByTestId('effort-chip-low'));
+      });
+      await act(async () => {
+        fireEvent.press(getByTestId('effort-chip-medium'));
+      });
+      await act(async () => {
+        fireEvent.press(getByTestId('effort-chip-high'));
       });
       await act(async () => {
         fireEvent.press(getByText('Save Changes'));
@@ -261,6 +264,84 @@ describe('ModelSettingsSheet', () => {
           effortValues: ['low', 'medium', 'high'],
           effortSource: 'user',
         },
+      );
+    });
+
+    it('persists effort levels ordered low→medium→high regardless of tap order', async () => {
+      const {getByTestId, getByText} = render(
+        <ModelSettingsSheet {...defaultProps} />,
+      );
+
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-is-reasoning-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-supports-effort-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      // Tap out of order; the saved set must still be canonically ordered.
+      await act(async () => {
+        fireEvent.press(getByTestId('effort-chip-high'));
+      });
+      await act(async () => {
+        fireEvent.press(getByTestId('effort-chip-low'));
+      });
+      await act(async () => {
+        fireEvent.press(getByText('Save Changes'));
+      });
+
+      expect(modelStore.setReasoningOverride).toHaveBeenCalledWith(
+        mockModel.id,
+        expect.objectContaining({
+          supportsEffort: true,
+          effortValues: ['low', 'high'],
+        }),
+      );
+    });
+
+    it('toggling an effort chip off removes it from the saved set', async () => {
+      const {getByTestId, getByText} = render(
+        <ModelSettingsSheet {...defaultProps} />,
+      );
+
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-is-reasoning-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-supports-effort-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent.press(getByTestId('effort-chip-medium'));
+      });
+      // Tap again to deselect.
+      await act(async () => {
+        fireEvent.press(getByTestId('effort-chip-medium'));
+      });
+      await act(async () => {
+        fireEvent.press(getByText('Save Changes'));
+      });
+
+      expect(modelStore.setReasoningOverride).toHaveBeenCalledWith(
+        mockModel.id,
+        expect.objectContaining({
+          supportsEffort: true,
+          effortValues: [],
+        }),
       );
     });
 

--- a/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
+++ b/src/components/ModelSettingsSheet/__tests__/ModelSettingsSheet.test.tsx
@@ -265,7 +265,25 @@ describe('ModelSettingsSheet', () => {
     });
 
     it("saving axis-1 'no' clears axis-2 (inert)", async () => {
-      const {getByText} = render(<ModelSettingsSheet {...defaultProps} />);
+      const {getByTestId, getByText} = render(
+        <ModelSettingsSheet {...defaultProps} />,
+      );
+      // The seed is 'unknown' (switch off). Toggle on then off so axis-1 is a
+      // deliberate user 'no' (marks the reasoning controls dirty).
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-is-reasoning-switch'),
+          'valueChange',
+          true,
+        );
+      });
+      await act(async () => {
+        fireEvent(
+          getByTestId('reasoning-is-reasoning-switch'),
+          'valueChange',
+          false,
+        );
+      });
       await act(async () => {
         fireEvent.press(getByText('Save Changes'));
       });
@@ -279,6 +297,16 @@ describe('ModelSettingsSheet', () => {
           effortSource: 'none',
         }),
       );
+    });
+
+    it('save without touching reasoning controls does NOT write an override', async () => {
+      const {getByText} = render(<ModelSettingsSheet {...defaultProps} />);
+      await act(async () => {
+        fireEvent.press(getByText('Save Changes'));
+      });
+      // An unrelated save must not stamp a source:'user' override onto a
+      // fail-open 'unknown' model — that would kill detection + learn-from-stream.
+      expect(modelStore.setReasoningOverride).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/ModelSettingsSheet/styles.ts
+++ b/src/components/ModelSettingsSheet/styles.ts
@@ -26,4 +26,10 @@ export const styles = StyleSheet.create({
     marginBottom: 12,
     opacity: 0.7,
   },
+  effortChipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 12,
+  },
 });

--- a/src/components/ModelSettingsSheet/styles.ts
+++ b/src/components/ModelSettingsSheet/styles.ts
@@ -16,4 +16,14 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 12,
   },
+  reasoningRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  reasoningHelp: {
+    marginBottom: 12,
+    opacity: 0.7,
+  },
 });

--- a/src/components/RemoteModelSheet/RemoteModelSheet.tsx
+++ b/src/components/RemoteModelSheet/RemoteModelSheet.tsx
@@ -16,6 +16,7 @@ import {
   ActivityIndicator,
   Icon,
 } from 'react-native-paper';
+import {Dropdown} from '../ui';
 import {observer} from 'mobx-react';
 import {runInAction} from 'mobx';
 import debounce from 'lodash/debounce';
@@ -26,7 +27,10 @@ import {serverStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {isLocalHost} from '../../utils/network';
 import {parseTimeoutMs} from '../../utils/timeout';
-import {SERVER_TYPE_OPTIONS, seedServerType} from '../../utils/serverTypes';
+import {
+  SERVER_TYPE_DROPDOWN_OPTIONS,
+  seedServerType,
+} from '../../utils/serverTypes';
 import {ServerConfig} from '../../utils/types';
 import {
   RemoteModelInfo,
@@ -547,17 +551,12 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
 
               <View style={styles.inputSpacing}>
                 <Text>{l10n.settings.serverType}</Text>
-                <View style={styles.chipsRow}>
-                  {SERVER_TYPE_OPTIONS.map(option => (
-                    <Chip
-                      key={option}
-                      testID={`server-type-${option}`}
-                      selected={serverType === option}
-                      onPress={() => setServerType(option)}>
-                      {option}
-                    </Chip>
-                  ))}
-                </View>
+                <Dropdown
+                  testID="server-type-dropdown"
+                  value={serverType}
+                  options={SERVER_TYPE_DROPDOWN_OPTIONS}
+                  onChange={setServerType}
+                />
                 <Text style={styles.apiKeyDescription}>
                   {l10n.settings.serverTypeHelp}
                 </Text>

--- a/src/components/RemoteModelSheet/RemoteModelSheet.tsx
+++ b/src/components/RemoteModelSheet/RemoteModelSheet.tsx
@@ -26,6 +26,7 @@ import {serverStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {isLocalHost} from '../../utils/network';
 import {parseTimeoutMs} from '../../utils/timeout';
+import {SERVER_TYPE_OPTIONS, seedServerType} from '../../utils/serverTypes';
 import {ServerConfig} from '../../utils/types';
 import {
   RemoteModelInfo,
@@ -55,6 +56,7 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
     const [serverName, setServerName] = useState('');
     const [apiKey, setApiKey] = useState('');
     const [timeoutSeconds, setTimeoutSeconds] = useState('');
+    const [serverType, setServerType] = useState('unknown');
     const [secureTextEntry, setSecureTextEntry] = useState(true);
 
     // Auto-probe
@@ -100,6 +102,7 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
         setApiKey('');
         setTimeoutSeconds('');
         timeoutSecondsRef.current = '';
+        setServerType('unknown');
         setSecureTextEntry(true);
         setIsProbing(false);
         setProbeResult(null);
@@ -144,6 +147,7 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
             setSelectedModelId(models[0].id);
           }
           const detected = await detectServerType(trimmedUrl, models, headers);
+          setServerType(seedServerType(detected, trimmedUrl));
           setServerName(prev => {
             if (prev) {
               return prev;
@@ -266,6 +270,7 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
             name: serverName.trim(),
             url: url.trim(),
             requestTimeoutMs: parseTimeoutMs(timeoutSeconds),
+            serverType,
           });
           if (apiKey.trim()) {
             await serverStore.setApiKey(serverId, apiKey.trim());
@@ -287,6 +292,7 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
       url,
       apiKey,
       timeoutSeconds,
+      serverType,
       onModelAdded,
       onDismiss,
     ]);
@@ -536,6 +542,24 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                 />
                 <Text style={styles.apiKeyDescription}>
                   {l10n.settings.requestTimeoutHelp}
+                </Text>
+              </View>
+
+              <View style={styles.inputSpacing}>
+                <Text>{l10n.settings.serverType}</Text>
+                <View style={styles.chipsRow}>
+                  {SERVER_TYPE_OPTIONS.map(option => (
+                    <Chip
+                      key={option}
+                      testID={`server-type-${option}`}
+                      selected={serverType === option}
+                      onPress={() => setServerType(option)}>
+                      {option}
+                    </Chip>
+                  ))}
+                </View>
+                <Text style={styles.apiKeyDescription}>
+                  {l10n.settings.serverTypeHelp}
                 </Text>
               </View>
             </>

--- a/src/components/RemoteModelSheet/__tests__/RemoteModelSheet.test.tsx
+++ b/src/components/RemoteModelSheet/__tests__/RemoteModelSheet.test.tsx
@@ -245,6 +245,40 @@ describe('RemoteModelSheet', () => {
       });
     });
 
+    // The server-type dropdown is seeded by detectServerType (mocked to ''),
+    // so it falls back to 'unknown'. Selecting an override persists through the
+    // addServer call.
+    it('persists a user-selected serverType when adding a new server', async () => {
+      mockedFetchModelsWithHeaders.mockResolvedValue({
+        models: [{id: 'llama-7b', object: 'model', owned_by: 'system'}],
+        headers: {},
+      });
+
+      const {getByTestId, getByText} = render(
+        <RemoteModelSheet isVisible={true} onDismiss={jest.fn()} />,
+      );
+
+      fireEvent.changeText(
+        getByTestId('remote-url-input'),
+        'http://localhost:1234',
+      );
+      await waitFor(() => {
+        expect(getByTestId('server-type-dropdown')).toBeTruthy();
+        expect(getByText('llama-7b')).toBeTruthy();
+      });
+
+      // Open the dropdown and override the seeded value.
+      fireEvent.press(getByTestId('server-type-dropdown'));
+      fireEvent.press(getByTestId('server-type-option-Ollama'));
+      fireEvent.press(getByTestId('add-model-button'));
+
+      await waitFor(() => {
+        expect(serverStore.addServer).toHaveBeenCalledWith(
+          expect.objectContaining({serverType: 'Ollama'}),
+        );
+      });
+    });
+
     it('persists requestTimeoutMs undefined when adding a server with empty timeout', async () => {
       mockedFetchModelsWithHeaders.mockResolvedValue({
         models: [{id: 'llama-7b', object: 'model', owned_by: 'system'}],

--- a/src/components/ServerDetailsSheet/ServerDetailsSheet.tsx
+++ b/src/components/ServerDetailsSheet/ServerDetailsSheet.tsx
@@ -13,6 +13,7 @@ import {
   TextInput as PaperTextInput,
   ActivityIndicator,
   Icon,
+  Chip,
 } from 'react-native-paper';
 import {observer} from 'mobx-react';
 import debounce from 'lodash/debounce';
@@ -22,6 +23,7 @@ import {useTheme} from '../../hooks';
 import {serverStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {parseTimeoutMs} from '../../utils/timeout';
+import {SERVER_TYPE_OPTIONS} from '../../utils/serverTypes';
 import {testConnection} from '../../api/openai';
 import {t} from '../../locales';
 
@@ -43,6 +45,7 @@ export const ServerDetailsSheet: React.FC<ServerDetailsSheetProps> = observer(
     const [url, setUrl] = useState('');
     const [apiKey, setApiKey] = useState('');
     const [timeoutSeconds, setTimeoutSeconds] = useState('');
+    const [serverType, setServerType] = useState('unknown');
     const [secureTextEntry, setSecureTextEntry] = useState(true);
     const [isProbing, setIsProbing] = useState(false);
     const [probeResult, setProbeResult] = useState<{
@@ -73,6 +76,7 @@ export const ServerDetailsSheet: React.FC<ServerDetailsSheetProps> = observer(
               : '';
           setTimeoutSeconds(seconds);
           timeoutSecondsRef.current = seconds;
+          setServerType(server.serverType || 'unknown');
         }
         serverStore.getApiKey(serverId).then(key => {
           setApiKey(key || '');
@@ -153,6 +157,7 @@ export const ServerDetailsSheet: React.FC<ServerDetailsSheetProps> = observer(
         serverStore.updateServer(serverId, {
           url: url.trim(),
           requestTimeoutMs: parseTimeoutMs(timeoutSeconds),
+          serverType,
         });
         if (apiKey.trim()) {
           await serverStore.setApiKey(serverId, apiKey.trim());
@@ -163,7 +168,7 @@ export const ServerDetailsSheet: React.FC<ServerDetailsSheetProps> = observer(
       } finally {
         setIsSaving(false);
       }
-    }, [serverId, server, url, apiKey, timeoutSeconds, onDismiss]);
+    }, [serverId, server, url, apiKey, timeoutSeconds, serverType, onDismiss]);
 
     const handleRemoveServer = useCallback(() => {
       if (!serverId || !server) {
@@ -236,6 +241,25 @@ export const ServerDetailsSheet: React.FC<ServerDetailsSheetProps> = observer(
             />
             <Text style={styles.apiKeyDescription}>
               {l10n.settings.requestTimeoutHelp}
+            </Text>
+          </View>
+
+          {/* Server Type selector */}
+          <View style={styles.inputSpacing}>
+            <Text>{l10n.settings.serverType}</Text>
+            <View style={styles.serverTypeRow}>
+              {SERVER_TYPE_OPTIONS.map(option => (
+                <Chip
+                  key={option}
+                  testID={`server-type-${option}`}
+                  selected={serverType === option}
+                  onPress={() => setServerType(option)}>
+                  {option}
+                </Chip>
+              ))}
+            </View>
+            <Text style={styles.apiKeyDescription}>
+              {l10n.settings.serverTypeHelp}
             </Text>
           </View>
 

--- a/src/components/ServerDetailsSheet/ServerDetailsSheet.tsx
+++ b/src/components/ServerDetailsSheet/ServerDetailsSheet.tsx
@@ -13,8 +13,8 @@ import {
   TextInput as PaperTextInput,
   ActivityIndicator,
   Icon,
-  Chip,
 } from 'react-native-paper';
+import {Dropdown} from '../ui';
 import {observer} from 'mobx-react';
 import debounce from 'lodash/debounce';
 
@@ -23,7 +23,7 @@ import {useTheme} from '../../hooks';
 import {serverStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {parseTimeoutMs} from '../../utils/timeout';
-import {SERVER_TYPE_OPTIONS} from '../../utils/serverTypes';
+import {SERVER_TYPE_DROPDOWN_OPTIONS} from '../../utils/serverTypes';
 import {testConnection} from '../../api/openai';
 import {t} from '../../locales';
 
@@ -247,17 +247,12 @@ export const ServerDetailsSheet: React.FC<ServerDetailsSheetProps> = observer(
           {/* Server Type selector */}
           <View style={styles.inputSpacing}>
             <Text>{l10n.settings.serverType}</Text>
-            <View style={styles.serverTypeRow}>
-              {SERVER_TYPE_OPTIONS.map(option => (
-                <Chip
-                  key={option}
-                  testID={`server-type-${option}`}
-                  selected={serverType === option}
-                  onPress={() => setServerType(option)}>
-                  {option}
-                </Chip>
-              ))}
-            </View>
+            <Dropdown
+              testID="server-type-dropdown"
+              value={serverType}
+              options={SERVER_TYPE_DROPDOWN_OPTIONS}
+              onChange={setServerType}
+            />
             <Text style={styles.apiKeyDescription}>
               {l10n.settings.serverTypeHelp}
             </Text>

--- a/src/components/ServerDetailsSheet/__tests__/ServerDetailsSheet.test.tsx
+++ b/src/components/ServerDetailsSheet/__tests__/ServerDetailsSheet.test.tsx
@@ -406,7 +406,9 @@ describe('ServerDetailsSheet', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('server-type-Ollama'));
+    // Open the dropdown, then pick an override.
+    fireEvent.press(getByTestId('server-type-dropdown'));
+    fireEvent.press(getByTestId('server-type-option-Ollama'));
     fireEvent.press(getByTestId('save-server-button'));
 
     await waitFor(() => {

--- a/src/components/ServerDetailsSheet/__tests__/ServerDetailsSheet.test.tsx
+++ b/src/components/ServerDetailsSheet/__tests__/ServerDetailsSheet.test.tsx
@@ -386,11 +386,34 @@ describe('ServerDetailsSheet', () => {
     fireEvent.press(getByTestId('save-server-button'));
 
     await waitFor(() => {
-      expect(serverStore.updateServer).toHaveBeenCalledWith('srv-1', {
-        url: 'http://localhost:5678',
-      });
+      expect(serverStore.updateServer).toHaveBeenCalledWith(
+        'srv-1',
+        expect.objectContaining({
+          url: 'http://localhost:5678',
+        }),
+      );
       expect(serverStore.setApiKey).toHaveBeenCalledWith('srv-1', 'sk-new-key');
       expect(mockDismiss).toHaveBeenCalled();
+    });
+  });
+
+  it('persists a user-selected serverType on save', async () => {
+    const {getByTestId} = render(
+      <ServerDetailsSheet
+        isVisible={true}
+        onDismiss={jest.fn()}
+        serverId="srv-1"
+      />,
+    );
+
+    fireEvent.press(getByTestId('server-type-Ollama'));
+    fireEvent.press(getByTestId('save-server-button'));
+
+    await waitFor(() => {
+      expect(serverStore.updateServer).toHaveBeenCalledWith(
+        'srv-1',
+        expect.objectContaining({serverType: 'Ollama'}),
+      );
     });
   });
 });

--- a/src/components/ServerDetailsSheet/styles.ts
+++ b/src/components/ServerDetailsSheet/styles.ts
@@ -16,12 +16,6 @@ export const createStyles = (theme: Theme) => {
       color: theme.colors.onSurfaceVariant,
       fontSize: 12,
     },
-    serverTypeRow: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: 8,
-      marginTop: 4,
-    },
     probeStatusContainer: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/src/components/ServerDetailsSheet/styles.ts
+++ b/src/components/ServerDetailsSheet/styles.ts
@@ -16,6 +16,12 @@ export const createStyles = (theme: Theme) => {
       color: theme.colors.onSurfaceVariant,
       fontSize: 12,
     },
+    serverTypeRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 8,
+      marginTop: 4,
+    },
     probeStatusContainer: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/src/components/ui/Dropdown/Dropdown.tsx
+++ b/src/components/ui/Dropdown/Dropdown.tsx
@@ -14,6 +14,7 @@ export type DropdownOption = {
   value: string;
   label: string;
   disabled?: boolean;
+  testID?: string;
 };
 
 export type DropdownProps = CommonDSProps & {
@@ -72,6 +73,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       {options.map(option => (
         <Menu.Item
           key={option.value}
+          testID={option.testID}
           title={option.label}
           disabled={option.disabled}
           onPress={() => {

--- a/src/hooks/__tests__/useChatSession.reasoning.test.ts
+++ b/src/hooks/__tests__/useChatSession.reasoning.test.ts
@@ -82,17 +82,18 @@ describe('useChatSession reasoning wire (local)', () => {
     ).toBeUndefined();
   });
 
-  it('axis-1 OFF emits enable_thinking:false + reasoning_format none', async () => {
+  it('axis-1 OFF emits enable_thinking:false + reasoning_format auto', async () => {
     setSettings({enable_thinking: false});
     const captured = captureCompletionParams();
     await send();
-    expect(captured.current.reasoning_format).toBe('none');
+    expect(captured.current.reasoning_format).toBe('auto');
     expect(captured.current.chat_template_kwargs?.enable_thinking).toBe(false);
   });
 
-  it('non-reasoning model: stale enable_thinking false attaches no reasoning hints', async () => {
-    // A model resolved as isReasoning:'no' must not receive reasoning wire
-    // hints even when enable_thinking is stale-false.
+  it('non-reasoning model: reasoning_format auto (no-op) but no enable_thinking hint', async () => {
+    // reasoning_format is always 'auto' (a no-op for non-reasoning models, and
+    // the value that prevents raw channel/think markers leaking into content);
+    // the enable_thinking:false hint is still withheld from isReasoning:'no'.
     setSettings({enable_thinking: false});
     const model = {
       ...(modelsList as any)[0],
@@ -108,7 +109,7 @@ describe('useChatSession reasoning wire (local)', () => {
     modelStore.activeModelId = model.id;
     const captured = captureCompletionParams();
     await send();
-    expect(captured.current.reasoning_format).toBeUndefined();
+    expect(captured.current.reasoning_format).toBe('auto');
     expect(
       captured.current.chat_template_kwargs?.enable_thinking,
     ).toBeUndefined();
@@ -134,7 +135,7 @@ describe('useChatSession reasoning wire (local)', () => {
     await send();
     // No client-side reasoning-display suppression is added to the params.
     expect(captured.current).not.toHaveProperty('strip_reasoning');
-    expect(captured.current.reasoning_format).toBe('none');
+    expect(captured.current.reasoning_format).toBe('auto');
   });
 });
 

--- a/src/hooks/__tests__/useChatSession.reasoning.test.ts
+++ b/src/hooks/__tests__/useChatSession.reasoning.test.ts
@@ -1,0 +1,137 @@
+import {LlamaContext} from 'llama.rn';
+import {renderHook, act} from '@testing-library/react-native';
+
+import {textMessage} from '../../../jest/fixtures';
+import {sessionFixtures} from '../../../jest/fixtures/chatSessions';
+import {
+  mockDefaultCompletionParams,
+  mockLlamaContextParams,
+  modelsList,
+} from '../../../jest/fixtures/models';
+
+import {useChatSession} from '../useChatSession';
+
+import {chatSessionStore, modelStore, palStore, serverStore} from '../../store';
+
+const mockAssistant = {id: 'assistant-1'};
+
+// Capture the params handed to the engine so we can assert the reasoning wire.
+const captureCompletionParams = (): {current: any} => {
+  const captured: {current: any} = {current: undefined};
+  if (modelStore.context) {
+    modelStore.context.completion = jest
+      .fn()
+      .mockImplementation((params, _onData) => {
+        captured.current = params;
+        return Promise.resolve({
+          text: 'ok',
+          content: 'ok',
+          timings: {total: 100},
+        });
+      });
+  }
+  return captured;
+};
+
+const setSettings = (overrides: Record<string, any>) => {
+  (
+    chatSessionStore.getCurrentCompletionSettings as jest.Mock
+  ).mockResolvedValue({...mockDefaultCompletionParams, ...overrides});
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  palStore.pals = [] as any;
+  chatSessionStore.sessions = sessionFixtures as any;
+  chatSessionStore.activeSessionId = 'session-1';
+  modelStore.models = modelsList as any;
+  modelStore.activeModelId = undefined;
+  modelStore.context = new LlamaContext(mockLlamaContextParams);
+  modelStore.engine = {
+    completion: jest.fn((params, onData) =>
+      modelStore.context!.completion(params, onData),
+    ),
+    stopCompletion: jest.fn(async () => {
+      await modelStore.context?.stopCompletion();
+    }),
+  } as any;
+  serverStore.remoteReasoning = {};
+});
+
+jest
+  .spyOn(require('../../utils/chat'), 'applyChatTemplate')
+  .mockImplementation(async () => 'mocked prompt');
+
+const send = async () => {
+  const {result} = renderHook(() =>
+    useChatSession({current: null}, textMessage.author, mockAssistant),
+  );
+  await act(async () => {
+    await result.current.handleSendPress(textMessage);
+  });
+};
+
+describe('useChatSession reasoning wire (local)', () => {
+  it('axis-1 ON keeps reasoning_format auto, no enable_thinking kwarg', async () => {
+    setSettings({enable_thinking: true});
+    const captured = captureCompletionParams();
+    await send();
+    expect(captured.current.reasoning_format).toBe('auto');
+    expect(
+      captured.current.chat_template_kwargs?.enable_thinking,
+    ).toBeUndefined();
+  });
+
+  it('axis-1 OFF emits enable_thinking:false + reasoning_format none', async () => {
+    setSettings({enable_thinking: false});
+    const captured = captureCompletionParams();
+    await send();
+    expect(captured.current.reasoning_format).toBe('none');
+    expect(captured.current.chat_template_kwargs?.enable_thinking).toBe(false);
+  });
+
+  it('axis-2 effort emits chat_template_kwargs.reasoning_effort', async () => {
+    setSettings({
+      enable_thinking: true,
+      reasoning: {enabled: true, effort: 'high'},
+    });
+    const captured = captureCompletionParams();
+    await send();
+    expect(captured.current.chat_template_kwargs?.reasoning_effort).toBe(
+      'high',
+    );
+  });
+
+  it('does not strip reasoning: no removeThinkingParts on displayed output (include_thinking unchanged)', async () => {
+    // include_thinking_in_context controls only the SENT context; with it left
+    // at its default (true) the assistant content is forwarded untouched.
+    setSettings({enable_thinking: false, include_thinking_in_context: true});
+    const captured = captureCompletionParams();
+    await send();
+    // No client-side reasoning-display suppression is added to the params.
+    expect(captured.current).not.toHaveProperty('strip_reasoning');
+    expect(captured.current.reasoning_format).toBe('none');
+  });
+});
+
+describe('useChatSession learn-from-stream', () => {
+  it('records reasoning observed on the first reasoning token', async () => {
+    setSettings({enable_thinking: true});
+    const spy = jest.spyOn(modelStore, 'recordReasoningObserved');
+    // Active model whose resolver says not-yes (unknown), so the learn path fires.
+    const model = {...(modelsList as any)[0], reasoning: undefined};
+    modelStore.models = [model] as any;
+    modelStore.activeModelId = model.id;
+    if (modelStore.context) {
+      modelStore.context.completion = jest
+        .fn()
+        .mockImplementation((_params, onData) => {
+          onData?.({token: 'x', reasoning_content: 'thinking...'});
+          return Promise.resolve({text: 'ok', content: 'ok', timings: {}});
+        });
+    }
+    await send();
+    expect(spy).toHaveBeenCalledWith(model.id);
+    spy.mockRestore();
+  });
+});

--- a/src/hooks/__tests__/useChatSession.reasoning.test.ts
+++ b/src/hooks/__tests__/useChatSession.reasoning.test.ts
@@ -90,6 +90,30 @@ describe('useChatSession reasoning wire (local)', () => {
     expect(captured.current.chat_template_kwargs?.enable_thinking).toBe(false);
   });
 
+  it('non-reasoning model: stale enable_thinking false attaches no reasoning hints', async () => {
+    // A model resolved as isReasoning:'no' must not receive reasoning wire
+    // hints even when enable_thinking is stale-false.
+    setSettings({enable_thinking: false});
+    const model = {
+      ...(modelsList as any)[0],
+      reasoning: {
+        isReasoning: 'no' as const,
+        source: 'user' as const,
+        supportsEffort: false,
+        effortValues: [],
+        effortSource: 'none' as const,
+      },
+    };
+    modelStore.models = [model] as any;
+    modelStore.activeModelId = model.id;
+    const captured = captureCompletionParams();
+    await send();
+    expect(captured.current.reasoning_format).toBeUndefined();
+    expect(
+      captured.current.chat_template_kwargs?.enable_thinking,
+    ).toBeUndefined();
+  });
+
   it('axis-2 effort emits chat_template_kwargs.reasoning_effort', async () => {
     setSettings({
       enable_thinking: true,

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -145,14 +145,24 @@ const prepareCompletion = async ({
   // hint only — it never strips reasoning the model still returns (rendered by
   // ReasoningBlock regardless). This is separate from include_thinking_in_context
   // above, which only governs what prior <think> we SEND.
-  if (cleanCompletionParams.enable_thinking) {
-    cleanCompletionParams.reasoning_format = 'auto';
-  } else {
-    cleanCompletionParams.reasoning_format = 'none';
-    cleanCompletionParams.chat_template_kwargs = {
-      ...cleanCompletionParams.chat_template_kwargs,
-      enable_thinking: false,
-    };
+  // Only attach hints for reasoning-capable models (axis-1 not 'no'); a plain
+  // non-reasoning model with stale enable_thinking:false gets no reasoning wire
+  // params.
+  const isReasoningCapable =
+    resolveReasoningCapability(
+      modelStore.activeModel,
+      serverStore.remoteReasoning,
+    ).isReasoning !== 'no';
+  if (isReasoningCapable) {
+    if (cleanCompletionParams.enable_thinking) {
+      cleanCompletionParams.reasoning_format = 'auto';
+    } else {
+      cleanCompletionParams.reasoning_format = 'none';
+      cleanCompletionParams.chat_template_kwargs = {
+        ...cleanCompletionParams.chat_template_kwargs,
+        enable_thinking: false,
+      };
+    }
   }
   // Graded effort (gpt-oss-style): carried by the resolver-populated intent.
   const reasoningEffort = cleanCompletionParams.reasoning?.effort;

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -11,9 +11,11 @@ import {
   chatSessionStore,
   modelStore,
   palStore,
+  serverStore,
   ttsStore,
   uiStore,
 } from '../store';
+import {resolveReasoningCapability} from '../utils/reasoningCapability';
 
 import {MessageType, ModelOrigin, User} from '../utils/types';
 import {createMultimodalWarning} from '../utils/errors';
@@ -139,8 +141,26 @@ const prepareCompletion = async ({
     completionParamsWithAppProps as CompletionParams,
   );
 
+  // Reasoning wire hints (llama.cpp template kwargs). "Off" is a best-effort
+  // hint only — it never strips reasoning the model still returns (rendered by
+  // ReasoningBlock regardless). This is separate from include_thinking_in_context
+  // above, which only governs what prior <think> we SEND.
   if (cleanCompletionParams.enable_thinking) {
     cleanCompletionParams.reasoning_format = 'auto';
+  } else {
+    cleanCompletionParams.reasoning_format = 'none';
+    cleanCompletionParams.chat_template_kwargs = {
+      ...cleanCompletionParams.chat_template_kwargs,
+      enable_thinking: false,
+    };
+  }
+  // Graded effort (gpt-oss-style): carried by the resolver-populated intent.
+  const reasoningEffort = cleanCompletionParams.reasoning?.effort;
+  if (reasoningEffort) {
+    cleanCompletionParams.chat_template_kwargs = {
+      ...cleanCompletionParams.chat_template_kwargs,
+      reasoning_effort: reasoningEffort,
+    };
   }
 
   // Create the empty AssistantTurn row in the store BEFORE the run
@@ -260,6 +280,23 @@ async function applyEventToStore(
       }
       if (!modelStore.isStreaming) {
         modelStore.setIsStreaming(true);
+      }
+      // Learn-from-stream: the first time a model emits reasoning while the
+      // resolver does not already know it reasons, persist the learned flag so
+      // the pill becomes reachable on the next render. The store writer is
+      // idempotent and never downgrades a user/learned 'yes'.
+      if (
+        event.delta.reasoningContent &&
+        event.delta.reasoningContent.length > 0
+      ) {
+        const activeModel = modelStore.activeModel;
+        if (
+          activeModel &&
+          resolveReasoningCapability(activeModel, serverStore.remoteReasoning)
+            .isReasoning !== 'yes'
+        ) {
+          modelStore.recordReasoningObserved(activeModel.id);
+        }
       }
       // TTS streaming hooks. Open a StreamingHandle on the first token
       // that carries content OR reasoning, then forward each new

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -141,28 +141,27 @@ const prepareCompletion = async ({
     completionParamsWithAppProps as CompletionParams,
   );
 
-  // Reasoning wire hints (llama.cpp template kwargs). "Off" is a best-effort
-  // hint only — it never strips reasoning the model still returns (rendered by
-  // ReasoningBlock regardless). This is separate from include_thinking_in_context
-  // above, which only governs what prior <think> we SEND.
-  // Only attach hints for reasoning-capable models (axis-1 not 'no'); a plain
-  // non-reasoning model with stale enable_thinking:false gets no reasoning wire
-  // params.
+  // reasoning_format is always 'auto' for the local (llama.rn) path: a no-op for
+  // non-reasoning models and the value that extracts reasoning into
+  // reasoning_content instead of leaking raw channel/think markers into content
+  // (e.g. gemma-4 emits an empty <|channel>thought block even when thinking is
+  // off). On/off is carried solely by enable_thinking. "Off" stays a best-effort
+  // hint — it never strips reasoning the model still returns (rendered by
+  // ReasoningBlock); separate from include_thinking_in_context, which only
+  // governs what prior <think> we SEND.
   const isReasoningCapable =
     resolveReasoningCapability(
       modelStore.activeModel,
       serverStore.remoteReasoning,
     ).isReasoning !== 'no';
-  if (isReasoningCapable) {
-    if (cleanCompletionParams.enable_thinking) {
-      cleanCompletionParams.reasoning_format = 'auto';
-    } else {
-      cleanCompletionParams.reasoning_format = 'none';
-      cleanCompletionParams.chat_template_kwargs = {
-        ...cleanCompletionParams.chat_template_kwargs,
-        enable_thinking: false,
-      };
-    }
+  cleanCompletionParams.reasoning_format = 'auto';
+  // The enable_thinking:false hint only matters for reasoning-capable models;
+  // a non-reasoning model would just ignore it.
+  if (isReasoningCapable && !cleanCompletionParams.enable_thinking) {
+    cleanCompletionParams.chat_template_kwargs = {
+      ...cleanCompletionParams.chat_template_kwargs,
+      enable_thinking: false,
+    };
   }
   // Graded effort (gpt-oss-style): carried by the resolver-populated intent.
   const reasoningEffort = cleanCompletionParams.reasoning?.effort;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -755,9 +755,12 @@
       "supportsEffort": "Supports graded effort",
       "effortValues": "Effort levels this model supports",
       "effortLevels": {
+        "minimal": "Minimal",
         "low": "Low",
         "medium": "Medium",
-        "high": "High"
+        "high": "High",
+        "xhigh": "Extra high",
+        "max": "Max"
       }
     },
     "modelsHeaderRight": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -565,7 +565,8 @@
         "disableThinking": "Disable thinking mode",
         "thinkingEnabled": "Thinking mode enabled",
         "thinkingDisabled": "Thinking mode disabled",
-        "thinkText": "Think"
+        "thinkText": "Think",
+        "cycleEffort": "Reasoning effort: {{level}}. Double tap to cycle effort level"
       }
     },
     "contentReportSheet": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -131,6 +131,8 @@
     "requestTimeout": "Request Timeout (seconds)",
     "requestTimeoutPlaceholder": "Optional - leave empty for default",
     "requestTimeoutHelp": "Max wait for a slow server to respond. Leave empty for default.",
+    "serverType": "Server Type",
+    "serverTypeHelp": "Controls how reasoning settings are sent. Auto-detected; change if it's wrong.",
     "apiKey": "API Key",
     "apiKeyPlaceholder": "Optional - required for OpenAI/Groq",
     "apiKeyDescription": "Stored securely on device.",
@@ -746,7 +748,13 @@
     },
     "modelSettingsSheet": {
       "modelSettings": "Model Settings",
-      "saveChanges": "Save Changes"
+      "saveChanges": "Save Changes",
+      "reasoningSection": "Reasoning",
+      "isReasoningModel": "Reasoning model",
+      "isReasoningModelHelp": "Show the thinking control for this model, even if it wasn't auto-detected.",
+      "supportsEffort": "Supports graded effort",
+      "effortValues": "Effort levels",
+      "effortValuesPlaceholder": "low, medium, high"
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Hugging Face Models",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -132,7 +132,7 @@
     "requestTimeoutPlaceholder": "Optional - leave empty for default",
     "requestTimeoutHelp": "Max wait for a slow server to respond. Leave empty for default.",
     "serverType": "Server Type",
-    "serverTypeHelp": "Controls how reasoning settings are sent. Auto-detected; change if it's wrong.",
+    "serverTypeHelp": "Auto-detected; change if it's wrong.",
     "apiKey": "API Key",
     "apiKeyPlaceholder": "Optional - required for OpenAI/Groq",
     "apiKeyDescription": "Stored securely on device.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -753,8 +753,12 @@
       "isReasoningModel": "Reasoning model",
       "isReasoningModelHelp": "Show the thinking control for this model, even if it wasn't auto-detected.",
       "supportsEffort": "Supports graded effort",
-      "effortValues": "Effort levels",
-      "effortValuesPlaceholder": "low, medium, high"
+      "effortValues": "Effort levels this model supports",
+      "effortLevels": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High"
+      }
     },
     "modelsHeaderRight": {
       "menuTitleHf": "Hugging Face Models",

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -196,34 +196,12 @@ export const ChatScreen: React.FC = observer(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activePalId, modelStore.activeModelId, modelStore.context]);
 
-  const handleThinkingToggle = async (enabled: boolean) => {
-    const currentSession = chatSessionStore.sessions.find(
-      s => s.id === chatSessionStore.activeSessionId,
-    );
-
-    if (currentSession) {
-      // Use resolved settings so pal overrides (temperature, etc.) are preserved
-      const resolvedSettings =
-        await chatSessionStore.getCurrentCompletionSettings();
-      const updatedSettings = {
-        ...resolvedSettings,
-        enable_thinking: enabled,
-      };
-      await chatSessionStore.updateSessionCompletionSettings(updatedSettings);
-    } else {
-      // No active session: stage the user's choice on the new-chat
-      // override field. Resolver applies it as the last layer so the
-      // toggle persists; session creation bakes it in and births the
-      // session as 'custom'. Does NOT touch newChatCompletionSettings or
-      // newChatSettingsSource — pal's other params remain intact.
-      runInAction(() => {
-        chatSessionStore.newChatThinkingOverride = enabled;
-      });
-    }
-  };
-
-  // Persist the chosen reasoning effort alongside the on/off intent so the
-  // local hook / remote carrier can pick it up. Preserves pal overrides.
+  // Persist the on/off intent (and optional effort) onto both the local
+  // enable_thinking flag and the reasoning carrier so the remote wire path
+  // (openai.ts, gated per serverType) and the local hook both see it.
+  // Preserves pal overrides. No active session: stage on the new-chat
+  // override field — the resolver applies it as the last layer and session
+  // creation bakes it in, without touching newChatCompletionSettings.
   const persistReasoning = async (enabled: boolean, effort?: string) => {
     const currentSession = chatSessionStore.sessions.find(
       s => s.id === chatSessionStore.activeSessionId,
@@ -241,6 +219,12 @@ export const ChatScreen: React.FC = observer(() => {
         chatSessionStore.newChatThinkingOverride = enabled;
       });
     }
+  };
+
+  // Simple on/off pill (effortless models): carries the on/off intent on the
+  // reasoning carrier (effort undefined) so remote OFF is not a no-op.
+  const handleThinkingToggle = async (enabled: boolean) => {
+    await persistReasoning(enabled);
   };
 
   // Graded pill cycle: off -> values[0] -> ... -> values[n] -> off.

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -148,6 +148,7 @@ export const ChatScreen: React.FC = observer(() => {
     activeSession?.completionSettings,
     chatSessionStore.newChatCompletionSettings,
     chatSessionStore.newChatThinkingOverride,
+    chatSessionStore.newChatReasoningEffort,
     activePalId,
   ]);
 
@@ -217,6 +218,7 @@ export const ChatScreen: React.FC = observer(() => {
     } else {
       runInAction(() => {
         chatSessionStore.newChatThinkingOverride = enabled;
+        chatSessionStore.newChatReasoningEffort = effort;
       });
     }
   };

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -15,10 +15,17 @@ import {useChatSession} from '../../hooks';
 import {usePendingMessage} from '../../hooks/useDeepLinking';
 import {Pal} from '../../types/pal';
 
-import {modelStore, chatSessionStore, palStore, uiStore} from '../../store';
+import {
+  modelStore,
+  chatSessionStore,
+  palStore,
+  serverStore,
+  uiStore,
+} from '../../store';
 import {hasVideoCapability} from '../../utils/pal-capabilities';
 
 import {L10nContext} from '../../utils';
+import {resolveReasoningCapability} from '../../utils/reasoningCapability';
 import {MessageType} from '../../utils/types';
 import {ErrorState} from '../../utils/errors';
 import {user, assistant} from '../../utils/chat';
@@ -106,9 +113,20 @@ export const ChatScreen: React.FC = observer(() => {
     checkMultimodal();
   }, [isMultimodalEnabled]);
 
-  const thinkingSupported = modelStore.activeModel?.supportsThinking ?? false;
+  // Resolver is the single source of truth for reasoning capability.
+  // Pill is reachable whenever the model is not known to be non-reasoning
+  // (fail-open on 'unknown' so remote + missed-local models are reachable).
+  const reasoningCapability = resolveReasoningCapability(
+    modelStore.activeModel,
+    serverStore.remoteReasoning,
+  );
+  const thinkingSupported =
+    !!modelStore.activeModel && reasoningCapability.isReasoning !== 'no';
 
   const [thinkingEnabled, setThinkingEnabled] = useState(true);
+  const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
+    undefined,
+  );
   const activeSession = chatSessionStore.sessions.find(
     s => s.id === chatSessionStore.activeSessionId,
   );
@@ -117,6 +135,7 @@ export const ChatScreen: React.FC = observer(() => {
     chatSessionStore.getCurrentCompletionSettings().then(settings => {
       if (!cancelled) {
         setThinkingEnabled(settings.enable_thinking ?? true);
+        setReasoningEffort(settings.reasoning?.effort);
       }
     });
     return () => {
@@ -203,6 +222,53 @@ export const ChatScreen: React.FC = observer(() => {
     }
   };
 
+  // Persist the chosen reasoning effort alongside the on/off intent so the
+  // local hook / remote carrier can pick it up. Preserves pal overrides.
+  const persistReasoning = async (enabled: boolean, effort?: string) => {
+    const currentSession = chatSessionStore.sessions.find(
+      s => s.id === chatSessionStore.activeSessionId,
+    );
+    if (currentSession) {
+      const resolvedSettings =
+        await chatSessionStore.getCurrentCompletionSettings();
+      await chatSessionStore.updateSessionCompletionSettings({
+        ...resolvedSettings,
+        enable_thinking: enabled,
+        reasoning: {enabled, effort},
+      });
+    } else {
+      runInAction(() => {
+        chatSessionStore.newChatThinkingOverride = enabled;
+      });
+    }
+  };
+
+  // Graded pill cycle: off -> values[0] -> ... -> values[n] -> off.
+  const handleEffortCycle = async () => {
+    const values = reasoningCapability.effortValues;
+    if (values.length === 0) {
+      return;
+    }
+    let nextEnabled: boolean;
+    let nextEffort: string | undefined;
+    if (!thinkingEnabled) {
+      nextEnabled = true;
+      nextEffort = values[0];
+    } else {
+      const idx = reasoningEffort ? values.indexOf(reasoningEffort) : -1;
+      if (idx < 0 || idx >= values.length - 1) {
+        nextEnabled = false;
+        nextEffort = undefined;
+      } else {
+        nextEnabled = true;
+        nextEffort = values[idx + 1];
+      }
+    }
+    setThinkingEnabled(nextEnabled);
+    setReasoningEffort(nextEffort);
+    await persistReasoning(nextEnabled, nextEffort);
+  };
+
   // If the active pal is a video pal, show the video pal screen
   if (isVideoPal) {
     return <VideoPalScreen activePal={activePal} />;
@@ -230,6 +296,10 @@ export const ChatScreen: React.FC = observer(() => {
           showThinkingToggle: thinkingSupported,
           isThinkingEnabled: thinkingEnabled,
           onThinkingToggle: handleThinkingToggle,
+          supportsEffort: reasoningCapability.supportsEffort,
+          effortValues: reasoningCapability.effortValues,
+          reasoningEffort,
+          onEffortCycle: handleEffortCycle,
         }}
         textInputProps={{
           placeholder: !modelStore.engine

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -15,6 +15,8 @@ import {chatSessionStore, modelStore, serverStore} from '../../../store';
 
 import {l10n} from '../../../locales';
 import {mockLlamaContextParams} from '../../../../jest/fixtures/models';
+import {buildReasoningPayload} from '../../../api/openai';
+import {ModelOrigin} from '../../../utils/types';
 
 const render = (ui: React.ReactElement, options: any = {}) =>
   baseRender(ui, {withBottomSheetProvider: true, ...options});
@@ -577,6 +579,105 @@ describe('ChatScreen graded effort pill cycle', () => {
     expect(persisted).toMatchObject({
       enable_thinking: false,
       reasoning: {enabled: false, effort: undefined},
+    });
+  });
+});
+
+describe('ChatScreen on/off toggle → reasoning carrier (remote)', () => {
+  let savedModels: any[];
+  let savedSessionId: string | null | undefined;
+  // Session-backed persistence so the simple on/off toggle round-trips through
+  // updateSessionCompletionSettings, mirroring real session behaviour.
+  let persisted: {
+    enable_thinking: boolean;
+    reasoning?: {enabled: boolean; effort?: string};
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    savedModels = modelStore.models;
+    savedSessionId = chatSessionStore.activeSessionId;
+    persisted = {enable_thinking: true, reasoning: undefined};
+    runInAction(() => {
+      modelStore.context = new LlamaContext(mockLlamaContextParams);
+      // No entry → resolver reports isReasoning 'unknown' (pill shown,
+      // fail-open) and supportsEffort false (simple on/off toggle).
+      serverStore.remoteReasoning = {};
+      chatSessionStore.activeSessionId = 'session-1';
+    });
+    modelStore.engine = {
+      completion: jest.fn(),
+      stopCompletion: jest.fn(),
+    } as any;
+    (
+      chatSessionStore.getCurrentCompletionSettings as jest.Mock
+    ).mockImplementation(async () => ({...persisted}));
+    (
+      chatSessionStore.updateSessionCompletionSettings as jest.Mock
+    ).mockImplementation(async (s: any) => {
+      persisted = {
+        enable_thinking: s.enable_thinking,
+        reasoning: s.reasoning,
+      };
+      runInAction(() => {
+        const session = chatSessionStore.sessions.find(
+          x => x.id === 'session-1',
+        );
+        if (session) {
+          (session as any).completionSettings = {...persisted};
+        }
+      });
+    });
+  });
+
+  afterEach(() => {
+    modelStore.models = savedModels;
+    runInAction(() => {
+      modelStore.activeModelId = undefined;
+      chatSessionStore.activeSessionId = savedSessionId as any;
+    });
+  });
+
+  const useRemoteEffortUnknownModel = () => {
+    const model = {
+      ...savedModels[0],
+      id: 'remote-effort-unknown',
+      origin: ModelOrigin.REMOTE,
+      supportsThinking: undefined,
+      reasoning: undefined,
+    };
+    modelStore.models = [...savedModels, model];
+    runInAction(() => {
+      modelStore.activeModelId = 'remote-effort-unknown';
+    });
+  };
+
+  // Toggling thinking OFF on a remote effort-unknown model must populate the
+  // reasoning carrier (enabled:false), so buildReasoningPayload produces the
+  // per-serverType OFF wire shape. Pre-R1 the toggle set only enable_thinking,
+  // leaving params.reasoning undefined → buildReasoningPayload returns {}.
+  it('off toggle yields reasoning.enabled false reaching buildReasoningPayload', async () => {
+    useRemoteEffortUnknownModel();
+    const {getByLabelText} = render(<ChatScreen />, {withNavigation: true});
+
+    // Default thinkingEnabled true → label is "Disable thinking mode".
+    const toggle = getByLabelText('Disable thinking mode');
+    await act(async () => {
+      fireEvent.press(toggle);
+    });
+
+    await waitFor(() =>
+      expect(persisted.reasoning).toEqual({enabled: false, effort: undefined}),
+    );
+    expect(persisted.reasoning?.enabled).toBe(false);
+
+    // The carrier drives the per-serverType OFF payload.
+    expect(buildReasoningPayload('llama.cpp', persisted.reasoning)).toEqual({
+      reasoning_format: 'none',
+      chat_template_kwargs: {enable_thinking: false},
+    });
+    expect(buildReasoningPayload('Ollama', persisted.reasoning)).toEqual({
+      reasoning_effort: 'none',
     });
   });
 });

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -839,7 +839,7 @@ describe('ChatScreen on/off toggle → reasoning carrier (remote)', () => {
 
     // The carrier drives the per-serverType OFF payload.
     expect(buildReasoningPayload('llama.cpp', persisted.reasoning)).toEqual({
-      reasoning_format: 'none',
+      reasoning_format: 'auto',
       chat_template_kwargs: {enable_thinking: false},
     });
     expect(buildReasoningPayload('Ollama', persisted.reasoning)).toEqual({

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -476,6 +476,172 @@ describe('ChatScreen reasoning pill visibility', () => {
   });
 });
 
+describe('ChatScreen reasoning override reaches the pill (live, no remount)', () => {
+  // Reproduces the user-reported flow: a model is loaded as the active chat
+  // model with NO reasoning capability (binary pill), the chat is already on
+  // screen, then the user saves a graded-effort override on the model card.
+  // The card mutates the live observable Model via setReasoningOverride; the
+  // already-mounted ChatScreen must react and the pill must become graded
+  // without a remount. Existing tests bake `reasoning` in before render, so
+  // they cannot catch a broken live-override/observation path.
+  let savedModels: any[];
+  let savedSessionId: string | null | undefined;
+  // Persisted reasoning settings for the active session — the pill init effect
+  // reads enable_thinking back from here, mirroring real session persistence.
+  let persisted: {enable_thinking: boolean; reasoning?: {effort?: string}};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    savedModels = modelStore.models;
+    savedSessionId = chatSessionStore.activeSessionId;
+    // Start from a settled OFF pill so the first graded tap advances to the
+    // first effort value rather than wrapping the cycle from an on-state.
+    persisted = {enable_thinking: false, reasoning: {effort: undefined}};
+    runInAction(() => {
+      modelStore.context = new LlamaContext(mockLlamaContextParams);
+      serverStore.remoteReasoning = {};
+      chatSessionStore.activeSessionId = 'session-1';
+    });
+    modelStore.engine = {
+      completion: jest.fn(),
+      stopCompletion: jest.fn(),
+    } as any;
+    (
+      chatSessionStore.getCurrentCompletionSettings as jest.Mock
+    ).mockImplementation(async () => ({...persisted}));
+    (
+      chatSessionStore.updateSessionCompletionSettings as jest.Mock
+    ).mockImplementation(async (s: any) => {
+      persisted = {enable_thinking: s.enable_thinking, reasoning: s.reasoning};
+      runInAction(() => {
+        const session = chatSessionStore.sessions.find(
+          x => x.id === 'session-1',
+        );
+        if (session) {
+          (session as any).completionSettings = {...persisted};
+        }
+      });
+    });
+  });
+
+  afterEach(() => {
+    runInAction(() => {
+      modelStore.models = savedModels;
+      modelStore.activeModelId = undefined;
+      chatSessionStore.activeSessionId = savedSessionId as any;
+    });
+  });
+
+  it('turns the binary pill into a graded cycle after setReasoningOverride', async () => {
+    const thinkText = l10n.en.components.chatInput.thinkingToggle.thinkText;
+
+    // Active local model with reasoning absent → pill is binary on/off.
+    const model = {
+      ...savedModels[0],
+      id: 'override-model',
+      origin: ModelOrigin.LOCAL,
+      supportsThinking: true,
+      reasoning: undefined,
+    };
+    runInAction(() => {
+      modelStore.models = [...savedModels, model];
+      modelStore.activeModelId = 'override-model';
+    });
+
+    const {getByTestId} = render(<ChatScreen />, {
+      withNavigation: true,
+    });
+    const pill = () => within(getByTestId('thinking-toggle'));
+
+    // The pill starts binary and settled OFF (no effort label, no graded cycle
+    // available yet).
+    await waitFor(() => expect(pill().getByText(thinkText)).toBeTruthy());
+
+    // User saves a graded-effort override on the model card. This is the exact
+    // writer the ModelSettingsSheet calls.
+    await act(async () => {
+      modelStore.setReasoningOverride('override-model', {
+        isReasoning: 'yes',
+        source: 'user',
+        supportsEffort: true,
+        effortValues: ['low', 'medium', 'high'],
+        effortSource: 'user',
+      });
+    });
+
+    // The already-mounted ChatScreen must now drive a graded pill: tapping
+    // cycles off → low → medium → high instead of a plain on/off toggle. Each
+    // tap awaits the async persist + state flush before the label settles.
+    for (const expected of ['low', 'medium', 'high']) {
+      await act(async () => {
+        fireEvent.press(getByTestId('thinking-toggle'));
+      });
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 30));
+      });
+      await waitFor(() => expect(pill().getByText(expected)).toBeTruthy());
+    }
+  });
+
+  it('graded cycle advances in a fresh chat (no active session)', async () => {
+    // The user-reported repro: a freshly loaded model in a brand-new chat (no
+    // session yet). The graded pill must still advance off → low → medium →
+    // high. The no-session path stages the effort on the new-chat override
+    // fields; if it drops the effort grade the cycle collapses to on/off and
+    // the pill alternates instead of stepping through the grades.
+    runInAction(() => {
+      chatSessionStore.activeSessionId = null as any;
+      chatSessionStore.newChatThinkingOverride = undefined;
+      chatSessionStore.newChatReasoningEffort = undefined;
+    });
+    // Mirror resolveCompletionSettings' no-session overlay: read the on/off and
+    // effort back from the new-chat override fields the pill writes through.
+    (
+      chatSessionStore.getCurrentCompletionSettings as jest.Mock
+    ).mockImplementation(async () => ({
+      enable_thinking: chatSessionStore.newChatThinkingOverride ?? false,
+      reasoning: {
+        enabled: chatSessionStore.newChatThinkingOverride ?? false,
+        effort: chatSessionStore.newChatReasoningEffort,
+      },
+    }));
+
+    const model = {
+      ...savedModels[0],
+      id: 'fresh-chat-model',
+      origin: ModelOrigin.HF,
+      supportsThinking: true,
+      reasoning: {
+        isReasoning: 'yes' as const,
+        source: 'user' as const,
+        supportsEffort: true,
+        effortValues: ['low', 'medium', 'high'],
+        effortSource: 'user' as const,
+      },
+    };
+    runInAction(() => {
+      modelStore.models = [...savedModels, model];
+      modelStore.activeModelId = 'fresh-chat-model';
+    });
+
+    const {getByTestId} = render(<ChatScreen />, {withNavigation: true});
+    const pill = () => within(getByTestId('thinking-toggle'));
+    const thinkText = l10n.en.components.chatInput.thinkingToggle.thinkText;
+
+    await waitFor(() => expect(pill().getByText(thinkText)).toBeTruthy());
+
+    for (const expected of ['low', 'medium', 'high']) {
+      await act(async () => {
+        fireEvent.press(getByTestId('thinking-toggle'));
+      });
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 30));
+      });
+      await waitFor(() => expect(pill().getByText(expected)).toBeTruthy());
+    }
+  });
+});
+
 describe('ChatScreen graded effort pill cycle', () => {
   let savedModels: any[];
   let savedSessionId: string | null | undefined;

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -7,6 +7,7 @@ import {
   fireEvent,
   act,
   waitFor,
+  within,
 } from '../../../../jest/test-utils';
 import {ChatScreen} from '../ChatScreen';
 
@@ -470,5 +471,112 @@ describe('ChatScreen reasoning pill visibility', () => {
     });
     const {queryByTestId} = render(<ChatScreen />, {withNavigation: true});
     expect(queryByTestId('thinking-toggle')).toBeTruthy();
+  });
+});
+
+describe('ChatScreen graded effort pill cycle', () => {
+  let savedModels: any[];
+  let savedSessionId: string | null | undefined;
+  // Persisted reasoning settings for the active session. The pill's cycle
+  // writes through updateSessionCompletionSettings; the init effect reads back
+  // via getCurrentCompletionSettings, mirroring real session persistence so a
+  // re-render does not clobber the just-applied state.
+  let persisted: {enable_thinking: boolean; reasoning?: {effort?: string}};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    savedModels = modelStore.models;
+    savedSessionId = chatSessionStore.activeSessionId;
+    persisted = {enable_thinking: false, reasoning: {effort: undefined}};
+    runInAction(() => {
+      modelStore.context = new LlamaContext(mockLlamaContextParams);
+      serverStore.remoteReasoning = {};
+      chatSessionStore.activeSessionId = 'session-1';
+    });
+    modelStore.engine = {
+      completion: jest.fn(),
+      stopCompletion: jest.fn(),
+    } as any;
+    // Pill initializes to OFF; cycle round-trips through the session settings.
+    (
+      chatSessionStore.getCurrentCompletionSettings as jest.Mock
+    ).mockImplementation(async () => ({...persisted}));
+    (
+      chatSessionStore.updateSessionCompletionSettings as jest.Mock
+    ).mockImplementation(async (s: any) => {
+      persisted = {
+        enable_thinking: s.enable_thinking,
+        reasoning: s.reasoning,
+      };
+      // Bump the session reference so the init effect re-reads the new value.
+      runInAction(() => {
+        const session = chatSessionStore.sessions.find(
+          x => x.id === 'session-1',
+        );
+        if (session) {
+          (session as any).completionSettings = {...persisted};
+        }
+      });
+    });
+  });
+
+  afterEach(() => {
+    modelStore.models = savedModels;
+    runInAction(() => {
+      modelStore.activeModelId = undefined;
+      chatSessionStore.activeSessionId = savedSessionId as any;
+    });
+  });
+
+  const useGradedModel = () => {
+    const model = {
+      ...savedModels[0],
+      id: 'graded-model',
+      reasoning: {
+        isReasoning: 'yes' as const,
+        source: 'user' as const,
+        supportsEffort: true,
+        effortValues: ['low', 'medium', 'high'],
+        effortSource: 'user' as const,
+      },
+    };
+    modelStore.models = [...savedModels, model];
+    runInAction(() => {
+      modelStore.activeModelId = 'graded-model';
+    });
+  };
+
+  // Scenario D state machine (§3): a graded model's single pill cycles
+  // off → low → medium → high → off in value-set order, never on/off only.
+  it('cycles off → low → medium → high → off in value-set order', async () => {
+    const thinkText = l10n.en.components.chatInput.thinkingToggle.thinkText;
+    useGradedModel();
+    const {getByTestId} = render(<ChatScreen />, {withNavigation: true});
+    const pill = () => within(getByTestId('thinking-toggle'));
+
+    // The init effect resolves enable_thinking:false → pill settles to OFF.
+    await waitFor(() => expect(pill().getByText(thinkText)).toBeTruthy());
+
+    for (const expected of ['low', 'medium', 'high']) {
+      await act(async () => {
+        fireEvent.press(getByTestId('thinking-toggle'));
+      });
+      await waitFor(() => expect(pill().getByText(expected)).toBeTruthy());
+      // The chosen effort is persisted onto the reasoning carrier intent.
+      expect(persisted).toMatchObject({
+        enable_thinking: true,
+        reasoning: {enabled: true, effort: expected},
+      });
+    }
+
+    // One more tap past the last value wraps back to off.
+    await act(async () => {
+      fireEvent.press(getByTestId('thinking-toggle'));
+    });
+    await waitFor(() => expect(pill().getByText(thinkText)).toBeTruthy());
+    expect(persisted).toMatchObject({
+      enable_thinking: false,
+      reasoning: {enabled: false, effort: undefined},
+    });
   });
 });

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -21,6 +21,11 @@ import {ModelOrigin} from '../../../utils/types';
 const render = (ui: React.ReactElement, options: any = {}) =>
   baseRender(ui, {withBottomSheetProvider: true, ...options});
 
+// The pill renders the localized effort tier (e.g. 'Low'), not the raw carrier
+// token ('low'); map the token through the same table the component uses.
+const effortLabels = l10n.en.components.modelSettingsSheet.effortLevels;
+const effortLabel = (token: keyof typeof effortLabels) => effortLabels[token];
+
 describe('ChatScreen', () => {
   let llamaRN;
 
@@ -572,14 +577,16 @@ describe('ChatScreen reasoning override reaches the pill (live, no remount)', ()
     // The already-mounted ChatScreen must now drive a graded pill: tapping
     // cycles off → low → medium → high instead of a plain on/off toggle. Each
     // tap awaits the async persist + state flush before the label settles.
-    for (const expected of ['low', 'medium', 'high']) {
+    for (const expected of ['low', 'medium', 'high'] as const) {
       await act(async () => {
         fireEvent.press(getByTestId('thinking-toggle'));
       });
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 30));
       });
-      await waitFor(() => expect(pill().getByText(expected)).toBeTruthy());
+      await waitFor(() =>
+        expect(pill().getByText(effortLabel(expected))).toBeTruthy(),
+      );
     }
   });
 
@@ -630,14 +637,16 @@ describe('ChatScreen reasoning override reaches the pill (live, no remount)', ()
 
     await waitFor(() => expect(pill().getByText(thinkText)).toBeTruthy());
 
-    for (const expected of ['low', 'medium', 'high']) {
+    for (const expected of ['low', 'medium', 'high'] as const) {
       await act(async () => {
         fireEvent.press(getByTestId('thinking-toggle'));
       });
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 30));
       });
-      await waitFor(() => expect(pill().getByText(expected)).toBeTruthy());
+      await waitFor(() =>
+        expect(pill().getByText(effortLabel(expected))).toBeTruthy(),
+      );
     }
   });
 });
@@ -725,11 +734,13 @@ describe('ChatScreen graded effort pill cycle', () => {
     // The init effect resolves enable_thinking:false → pill settles to OFF.
     await waitFor(() => expect(pill().getByText(thinkText)).toBeTruthy());
 
-    for (const expected of ['low', 'medium', 'high']) {
+    for (const expected of ['low', 'medium', 'high'] as const) {
       await act(async () => {
         fireEvent.press(getByTestId('thinking-toggle'));
       });
-      await waitFor(() => expect(pill().getByText(expected)).toBeTruthy());
+      await waitFor(() =>
+        expect(pill().getByText(effortLabel(expected))).toBeTruthy(),
+      );
       // The chosen effort is persisted onto the reasoning carrier intent.
       expect(persisted).toMatchObject({
         enable_thinking: true,

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../jest/test-utils';
 import {ChatScreen} from '../ChatScreen';
 
-import {chatSessionStore, modelStore} from '../../../store';
+import {chatSessionStore, modelStore, serverStore} from '../../../store';
 
 import {l10n} from '../../../locales';
 import {mockLlamaContextParams} from '../../../../jest/fixtures/models';
@@ -248,13 +248,20 @@ describe('ChatScreen', () => {
     let savedModels: any[];
 
     beforeEach(() => {
-      // Inject a thinking-capable model into the mock model list so the
-      // `activeModel?.supportsThinking` computed in ChatScreen returns true.
+      // Inject a reasoning-capable model so the resolver in ChatScreen reports
+      // isReasoning 'yes' and the thinking pill is shown.
       savedModels = modelStore.models;
       const thinkingModel = {
         ...modelStore.models[0],
         id: 'thinking-model-id',
         supportsThinking: true,
+        reasoning: {
+          isReasoning: 'yes' as const,
+          source: 'detected' as const,
+          supportsEffort: false,
+          effortValues: [],
+          effortSource: 'none' as const,
+        },
       };
       modelStore.models = [...modelStore.models, thinkingModel];
 
@@ -399,5 +406,69 @@ describe('ChatScreen', () => {
         'tool-model-id',
       );
     });
+  });
+});
+
+describe('ChatScreen reasoning pill visibility', () => {
+  let savedModels: any[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    savedModels = modelStore.models;
+    runInAction(() => {
+      modelStore.context = new LlamaContext(mockLlamaContextParams);
+      serverStore.remoteReasoning = {};
+    });
+    modelStore.engine = {
+      completion: jest.fn(),
+      stopCompletion: jest.fn(),
+    } as any;
+  });
+
+  afterEach(() => {
+    modelStore.models = savedModels;
+    modelStore.activeModelId = undefined;
+  });
+
+  const useModel = (overrides: any) => {
+    const model = {...savedModels[0], id: 'pill-model', ...overrides};
+    modelStore.models = [...savedModels, model];
+    runInAction(() => {
+      modelStore.activeModelId = 'pill-model';
+    });
+  };
+
+  it("shows the pill when isReasoning is 'unknown' (fail-open)", () => {
+    useModel({supportsThinking: undefined, reasoning: undefined});
+    const {queryByTestId} = render(<ChatScreen />, {withNavigation: true});
+    expect(queryByTestId('thinking-toggle')).toBeTruthy();
+  });
+
+  it("hides the pill when isReasoning is 'no'", () => {
+    useModel({
+      reasoning: {
+        isReasoning: 'no',
+        source: 'user',
+        supportsEffort: true,
+        effortValues: ['low', 'high'],
+        effortSource: 'user',
+      },
+    });
+    const {queryByTestId} = render(<ChatScreen />, {withNavigation: true});
+    expect(queryByTestId('thinking-toggle')).toBeNull();
+  });
+
+  it('shows the pill for a graded effort model', () => {
+    useModel({
+      reasoning: {
+        isReasoning: 'yes',
+        source: 'user',
+        supportsEffort: true,
+        effortValues: ['low', 'medium', 'high'],
+        effortSource: 'user',
+      },
+    });
+    const {queryByTestId} = render(<ChatScreen />, {withNavigation: true});
+    expect(queryByTestId('thinking-toggle')).toBeTruthy();
   });
 });

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -546,8 +546,8 @@ describe('ChatScreen graded effort pill cycle', () => {
     });
   };
 
-  // Scenario D state machine (§3): a graded model's single pill cycles
-  // off → low → medium → high → off in value-set order, never on/off only.
+  // A graded model's single pill cycles off → low → medium → high → off in
+  // value-set order, never on/off only.
   it('cycles off → low → medium → high → off in value-set order', async () => {
     const thinkText = l10n.en.components.chatInput.thinkingToggle.thinkText;
     useGradedModel();

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -364,11 +364,23 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
     }, [model, l10n, isActiveModel]);
 
     const renderActionButtons = () => {
-      // Remote models: load/offload + delete
+      // Remote models: load/offload + settings (reasoning override) + delete
       if (isRemoteModel) {
         return (
           <View style={styles.actionButtonsRow}>
             {renderModelLoadButton()}
+            <TouchableOpacity
+              testID="settings-button"
+              onPress={onOpenSettings}
+              style={styles.iconButton}
+              accessibilityRole="button"
+              accessibilityLabel={l10n.models.modelCard.buttons.settings}>
+              <SettingsIcon
+                width={16}
+                height={16}
+                stroke={theme.colors.onSurfaceVariant}
+              />
+            </TouchableOpacity>
             <TouchableOpacity
               testID="delete-button"
               onPress={handleRemoteDelete}

--- a/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
+++ b/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
@@ -553,6 +553,33 @@ describe('ModelCard', () => {
       });
     });
 
+    it('shows a settings button for remote models', async () => {
+      const {getByTestId} = customRender(
+        <ModelCard
+          model={remoteModel}
+          onOpenServerDetails={mockOnOpenServerDetails}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('settings-button')).toBeTruthy();
+      });
+    });
+
+    it('calls onOpenSettings when the remote settings button is pressed', async () => {
+      const mockOnOpenSettings = jest.fn();
+      const {getByTestId} = customRender(
+        <ModelCard
+          model={remoteModel}
+          onOpenSettings={mockOnOpenSettings}
+          onOpenServerDetails={mockOnOpenServerDetails}
+        />,
+      );
+
+      fireEvent.press(getByTestId('settings-button'));
+      expect(mockOnOpenSettings).toHaveBeenCalled();
+    });
+
     it('shows delete confirmation dialog for remote models', async () => {
       jest.spyOn(Alert, 'alert').mockImplementation();
 

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -96,6 +96,11 @@ class ChatSessionStore {
   // persists; cleared on session creation, new-chat reset, and session
   // switch.
   newChatThinkingOverride: boolean | undefined = undefined;
+  // User's manual graded-effort choice in the no-session chat path, paired with
+  // newChatThinkingOverride. Carries the effort grade (low/medium/high) so a
+  // graded pill round-trips before the first message creates a session; cleared
+  // alongside newChatThinkingOverride.
+  newChatReasoningEffort: string | undefined = undefined;
   // Store localized date group names
   dateGroupNames: typeof DEFAULT_GROUP_NAMES = DEFAULT_GROUP_NAMES;
   // Migration status
@@ -358,6 +363,7 @@ class ChatSessionStore {
       this.newChatPalId = this.activePalId;
       this.newChatSettingsSource = 'pal'; // Reset to default for new chat
       this.newChatThinkingOverride = undefined;
+      this.newChatReasoningEffort = undefined;
       // Do not copy completion settings from session to global settings
       // Instead, preserve global settings as they are
       this.exitEditMode();
@@ -409,6 +415,7 @@ class ChatSessionStore {
       this.newChatPalId = undefined;
       this.newChatSettingsSource = 'pal'; // Reset for consistency
       this.newChatThinkingOverride = undefined;
+      this.newChatReasoningEffort = undefined;
       this.lastCompletionResult = this.hydrateCompletionSnapshot(session);
       this.dismissedBannerVariants = new Set();
       this.consecutiveFullFailures = 0;
@@ -605,6 +612,7 @@ class ChatSessionStore {
         this.activeSessionId = newSession.id;
         this.newChatPalId = undefined;
         this.newChatThinkingOverride = undefined;
+        this.newChatReasoningEffort = undefined;
       });
     } catch (error) {
       console.error('Failed to create new session:', error);
@@ -1486,6 +1494,7 @@ class ChatSessionStore {
         reasoning: {
           ...resolvedSettings.reasoning,
           enabled: this.newChatThinkingOverride,
+          effort: this.newChatReasoningEffort,
         },
       };
     }

--- a/src/store/ChatSessionStore.ts
+++ b/src/store/ChatSessionStore.ts
@@ -1475,12 +1475,18 @@ class ChatSessionStore {
     }
 
     // No-session-only: apply user's explicit thinking override last so it
-    // wins over pal's enable_thinking. Single-key overlay — does NOT touch
-    // any other field, and does NOT affect tool availability.
+    // wins over pal's enable_thinking. Overlays the local enable_thinking flag
+    // AND the reasoning carrier (so the remote wire path honors the on/off
+    // intent for the first message of the new chat, not just local thinking).
+    // Does NOT touch any other field, and does NOT affect tool availability.
     if (!sessionId && this.newChatThinkingOverride !== undefined) {
       resolvedSettings = {
         ...resolvedSettings,
         enable_thinking: this.newChatThinkingOverride,
+        reasoning: {
+          ...resolvedSettings.reasoning,
+          enabled: this.newChatThinkingOverride,
+        },
       };
     }
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2129,6 +2129,7 @@ class ModelStore {
         model.remoteModelId!,
         apiKey,
         server.requestTimeoutMs,
+        server.serverType,
       );
       this.setActiveModel(model.id);
       // Do NOT set lastUsedModelId for remote models -- server may be offline on next launch

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -80,6 +80,7 @@ import {
   getCpuCoreCount,
 } from '../utils/deviceCapabilities';
 import {detectThinkingCapability} from '../utils/thinkingCapabilityDetection';
+import {ReasoningCapability} from '../utils/reasoningCapability';
 import {t} from '../locales';
 import {resolveUseMmap} from '../utils/memorySettings';
 import {
@@ -2669,25 +2670,84 @@ class ModelStore {
         return;
       }
 
-      // Only check if supportsThinking is not already explicitly set
-      if (storeModel.supportsThinking === undefined) {
-        const result = await detectThinkingCapability(ctx);
-
-        runInAction(() => {
-          storeModel.supportsThinking = result.supported;
-          if (result.thinkingStartTag) {
-            storeModel.thinkingStartTag = result.thinkingStartTag;
-          }
-          if (result.thinkingEndTag) {
-            storeModel.thinkingEndTag = result.thinkingEndTag;
-          }
-        });
+      // Detection is the 'detected' writer; it must not override a user
+      // declaration or a learned flip (precedence: user > learned > detected).
+      if (
+        storeModel.reasoning?.source === 'user' ||
+        storeModel.reasoning?.source === 'learned'
+      ) {
+        return;
       }
+
+      const result = await detectThinkingCapability(ctx);
+
+      runInAction(() => {
+        // Keep the deprecated boolean + tags in sync for back-compat readers.
+        storeModel.supportsThinking = result.supported;
+        if (result.thinkingStartTag) {
+          storeModel.thinkingStartTag = result.thinkingStartTag;
+        }
+        if (result.thinkingEndTag) {
+          storeModel.thinkingEndTag = result.thinkingEndTag;
+        }
+        storeModel.reasoning = {
+          isReasoning: result.supported ? 'yes' : 'no',
+          source: 'detected',
+          supportsEffort: false,
+          effortValues: [],
+          effortSource: 'none',
+        };
+      });
     } catch (error) {
       console.error('Error updating model thinking capabilities:', error);
       // Continue execution - thinking capability detection is not critical
     }
   }
+
+  /**
+   * Learn-from-stream entry point. The first time a model actually emits
+   * reasoning, flip axis-1 to learned 'yes'. Routes remote ids to ServerStore
+   * (one direction). Idempotent and monotonic; never overrides a user
+   * declaration (handled by the per-store writers).
+   */
+  recordReasoningObserved = (modelId: string): void => {
+    const localModel = this.models.find(m => m.id === modelId);
+    if (!localModel) {
+      // Not a persisted local model → remote; delegate to ServerStore.
+      serverStore.recordRemoteReasoningObserved(modelId);
+      return;
+    }
+    const existing = localModel.reasoning;
+    if (existing?.source === 'user' || existing?.isReasoning === 'yes') {
+      return;
+    }
+    runInAction(() => {
+      localModel.reasoning = {
+        isReasoning: 'yes',
+        source: 'learned',
+        supportsEffort: existing?.supportsEffort ?? false,
+        effortValues: existing?.effortValues ?? [],
+        effortSource: existing?.effortSource ?? 'none',
+      };
+      localModel.supportsThinking = true;
+    });
+  };
+
+  /**
+   * Manual model-card override. Top of precedence; routes remote ids to
+   * ServerStore, local to the persisted Model.
+   */
+  setReasoningOverride = (modelId: string, cap: ReasoningCapability): void => {
+    const localModel = this.models.find(m => m.id === modelId);
+    if (!localModel) {
+      serverStore.setRemoteReasoningOverride(modelId, cap);
+      return;
+    }
+    runInAction(() => {
+      localModel.reasoning = cap;
+      localModel.supportsThinking = cap.isReasoning === 'yes';
+    });
+  };
 
   /**
    * Returns available (i.e. downloaded models) models with projection models filtered out,

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -6,6 +6,7 @@ import * as Keychain from 'react-native-keychain';
 
 import {fetchModels, testConnection, RemoteModelInfo} from '../api/openai';
 import {ServerConfig} from '../utils/types';
+import {ReasoningCapability} from '../utils/reasoningCapability';
 
 const KEYCHAIN_SERVICE_PREFIX = 'pocketpal-server-';
 
@@ -14,6 +15,10 @@ const FETCH_THROTTLE_MS = 60000;
 
 class ServerStore {
   servers: ServerConfig[] = [];
+  // Remote reasoning capability keyed by full model id (`${serverId}/${remoteModelId}`).
+  // Remote Models are rebuilt each launch and not persisted, so their capability
+  // lives here and persists with the store.
+  remoteReasoning: Record<string, ReasoningCapability> = {};
   serverModels: Map<string, RemoteModelInfo[]> = observable.map();
   userSelectedModels: Array<{serverId: string; remoteModelId: string}> = [];
   isLoading = false;
@@ -34,6 +39,7 @@ class ServerStore {
         'servers',
         'privacyNoticeAcknowledged',
         'userSelectedModels',
+        'remoteReasoning',
       ],
       storage: AsyncStorage,
     }).then(() => {
@@ -69,6 +75,13 @@ class ServerStore {
     this.userSelectedModels = this.userSelectedModels.filter(
       m => m.serverId !== id,
     );
+    // Drop remote reasoning entries keyed by this server's model ids.
+    const prefix = `${id}/`;
+    this.remoteReasoning = Object.fromEntries(
+      Object.entries(this.remoteReasoning).filter(
+        ([k]) => !k.startsWith(prefix),
+      ),
+    );
     // Clean up API key from keychain
     this.removeApiKey(id);
   }
@@ -86,6 +99,30 @@ class ServerStore {
     this.userSelectedModels = this.userSelectedModels.filter(
       m => !(m.serverId === serverId && m.remoteModelId === remoteModelId),
     );
+  }
+
+  /**
+   * Learn-from-stream writer for a remote model. Flips axis-1 to learned 'yes'
+   * the first time the model actually emits reasoning. Idempotent and monotonic:
+   * a no-op once axis-1 is already 'yes', and never overrides a user declaration.
+   */
+  recordRemoteReasoningObserved(modelId: string): void {
+    const existing = this.remoteReasoning[modelId];
+    if (existing?.source === 'user' || existing?.isReasoning === 'yes') {
+      return;
+    }
+    this.remoteReasoning[modelId] = {
+      isReasoning: 'yes',
+      source: 'learned',
+      supportsEffort: existing?.supportsEffort ?? false,
+      effortValues: existing?.effortValues ?? [],
+      effortSource: existing?.effortSource ?? 'none',
+    };
+  }
+
+  /** Manual model-card override for a remote model. Top of precedence. */
+  setRemoteReasoningOverride(modelId: string, cap: ReasoningCapability): void {
+    this.remoteReasoning[modelId] = cap;
   }
 
   removeServerIfOrphaned(serverId: string): void {

--- a/src/store/__tests__/ChatSessionStore.palSettings.test.ts
+++ b/src/store/__tests__/ChatSessionStore.palSettings.test.ts
@@ -272,7 +272,7 @@ describe('ChatSessionStore - Pal Settings', () => {
 
       expect(result.reasoning?.enabled).toBe(false);
       expect(buildReasoningPayload('llama.cpp', result.reasoning)).toEqual({
-        reasoning_format: 'none',
+        reasoning_format: 'auto',
         chat_template_kwargs: {enable_thinking: false},
       });
       expect(buildReasoningPayload('Ollama', result.reasoning)).toEqual({

--- a/src/store/__tests__/ChatSessionStore.palSettings.test.ts
+++ b/src/store/__tests__/ChatSessionStore.palSettings.test.ts
@@ -3,6 +3,7 @@ import {palStore} from '../PalStore';
 import {defaultCompletionSettings} from '../ChatSessionStore';
 import {CompletionParams} from '../../utils/completionTypes';
 import type {Pal} from '../PalStore';
+import {buildReasoningPayload} from '../../api/openai';
 
 describe('ChatSessionStore - Pal Settings', () => {
   beforeEach(() => {
@@ -234,6 +235,9 @@ describe('ChatSessionStore - Pal Settings', () => {
 
       // Override wins for enable_thinking.
       expect(result.enable_thinking).toBe(false);
+      // Reasoning carrier mirrors the override so the remote wire path honors
+      // the OFF intent for the first message of the new chat (not local-only).
+      expect(result.reasoning).toEqual({enabled: false});
       // Pal's other completion settings survive — override is single-key.
       expect(result.temperature).toBe(0.5);
     });
@@ -250,6 +254,30 @@ describe('ChatSessionStore - Pal Settings', () => {
       );
 
       expect(result.enable_thinking).toBe(true);
+      expect(result.reasoning).toEqual({enabled: true});
+    });
+
+    it('no-session OFF override carrier yields per-serverType OFF payload', async () => {
+      // The whole point of carrying the override on `reasoning`: a brand-new
+      // remote chat opened with thinking OFF must produce a real OFF wire
+      // payload, not an empty object.
+      palStore.pals.push(makeThinkingPal('palRemote', true));
+      chatSessionStore.newChatPalId = 'palRemote';
+      chatSessionStore.newChatThinkingOverride = false;
+
+      const result = await chatSessionStore.resolveCompletionSettings(
+        undefined,
+        'palRemote',
+      );
+
+      expect(result.reasoning?.enabled).toBe(false);
+      expect(buildReasoningPayload('llama.cpp', result.reasoning)).toEqual({
+        reasoning_format: 'none',
+        chat_template_kwargs: {enable_thinking: false},
+      });
+      expect(buildReasoningPayload('Ollama', result.reasoning)).toEqual({
+        reasoning_effort: 'none',
+      });
     });
 
     it('override is ignored on session-branch resolution (settingsSource pal)', async () => {

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4147,6 +4147,23 @@ describe('ModelStore', () => {
 
       expect((modelStore.engine as any).timeoutMs).toBe(600000);
     });
+
+    it('builds the engine carrying the saved serverType', async () => {
+      runInAction(() => {
+        serverStore.servers = [
+          {
+            id: 'srv-1',
+            name: 'Ollama Server',
+            url: 'http://localhost:11434',
+            serverType: 'Ollama',
+          },
+        ];
+      });
+
+      await modelStore.setRemoteModel(remoteModel);
+
+      expect((modelStore.engine as any).serverType).toBe('Ollama');
+    });
   });
 
   describe('fetchAndPersistGGUFMetadata error handling', () => {

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4217,4 +4217,77 @@ describe('ModelStore', () => {
       expect(metadata.n_layers).toBe(32);
     });
   });
+
+  describe('reasoning capability writers', () => {
+    it('hydrating a model without reasoning does not crash and stays undefined', () => {
+      const m = createModel({id: 'local-1', origin: ModelOrigin.PRESET});
+      modelStore.models = [m];
+      expect(modelStore.models[0].reasoning).toBeUndefined();
+    });
+
+    it('recordReasoningObserved flips a local model to learned yes', () => {
+      const m = createModel({id: 'local-1', origin: ModelOrigin.PRESET});
+      modelStore.models = [m];
+      modelStore.recordReasoningObserved('local-1');
+      expect(modelStore.models[0].reasoning).toMatchObject({
+        isReasoning: 'yes',
+        source: 'learned',
+      });
+    });
+
+    it('recordReasoningObserved never downgrades a user declaration', () => {
+      const m = createModel({id: 'local-1', origin: ModelOrigin.PRESET});
+      m.reasoning = {
+        isReasoning: 'no',
+        source: 'user',
+        supportsEffort: false,
+        effortValues: [],
+        effortSource: 'none',
+      };
+      modelStore.models = [m];
+      modelStore.recordReasoningObserved('local-1');
+      expect(modelStore.models[0].reasoning?.source).toBe('user');
+      expect(modelStore.models[0].reasoning?.isReasoning).toBe('no');
+    });
+
+    it('recordReasoningObserved routes an unknown id to ServerStore', () => {
+      const spy = jest.spyOn(serverStore, 'recordRemoteReasoningObserved');
+      modelStore.models = [];
+      modelStore.recordReasoningObserved('server-1/remote-m');
+      expect(spy).toHaveBeenCalledWith('server-1/remote-m');
+      spy.mockRestore();
+    });
+
+    it('setReasoningOverride writes a user capability on a local model', () => {
+      const m = createModel({id: 'local-1', origin: ModelOrigin.PRESET});
+      modelStore.models = [m];
+      modelStore.setReasoningOverride('local-1', {
+        isReasoning: 'yes',
+        source: 'user',
+        supportsEffort: true,
+        effortValues: ['low', 'medium', 'high'],
+        effortSource: 'user',
+      });
+      expect(modelStore.models[0].reasoning).toMatchObject({
+        source: 'user',
+        supportsEffort: true,
+      });
+      expect(modelStore.models[0].supportsThinking).toBe(true);
+    });
+
+    it('setReasoningOverride routes an unknown id to ServerStore', () => {
+      const spy = jest.spyOn(serverStore, 'setRemoteReasoningOverride');
+      modelStore.models = [];
+      const cap = {
+        isReasoning: 'yes' as const,
+        source: 'user' as const,
+        supportsEffort: false,
+        effortValues: [],
+        effortSource: 'none' as const,
+      };
+      modelStore.setReasoningOverride('server-1/remote-m', cap);
+      expect(spy).toHaveBeenCalledWith('server-1/remote-m', cap);
+      spy.mockRestore();
+    });
+  });
 });

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4267,6 +4267,28 @@ describe('ModelStore', () => {
       expect(modelStore.models[0].reasoning?.isReasoning).toBe('no');
     });
 
+    it('recordReasoningObserved is a monotonic no-op once axis-1 is already yes', () => {
+      const m = createModel({id: 'local-1', origin: ModelOrigin.PRESET});
+      const detectedYes = {
+        isReasoning: 'yes' as const,
+        source: 'detected' as const,
+        supportsEffort: true,
+        effortValues: ['low', 'high'],
+        effortSource: 'detected' as const,
+      };
+      m.reasoning = detectedYes;
+      modelStore.models = [m];
+      modelStore.recordReasoningObserved('local-1');
+      // Already 'yes' → not re-flipped to 'learned' and axis-2 preserved.
+      expect(modelStore.models[0].reasoning?.source).toBe('detected');
+      expect(modelStore.models[0].reasoning?.isReasoning).toBe('yes');
+      expect(modelStore.models[0].reasoning?.supportsEffort).toBe(true);
+      expect(modelStore.models[0].reasoning?.effortValues).toEqual([
+        'low',
+        'high',
+      ]);
+    });
+
     it('recordReasoningObserved routes an unknown id to ServerStore', () => {
       const spy = jest.spyOn(serverStore, 'recordRemoteReasoningObserved');
       modelStore.models = [];

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -39,6 +39,7 @@ describe('ServerStore', () => {
       serverStore.isLoading = false;
       serverStore.error = null;
       serverStore.privacyNoticeAcknowledged = false;
+      serverStore.remoteReasoning = {};
     });
   });
 
@@ -694,6 +695,93 @@ describe('ServerStore', () => {
       // we verify indirectly that the store has the subscription set up.
       // The constructor calls setupAppStateListener() which creates the subscription.
       expect(serverStore).toBeDefined();
+    });
+  });
+
+  describe('remote reasoning capability', () => {
+    const key = 'server-1/gpt-x';
+
+    it('starts empty and hydrating without the field does not crash', () => {
+      expect(serverStore.remoteReasoning).toEqual({});
+    });
+
+    it('recordRemoteReasoningObserved flips axis-1 to learned yes', () => {
+      serverStore.recordRemoteReasoningObserved(key);
+      expect(serverStore.remoteReasoning[key]).toMatchObject({
+        isReasoning: 'yes',
+        source: 'learned',
+        supportsEffort: false,
+      });
+    });
+
+    it('recordRemoteReasoningObserved is idempotent once yes', () => {
+      serverStore.recordRemoteReasoningObserved(key);
+      const first = serverStore.remoteReasoning[key];
+      serverStore.recordRemoteReasoningObserved(key);
+      expect(serverStore.remoteReasoning[key]).toBe(first);
+    });
+
+    it('recordRemoteReasoningObserved never overrides a user declaration', () => {
+      runInAction(() => {
+        serverStore.remoteReasoning[key] = {
+          isReasoning: 'no',
+          source: 'user',
+          supportsEffort: false,
+          effortValues: [],
+          effortSource: 'none',
+        };
+      });
+      serverStore.recordRemoteReasoningObserved(key);
+      expect(serverStore.remoteReasoning[key].source).toBe('user');
+      expect(serverStore.remoteReasoning[key].isReasoning).toBe('no');
+    });
+
+    it('setRemoteReasoningOverride writes a user-sourced capability', () => {
+      serverStore.setRemoteReasoningOverride(key, {
+        isReasoning: 'yes',
+        source: 'user',
+        supportsEffort: true,
+        effortValues: ['low', 'high'],
+        effortSource: 'user',
+      });
+      expect(serverStore.remoteReasoning[key]).toMatchObject({
+        source: 'user',
+        supportsEffort: true,
+      });
+    });
+
+    it('removeServer drops reasoning entries keyed by that server', () => {
+      const id = serverStore.addServer({name: 'A', url: 'http://x'});
+      runInAction(() => {
+        serverStore.remoteReasoning[`${id}/m1`] = {
+          isReasoning: 'yes',
+          source: 'learned',
+          supportsEffort: false,
+          effortValues: [],
+          effortSource: 'none',
+        };
+        serverStore.remoteReasoning['other-server/m2'] = {
+          isReasoning: 'yes',
+          source: 'learned',
+          supportsEffort: false,
+          effortValues: [],
+          effortSource: 'none',
+        };
+      });
+      serverStore.removeServer(id);
+      expect(serverStore.remoteReasoning[`${id}/m1`]).toBeUndefined();
+      expect(serverStore.remoteReasoning['other-server/m2']).toBeDefined();
+    });
+
+    it('addServer persists a user-selected serverType pass-through', () => {
+      const id = serverStore.addServer({
+        name: 'A',
+        url: 'http://x',
+        serverType: 'Ollama',
+      });
+      expect(serverStore.servers.find(s => s.id === id)?.serverType).toBe(
+        'Ollama',
+      );
     });
   });
 });

--- a/src/utils/__tests__/reasoningCapability.test.ts
+++ b/src/utils/__tests__/reasoningCapability.test.ts
@@ -5,6 +5,7 @@ import {
   orderEffortValues,
   EFFORT_LEVELS,
 } from '../reasoningCapability';
+import en from '../../locales/en.json';
 
 const localModel = (overrides: Partial<Model> = {}): Model =>
   ({
@@ -166,5 +167,14 @@ describe('orderEffortValues', () => {
       'xhigh',
       'max',
     ]);
+  });
+});
+
+describe('effortLevels l10n table', () => {
+  it('keeps en.json effortLevels keys in lockstep with EFFORT_LEVELS', () => {
+    const labelKeys = Object.keys(
+      en.components.modelSettingsSheet.effortLevels,
+    ).sort();
+    expect(labelKeys).toEqual([...EFFORT_LEVELS].sort());
   });
 });

--- a/src/utils/__tests__/reasoningCapability.test.ts
+++ b/src/utils/__tests__/reasoningCapability.test.ts
@@ -2,6 +2,8 @@ import {Model, ModelOrigin} from '../types';
 import {
   ReasoningCapability,
   resolveReasoningCapability,
+  orderEffortValues,
+  EFFORT_LEVELS,
 } from '../reasoningCapability';
 
 const localModel = (overrides: Partial<Model> = {}): Model =>
@@ -126,5 +128,31 @@ describe('resolveReasoningCapability', () => {
   it("isReasoning 'unknown' is preserved (pill fail-open)", () => {
     const m = remoteModel();
     expect(resolveReasoningCapability(m, {}).isReasoning).toBe('unknown');
+  });
+});
+
+describe('orderEffortValues', () => {
+  it('orders a selection canonically low→medium→high', () => {
+    expect(orderEffortValues(['high', 'low'])).toEqual(['low', 'high']);
+    expect(orderEffortValues(['medium', 'high', 'low'])).toEqual([
+      'low',
+      'medium',
+      'high',
+    ]);
+  });
+
+  it('drops values outside the canonical set', () => {
+    expect(orderEffortValues(['high', 'extreme', 'low'])).toEqual([
+      'low',
+      'high',
+    ]);
+  });
+
+  it('returns an empty array for an empty selection', () => {
+    expect(orderEffortValues([])).toEqual([]);
+  });
+
+  it('exposes the canonical level order', () => {
+    expect(EFFORT_LEVELS).toEqual(['low', 'medium', 'high']);
   });
 });

--- a/src/utils/__tests__/reasoningCapability.test.ts
+++ b/src/utils/__tests__/reasoningCapability.test.ts
@@ -132,8 +132,13 @@ describe('resolveReasoningCapability', () => {
 });
 
 describe('orderEffortValues', () => {
-  it('orders a selection canonically low→medium→high', () => {
+  it('orders a selection canonically lowest→highest', () => {
     expect(orderEffortValues(['high', 'low'])).toEqual(['low', 'high']);
+    expect(orderEffortValues(['max', 'minimal', 'high'])).toEqual([
+      'minimal',
+      'high',
+      'max',
+    ]);
     expect(orderEffortValues(['medium', 'high', 'low'])).toEqual([
       'low',
       'medium',
@@ -152,7 +157,14 @@ describe('orderEffortValues', () => {
     expect(orderEffortValues([])).toEqual([]);
   });
 
-  it('exposes the canonical level order', () => {
-    expect(EFFORT_LEVELS).toEqual(['low', 'medium', 'high']);
+  it('exposes the six canonical levels in intensity order', () => {
+    expect(EFFORT_LEVELS).toEqual([
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+    ]);
   });
 });

--- a/src/utils/__tests__/reasoningCapability.test.ts
+++ b/src/utils/__tests__/reasoningCapability.test.ts
@@ -1,0 +1,130 @@
+import {Model, ModelOrigin} from '../types';
+import {
+  ReasoningCapability,
+  resolveReasoningCapability,
+} from '../reasoningCapability';
+
+const localModel = (overrides: Partial<Model> = {}): Model =>
+  ({
+    id: 'local-1',
+    origin: ModelOrigin.PRESET,
+    ...overrides,
+  }) as Model;
+
+const remoteModel = (overrides: Partial<Model> = {}): Model =>
+  ({
+    id: 'server-1/remote-x',
+    origin: ModelOrigin.REMOTE,
+    ...overrides,
+  }) as Model;
+
+const cap = (
+  overrides: Partial<ReasoningCapability> = {},
+): ReasoningCapability => ({
+  isReasoning: 'yes',
+  source: 'detected',
+  supportsEffort: false,
+  effortValues: [],
+  effortSource: 'none',
+  ...overrides,
+});
+
+describe('resolveReasoningCapability', () => {
+  it('returns unknown for no model (fail-open)', () => {
+    expect(resolveReasoningCapability(undefined, {})).toMatchObject({
+      isReasoning: 'unknown',
+      source: 'unknown',
+    });
+  });
+
+  it('local model reads model.reasoning', () => {
+    const m = localModel();
+    m.reasoning = cap({isReasoning: 'yes', source: 'learned'});
+    expect(resolveReasoningCapability(m, {})).toMatchObject({
+      isReasoning: 'yes',
+      source: 'learned',
+    });
+  });
+
+  it('remote model reads the keyed remoteReasoning map', () => {
+    const m = remoteModel();
+    const remote = {
+      'server-1/remote-x': cap({isReasoning: 'yes', source: 'user'}),
+    };
+    expect(resolveReasoningCapability(m, remote)).toMatchObject({
+      isReasoning: 'yes',
+      source: 'user',
+    });
+  });
+
+  it('user source wins precedence over detection', () => {
+    const m = localModel();
+    m.supportsThinking = false; // detection said no
+    m.reasoning = cap({isReasoning: 'yes', source: 'user'});
+    expect(resolveReasoningCapability(m, {})).toMatchObject({
+      isReasoning: 'yes',
+      source: 'user',
+    });
+  });
+
+  it('legacy fallback: supportsThinking true → yes/detected', () => {
+    const m = localModel();
+    m.supportsThinking = true;
+    expect(resolveReasoningCapability(m, {})).toMatchObject({
+      isReasoning: 'yes',
+      source: 'detected',
+    });
+  });
+
+  it('legacy fallback: supportsThinking false → no/detected', () => {
+    const m = localModel();
+    m.supportsThinking = false;
+    expect(resolveReasoningCapability(m, {})).toMatchObject({
+      isReasoning: 'no',
+      source: 'detected',
+    });
+  });
+
+  it('legacy fallback: neither reasoning nor supportsThinking → unknown', () => {
+    const m = localModel();
+    expect(resolveReasoningCapability(m, {})).toMatchObject({
+      isReasoning: 'unknown',
+      source: 'unknown',
+    });
+  });
+
+  it('axis-2 is independent of axis-1 (graded effort on yes)', () => {
+    const m = localModel();
+    m.reasoning = cap({
+      isReasoning: 'yes',
+      source: 'user',
+      supportsEffort: true,
+      effortValues: ['low', 'medium', 'high'],
+      effortSource: 'user',
+    });
+    const r = resolveReasoningCapability(m, {});
+    expect(r.supportsEffort).toBe(true);
+    expect(r.effortValues).toEqual(['low', 'medium', 'high']);
+  });
+
+  it("axis-2 is inert when axis-1 is 'no'", () => {
+    const m = localModel();
+    m.reasoning = cap({
+      isReasoning: 'no',
+      source: 'user',
+      supportsEffort: true,
+      effortValues: ['low', 'high'],
+      effortSource: 'user',
+    });
+    const r = resolveReasoningCapability(m, {});
+    expect(r.isReasoning).toBe('no');
+    expect(r.supportsEffort).toBe(false);
+    expect(r.effortValues).toEqual([]);
+    expect(r.effortSource).toBe('none');
+  });
+
+  it("isReasoning 'unknown' is preserved (pill fail-open)", () => {
+    const m = remoteModel();
+    expect(resolveReasoningCapability(m, {}).isReasoning).toBe('unknown');
+  });
+});

--- a/src/utils/completionTypes.ts
+++ b/src/utils/completionTypes.ts
@@ -3,9 +3,22 @@ import {CompletionParams as LlamaRNCompletionParams} from 'llama.rn';
 export type {ToolCall} from 'llama.rn';
 import type {ToolCall} from 'llama.rn';
 
-// Alias allows flexibility to switch API providers later
-// We should move towards OpenAI Compatible API Params
-export type ApiCompletionParams = LlamaRNCompletionParams;
+/**
+ * Reasoning intent carried internally on the completion params. Populated
+ * from the resolver by the store/hook layer; the wire shape is decided
+ * downstream (openai.ts for remote, useChatSession for local). Off is a
+ * best-effort hint only — never used to strip displayed reasoning.
+ */
+export interface ReasoningIntent {
+  enabled: boolean;
+  effort?: string;
+}
+
+// Alias allows flexibility to switch API providers later. The `reasoning`
+// carrier is a LOCAL intersection — the upstream llama.rn alias is not edited.
+export type ApiCompletionParams = LlamaRNCompletionParams & {
+  reasoning?: ReasoningIntent;
+};
 
 /**
  * App-specific completion parameters that are not part of the llama.rn API.

--- a/src/utils/reasoningCapability.ts
+++ b/src/utils/reasoningCapability.ts
@@ -21,16 +21,23 @@ import {ModelOrigin} from './types';
 import type {Model} from './types';
 
 /**
- * Canonical axis-2 effort levels, in pill-cycle order (low→medium→high). The
- * universal set across reasoning families that grade effort; a model may
- * support a subset. `effortValues` is always stored in this order so the pill
- * cycles consistently.
+ * Canonical axis-2 effort levels, in pill-cycle order from lowest to highest
+ * intensity. The universal set across reasoning families that grade effort; a
+ * model may support a subset. `effortValues` is always stored in this order so
+ * the pill cycles consistently.
  */
-export const EFFORT_LEVELS = ['low', 'medium', 'high'] as const;
+export const EFFORT_LEVELS = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const;
 
 export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 
-/** Order an effort-level selection canonically (low→medium→high). */
+/** Order an effort-level selection canonically (lowest→highest intensity). */
 export function orderEffortValues(values: string[]): string[] {
   return EFFORT_LEVELS.filter(level => values.includes(level));
 }

--- a/src/utils/reasoningCapability.ts
+++ b/src/utils/reasoningCapability.ts
@@ -37,6 +37,13 @@ export const EFFORT_LEVELS = [
 
 export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 
+/**
+ * Standard subset pre-selected the first time a user enables graded effort on
+ * a model — gives the chips an immediate selected/unselected contrast (instead
+ * of an all-blank row that doesn't read as togglable) and a sensible default.
+ */
+export const DEFAULT_EFFORT_VALUES: string[] = ['low', 'medium', 'high'];
+
 /** Order an effort-level selection canonically (lowest→highest intensity). */
 export function orderEffortValues(values: string[]): string[] {
   return EFFORT_LEVELS.filter(level => values.includes(level));

--- a/src/utils/reasoningCapability.ts
+++ b/src/utils/reasoningCapability.ts
@@ -1,0 +1,18 @@
+/**
+ * Effective reasoning capability for a model, kept as two independent axes.
+ *
+ * Axis 1 (`isReasoning` / `source`) — whether the model reasons at all; drives
+ * pill visibility and the on/off state.
+ * Axis 2 (`supportsEffort` / `effortValues` / `effortSource`) — whether the pill
+ * grades to low/medium/high and the value set. Present only when axis 1 ≠ 'no'.
+ *
+ * Provenance precedence is user > learned > detected > unknown; a `source: 'user'`
+ * declaration is never downgraded by detection or learn-from-stream.
+ */
+export interface ReasoningCapability {
+  isReasoning: 'yes' | 'no' | 'unknown';
+  source: 'user' | 'learned' | 'detected' | 'unknown';
+  supportsEffort: boolean;
+  effortValues: string[];
+  effortSource: 'user' | 'detected' | 'none';
+}

--- a/src/utils/reasoningCapability.ts
+++ b/src/utils/reasoningCapability.ts
@@ -16,3 +16,60 @@ export interface ReasoningCapability {
   effortValues: string[];
   effortSource: 'user' | 'detected' | 'none';
 }
+
+import {ModelOrigin} from './types';
+import type {Model} from './types';
+
+const UNKNOWN: ReasoningCapability = {
+  isReasoning: 'unknown',
+  source: 'unknown',
+  supportsEffort: false,
+  effortValues: [],
+  effortSource: 'none',
+};
+
+/**
+ * Resolve the effective reasoning capability for a model. Single source of
+ * truth — no component reads `supportsThinking` directly post-migration.
+ *
+ * Local models read `model.reasoning`; remote models (not persisted) read
+ * `remoteReasoning[model.id]`. When neither is present the legacy
+ * `supportsThinking` boolean is the fail-open fallback: `true` → 'yes',
+ * `false` → 'no', absent → 'unknown'. Axis-2 (effort) is reported only when
+ * axis-1 is not 'no'.
+ */
+export function resolveReasoningCapability(
+  model: Model | undefined,
+  remoteReasoning: Record<string, ReasoningCapability>,
+): ReasoningCapability {
+  if (!model) {
+    return UNKNOWN;
+  }
+
+  const stored =
+    model.origin === ModelOrigin.REMOTE
+      ? remoteReasoning[model.id]
+      : model.reasoning;
+
+  let resolved: ReasoningCapability;
+  if (stored) {
+    resolved = stored;
+  } else if (model.supportsThinking === true) {
+    resolved = {...UNKNOWN, isReasoning: 'yes', source: 'detected'};
+  } else if (model.supportsThinking === false) {
+    resolved = {...UNKNOWN, isReasoning: 'no', source: 'detected'};
+  } else {
+    resolved = UNKNOWN;
+  }
+
+  // Axis-2 is inert when axis-1 is 'no'.
+  if (resolved.isReasoning === 'no') {
+    return {
+      ...resolved,
+      supportsEffort: false,
+      effortValues: [],
+      effortSource: 'none',
+    };
+  }
+  return resolved;
+}

--- a/src/utils/reasoningCapability.ts
+++ b/src/utils/reasoningCapability.ts
@@ -20,6 +20,21 @@ export interface ReasoningCapability {
 import {ModelOrigin} from './types';
 import type {Model} from './types';
 
+/**
+ * Canonical axis-2 effort levels, in pill-cycle order (low→medium→high). The
+ * universal set across reasoning families that grade effort; a model may
+ * support a subset. `effortValues` is always stored in this order so the pill
+ * cycles consistently.
+ */
+export const EFFORT_LEVELS = ['low', 'medium', 'high'] as const;
+
+export type EffortLevel = (typeof EFFORT_LEVELS)[number];
+
+/** Order an effort-level selection canonically (low→medium→high). */
+export function orderEffortValues(values: string[]): string[] {
+  return EFFORT_LEVELS.filter(level => values.includes(level));
+}
+
 const UNKNOWN: ReasoningCapability = {
   isReasoning: 'unknown',
   source: 'unknown',

--- a/src/utils/serverTypes.ts
+++ b/src/utils/serverTypes.ts
@@ -15,6 +15,17 @@ export const SERVER_TYPE_OPTIONS = [
 export type ServerTypeOption = (typeof SERVER_TYPE_OPTIONS)[number];
 
 /**
+ * Server-type options shaped for the ui Dropdown. Trigger testID is
+ * `server-type-dropdown`; each item carries `server-type-option-<value>` so
+ * e2e can both read the seeded value and pick an override.
+ */
+export const SERVER_TYPE_DROPDOWN_OPTIONS = SERVER_TYPE_OPTIONS.map(option => ({
+  value: option,
+  label: option,
+  testID: `server-type-option-${option}`,
+}));
+
+/**
  * Best-effort seed for a server's type from the detection result plus a host
  * heuristic (api.openai.com → OpenAI). detectServerType cannot classify
  * OpenAI or vLLM, so the user can correct it on the server sheet.

--- a/src/utils/serverTypes.ts
+++ b/src/utils/serverTypes.ts
@@ -1,0 +1,34 @@
+/**
+ * User-selectable server types. Gates the per-server reasoning wire payload
+ * (see api/openai.ts buildReasoningPayload). detectServerType seeds the value
+ * best-effort; the user's selection wins.
+ */
+export const SERVER_TYPE_OPTIONS = [
+  'llama.cpp',
+  'LM Studio',
+  'Ollama',
+  'OpenAI',
+  'vLLM',
+  'unknown',
+] as const;
+
+export type ServerTypeOption = (typeof SERVER_TYPE_OPTIONS)[number];
+
+/**
+ * Best-effort seed for a server's type from the detection result plus a host
+ * heuristic (api.openai.com → OpenAI). detectServerType cannot classify
+ * OpenAI or vLLM, so the user can correct it on the server sheet.
+ */
+export function seedServerType(detected: string, url: string): string {
+  if (detected) {
+    return detected;
+  }
+  try {
+    if (new URL(url).hostname.endsWith('api.openai.com')) {
+      return 'OpenAI';
+    }
+  } catch {
+    // ignore malformed URL
+  }
+  return 'unknown';
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,6 +10,7 @@ import {MD3Colors, MD3Typescale} from 'react-native-paper/lib/typescript/types';
 import type {TokenRadius, TokenStroke, TokenTypography} from '../theme/tokens';
 import {SkillKey} from '.';
 import type {TalentResult} from '../services/talents/types';
+import type {ReasoningCapability} from './reasoningCapability';
 
 /**
  * One model-emitted tool call within an `AgentStep`. The `arguments` field
@@ -455,6 +456,15 @@ export interface ServerConfig {
   url: string; // Base URL e.g. "http://192.168.1.100:1234"
   lastConnected?: number; // Timestamp
   requestTimeoutMs?: number; // Per-server network timeout in ms; undefined = API default
+  // User-selectable server type; gates the per-server reasoning wire payload.
+  // detectServerType seeds it best-effort; user selection wins. undefined = unknown.
+  serverType?:
+    | 'llama.cpp'
+    | 'LM Studio'
+    | 'Ollama'
+    | 'OpenAI'
+    | 'vLLM'
+    | string;
 }
 
 export enum ModelType {
@@ -510,9 +520,12 @@ export interface Model {
   visionEnabled?: boolean; // User preference for enabling vision capabilities (defaults to true for backward compatibility)
 
   // Thinking capabilities
+  /** @deprecated Read via resolveReasoningCapability; kept as a fallback for old records. */
   supportsThinking?: boolean; // Whether this model supports thinking/reasoning mode
   thinkingStartTag?: string; // Thinking start tag from getFormattedChat (e.g., '<think>')
   thinkingEndTag?: string; // Thinking end tag from getFormattedChat (e.g., '</think>')
+  // Reasoning capability (two axes). Local home; persisted with the model.
+  reasoning?: ReasoningCapability;
 
   // GGUF metadata (for memory estimation)
   ggufMetadata?: GGUFMetadata;


### PR DESCRIPTION
## Summary

Overhauls thinking/reasoning capability handling so the reasoning pill is reliable and user-controllable for both local and remote (OpenAI-compatible) models.

- **Pill decoupled from auto-detection.** Visibility now comes from a single pure resolver. The pill is reachable for remote models and for local models where detection missed (fail-open when capability is unknown); hidden only when a model is known not to reason.
- **Learn-from-stream.** The first time a model actually emits reasoning, the capability is persisted (local model record for local models, a keyed store map for remote models) and the control is revealed thereafter.
- **Manual model-card override.** Per model, the user can declare whether it is a reasoning model (axis 1) and whether it supports graded effort plus its value set (axis 2). A user declaration takes top precedence and is never downgraded by detection or learning. Available for both local and remote models.
- **Graded effort.** Where effort support is known the pill grades off → low → medium → high (gpt-oss-style locally via chat template kwargs, remotely via the request param); otherwise it stays on/off.
- **Remote control plumbing, gated per server type.** A user-selectable server type (seeded best-effort by detection) gates the per-server reasoning payload.

## Per-server reasoning behavior

The wire shape is owned in one place and keyed on the persisted server type (never live detection). Unknown/strict servers receive no reasoning controls (omit beats a 400):

| Server type | OFF | ON | Graded effort |
| --- | --- | --- | --- |
| llama.cpp | enable_thinking:false + reasoning_format:none | reasoning_format:auto | not standardized (omitted) |
| LM Studio / vLLM (modern) | enable_thinking:false | omit | omitted |
| Ollama | reasoning_effort:'none' (safe no-op) | omit (never think:true) | deferred |
| OpenAI | omit | omit | reasoning_effort only when effort support is known for the model |
| unknown / old vLLM | omit everything | omit everything | omit everything |

**"Off" is a best-effort hint only.** PocketPal never strips, hides, or post-filters reasoning the server/model actually returned — if an always-on model returns reasoning with the pill off, it is still rendered. Transparency over a faked off. The existing context-exclusion flag (what prior thinking is sent back) is a separate concern and is unchanged.

## Tests

- Full Jest suite green: 235 suites / 3535 passing / 2 skipped. TypeScript and lint clean.
- Coverage: statements 75.7%, branches 70.6%, functions 71.6%, lines 75.8% (resolver 100%).
- Covers: pill visibility (fail-open), learn-from-stream (once, idempotent, monotonic), override precedence, graded pill cycle, per-server payload gating (incl. Ollama never sending think:true and unknown omitting everything), and back-compat hydration of records that predate the new fields.

## On-device verification (required before merge)

- [ ] Qwen3.5: pill shown (unknown → fail-open), off/on behaves sanely, no 400/crash either way.
- [ ] gpt-oss graded effort: low/med/high actually affects reasoning depth; if the bundled build does not honor it, the pill degrades gracefully to on/off (still works).
- [ ] Ollama OFF (reasoning_effort:'none') against a non-thinking model is accepted with no HTTP 400.

## Visual evidence (to attach)

- [ ] pill off (best-effort) — dim Think pill; reasoning still rendered if returned
- [ ] pill on (effortless on/off)
- [ ] pill graded (off → low → medium → high with effort label)
- [ ] remote model pill reachable
- [ ] model-card override (local)
- [ ] model-card override (remote)
- [ ] server-type selector

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
