### PR TITLE
ci: run pipeline on redesign/phase-3 integration branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - redesign/phase-3
   push:
     branches:
       - main
+      - redesign/phase-3
 
 permissions:
   contents: read


### PR DESCRIPTION
Enables the CI pipeline (build-and-test, build-android, build-ios, detect-changes) to run on the redesign/phase-3 integration branch and on PRs targeting it, so Phase-3 slices are validated incrementally instead of only at the final main flip. Trigger-list change only; no job/step changes.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)