### PR TITLE
Allow chat reskin typography-token consumers in invariant test

### DIFF
--- a/src/theme/tokens/__tests__/invariants.test.ts
+++ b/src/theme/tokens/__tests__/invariants.test.ts
@@ -125,6 +125,16 @@ describe('design-token grep invariants', () => {
       // feature surfaces under the bottom-tab navigation.
       'screens/HomeScreen',
       'screens/ExploreScreen',
+      // Chat reskin: the chat surface adopts the typography axis across its
+      // composer, header title, message body, empty state, and tool/thinking
+      // affordances.
+      'components/ChatEmptyPlaceholder',
+      'components/ChatHeaderTitle',
+      'components/ChatInput',
+      'components/MarkdownView',
+      'components/ThinkingBubble',
+      'components/ToolErrorBlock',
+      'components/ToolUsedChip',
     ];
     const files = listFiles(SRC).filter(f => {
       const rel = path.relative(SRC, f).replace(/\\/g, '/');


### PR DESCRIPTION
## What

The chat reskin wired 7 chat-surface components to the `theme.typography.*` token axis as part of adopting the redesign visual language:

- `ChatEmptyPlaceholder`
- `ChatHeaderTitle`
- `ChatInput`
- `MarkdownView`
- `ThinkingBubble`
- `ToolErrorBlock`
- `ToolUsedChip`

The per-slice grep invariant in `src/theme/tokens/__tests__/invariants.test.ts` asserts that only allow-listed paths consume the new token surface. After the reskin landed, these 7 components became unexpected consumers and the test failed:

> New token surface has unexpected consumers in this slice (invisible foundation should have zero)

The test itself documents the remedy: "If this is intentional, update the allow-list."

## Change

Adds the 7 component directories to `ALLOWED_RELATIVE` so the intentional reskin consumers are recorded, matching the existing per-slice swap contract (same pattern as the onboarding/home/download entries). The invariant's intent is preserved — it still flags any *new* unlisted consumer.

## Verification

- `yarn test` — 250 suites passed, 3711 passed / 2 skipped (3713 total)
- `yarn typecheck` — clean
- `yarn lint` — 0 errors

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)