### PR TITLE
[Feat]: Add Brazilian Portuguese (pt-BR) language support

### DIFF
--- a/e2e/specs/features/language.spec.ts
+++ b/e2e/specs/features/language.spec.ts
@@ -57,6 +57,10 @@ const LANGUAGE_ASSERTIONS: Record<
     screenTitle: 'Tetapan',
     firstCardTitle: 'Tetapan Permulaan Model',
   },
+  pt_BR: {
+    screenTitle: 'Configurações',
+    firstCardTitle: 'Configurações de Inicialização do Modelo',
+  },
   ru: {
     screenTitle: 'Настройки',
     firstCardTitle: 'Настройки инициализации модели',
@@ -76,7 +80,7 @@ const LANGUAGE_ASSERTIONS: Record<
 };
 
 // Order: start with non-English, end with English to restore default state
-const LANGUAGE_ORDER = ['fa', 'he', 'id', 'ja', 'ko', 'ms', 'ru', 'uk', 'zh', 'zh_Hant', 'en'];
+const LANGUAGE_ORDER = ['fa', 'he', 'id', 'ja', 'ko', 'ms', 'pt_BR', 'ru', 'uk', 'zh', 'zh_Hant', 'en'];
 
 describe('Language Switching', () => {
   let chatPage: ChatPage;

--- a/scripts/__tests__/validate-l10n.test.js
+++ b/scripts/__tests__/validate-l10n.test.js
@@ -29,6 +29,7 @@ function runWithLocales(overrides = {}) {
       'ja.json',
       'ko.json',
       'ms.json',
+      'pt_BR.json',
       'ru.json',
       'uk.json',
       'zh.json',
@@ -88,6 +89,7 @@ describe('validate-l10n.js', () => {
     expect(result.output).toContain('ja.json: valid JSON');
     expect(result.output).toContain('ko.json: valid JSON');
     expect(result.output).toContain('ms.json: valid JSON');
+    expect(result.output).toContain('pt_BR.json: valid JSON');
     expect(result.output).toContain('ru.json: valid JSON');
     expect(result.output).toContain('uk.json: valid JSON');
     expect(result.output).toContain('zh.json: valid JSON');

--- a/scripts/sync-weblate.js
+++ b/scripts/sync-weblate.js
@@ -60,6 +60,7 @@ async function downloadTranslations() {
     'ja',
     'ko',
     'ms',
+    'pt_BR',
     'ru',
     'uk',
     'zh',

--- a/src/locales/__tests__/locales.test.ts
+++ b/src/locales/__tests__/locales.test.ts
@@ -46,6 +46,7 @@ const ALL_LANGUAGES: AvailableLanguage[] = [
   'ja',
   'ko',
   'ms',
+  'pt_BR',
   'ru',
   'uk',
   'zh',
@@ -84,6 +85,7 @@ describe('l10n object', () => {
     'ja',
     'ko',
     'ms',
+    'pt_BR',
     'ru',
     'uk',
     'zh',
@@ -104,6 +106,7 @@ describe('l10n object', () => {
     'ja',
     'ko',
     'ms',
+    'pt_BR',
     'ru',
     'uk',
     'zh',
@@ -153,6 +156,7 @@ describe('l10n object', () => {
     expect('ja' in l10n).toBe(true);
     expect('ko' in l10n).toBe(true);
     expect('ms' in l10n).toBe(true);
+    expect('pt_BR' in l10n).toBe(true);
     expect('ru' in l10n).toBe(true);
     expect('uk' in l10n).toBe(true);
     expect('zh' in l10n).toBe(true);
@@ -217,6 +221,7 @@ describe('exports', () => {
     expect(languageDisplayNames.ja).toBe('\u65E5\u672C\u8A9E (JA)');
     expect(languageDisplayNames.ko).toBe('\uD55C\uAD6D\uC5B4 (KO)');
     expect(languageDisplayNames.ms).toBe('Melayu (MS)');
+    expect(languageDisplayNames.pt_BR).toBe('Português (PT_BR)');
     expect(languageDisplayNames.ru).toBe(
       '\u0420\u0443\u0441\u0441\u043A\u0438\u0439 (RU)',
     );
@@ -262,6 +267,7 @@ describe('lazy loading', () => {
     'ja',
     'ko',
     'ms',
+    'pt_BR',
     'ru',
     'uk',
     'zh',
@@ -320,6 +326,7 @@ describe('type safety', () => {
       'ja',
       'ko',
       'ms',
+      'pt_BR',
       'ru',
       'uk',
       'zh',

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -16,6 +16,7 @@ const languageRegistry = {
   ja: {displayName: '日本語 (JA)'},
   ko: {displayName: '한국어 (KO)'},
   ms: {displayName: 'Melayu (MS)'},
+  pt_BR: {displayName: 'Português (PT_BR)'},
   ru: {displayName: 'Русский (RU)'},
   uk: {displayName: 'Українська (UK)'},
   zh: {displayName: '中文 (ZH)'},
@@ -35,6 +36,7 @@ export const languageDisplayNames: Record<AvailableLanguage, string> = {
   ja: languageRegistry.ja.displayName,
   ko: languageRegistry.ko.displayName,
   ms: languageRegistry.ms.displayName,
+  pt_BR: languageRegistry.pt_BR.displayName,
   ru: languageRegistry.ru.displayName,
   uk: languageRegistry.uk.displayName,
   zh: languageRegistry.zh.displayName,
@@ -61,6 +63,8 @@ function requireLanguageData(lang: AvailableLanguage): object | null {
       return require('./ko.json');
     case 'ms':
       return require('./ms.json');
+    case 'pt_BR':
+      return require('./pt_BR.json');
     case 'ru':
       return require('./ru.json');
     case 'uk':
@@ -116,6 +120,9 @@ export const l10n = {
   get ms(): Translations {
     return getTranslations('ms');
   },
+  get pt_BR(): Translations {
+    return getTranslations('pt_BR');
+  },
   get ru(): Translations {
     return getTranslations('ru');
   },
@@ -158,6 +165,7 @@ export const initLocale = (locale?: AvailableLanguage) => {
     ja: require('dayjs/locale/ja'),
     ko: require('dayjs/locale/ko'),
     ms: require('dayjs/locale/ms'),
+    pt_BR: require('dayjs/locale/pt-br'),
     ru: require('dayjs/locale/ru'),
     uk: require('dayjs/locale/uk'),
     zh: require('dayjs/locale/zh'),

--- a/src/store/__tests__/UIStore.test.ts
+++ b/src/store/__tests__/UIStore.test.ts
@@ -104,6 +104,7 @@ describe('UIStore', () => {
         'ja',
         'ko',
         'ms',
+        'pt_BR',
         'ru',
         'uk',
         'zh',


### PR DESCRIPTION
## Summary

Wires Brazilian Portuguese (`pt_BR`) into the app as a user-selectable language. The translation file `src/locales/pt_BR.json` already shipped to `main` via Weblate; this PR is the code wiring that registers it, following the established "add a new language" pattern (`zh_Hant` precedent).

## Changes

- `src/locales/index.ts` — register `pt_BR` at all five locale registry insertion points (registry, display-names map, require switch, l10n getter, and dayjs locale map via `dayjs/locale/pt-br`). Display name: `Português (PT_BR)`.
- `scripts/sync-weblate.js` — add `pt_BR` to the Weblate download list.
- Unit-test enumerations updated: `src/locales/__tests__/locales.test.ts`, `scripts/__tests__/validate-l10n.test.js`, `src/store/__tests__/UIStore.test.ts`.
- `e2e/specs/features/language.spec.ts` — add `pt_BR` assertions and ordering.

`pt_BR` is Latin-script, so it is correctly excluded from the non-Latin font fallback set (no typography change).

## Notes

- `pt_BR.json` already shipped to `main` via Weblate; this PR only adds the wiring.
- A small set of recently-added reasoning / server-type strings are not yet in `pt_BR.json`. They render in English (the built-in fallback) until the next Weblate sync localizes them. `validate-l10n` treats missing keys as warnings, so CI stays green.

## Verification

- `yarn lint` — 0 errors
- `yarn typecheck` — clean
- `yarn test` — 246 suites, 3714 passed; coverage 75% (threshold 60%)
- l10n validation — all locale files valid
- No native changes (JS/TS + JSON + tests only).

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
