### PR TITLE
[Bug]: Fix PalsHub profile load permission error (narrow profiles select)

### DIFF
--- a/src/services/palshub/AuthService.ts
+++ b/src/services/palshub/AuthService.ts
@@ -23,9 +23,9 @@ export interface Profile {
   avatar_url?: string;
   provider_user_id?: string;
   provider_profile_url?: string;
-  provider: string;
-  created_at: string;
-  updated_at: string;
+  provider?: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface AuthState {
@@ -173,7 +173,7 @@ class AuthService {
     try {
       const {data: profile, error} = await supabase
         .from('profiles')
-        .select('*')
+        .select('id, username, full_name, avatar_url')
         .eq('id', userId)
         .single();
 

--- a/src/services/palshub/__tests__/AuthService.test.ts
+++ b/src/services/palshub/__tests__/AuthService.test.ts
@@ -50,4 +50,20 @@ describe('AuthService.loadUserProfile', () => {
     ).resolves.toBeUndefined();
     expect(authService.profile).toBe(before);
   });
+
+  it('returns early on a permission-denied error without throwing and leaves profile unchanged', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const {authService} = setup({
+      data: null,
+      error: {code: '42501', message: 'permission denied for table profiles'},
+    });
+
+    const before = authService.profile;
+    await expect(
+      (authService as any).loadUserProfile('u1'),
+    ).resolves.toBeUndefined();
+    expect(authService.profile).toBe(before);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });

--- a/src/services/palshub/__tests__/AuthService.test.ts
+++ b/src/services/palshub/__tests__/AuthService.test.ts
@@ -1,0 +1,53 @@
+// Tests for AuthService.loadUserProfile column-narrowing and no-rows handling
+
+describe('AuthService.loadUserProfile', () => {
+  const setup = (singleResult: {data: any; error: any}) => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    const single = jest.fn().mockResolvedValue(singleResult);
+    const eq = jest.fn(() => ({single}));
+    const select = jest.fn(() => ({eq}));
+    const from = jest.fn(() => ({select}));
+
+    jest.doMock('../supabase', () => ({
+      supabase: {
+        from,
+        auth: {
+          onAuthStateChange: jest.fn(),
+          getSession: jest
+            .fn()
+            .mockResolvedValue({data: {session: null}, error: null}),
+        },
+      },
+    }));
+
+    const {authService} = require('../AuthService');
+    return {authService, from, select, eq, single};
+  };
+
+  it('selects only the granted columns and populates profile', async () => {
+    const row = {
+      id: 'u1',
+      username: 'pocket',
+      full_name: 'Pocket Pal',
+      avatar_url: 'https://example.com/a.png',
+    };
+    const {authService, select} = setup({data: row, error: null});
+
+    await (authService as any).loadUserProfile('u1');
+
+    expect(select).toHaveBeenCalledWith('id, username, full_name, avatar_url');
+    expect(authService.profile).toEqual(row);
+  });
+
+  it('handles the PGRST116 no-rows path without throwing and leaves profile unchanged', async () => {
+    const {authService} = setup({data: null, error: {code: 'PGRST116'}});
+
+    const before = authService.profile;
+    await expect(
+      (authService as any).loadUserProfile('u1'),
+    ).resolves.toBeUndefined();
+    expect(authService.profile).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Signed-in PalsHub users hit a Postgres permission-denied error (`42501 permission denied for table profiles`) on every profile load. The shared Supabase backend narrowed the `profiles` SELECT grant for the `authenticated` role to four columns (`id, username, full_name, avatar_url`), but the client used `.select('*')`, which PostgREST expands to all columns — including the now-ungranted PII columns — triggering the error on every sign-in and cold-start session restore.

## Fix

- Narrow `loadUserProfile`'s `profiles` query from `.select('*')` to `.select('id, username, full_name, avatar_url')` (the columns the `authenticated` role is granted). The `.eq('id', userId).single()` chain and the `PGRST116` no-rows guard are unchanged.
- Relax the now-unselected `Profile` fields (`provider`, `created_at`, `updated_at`) to optional, since `loadUserProfile` no longer populates them; `id` stays required. No consumer reads these fields today (`ProfileSheet` renders from the auth session, not from `profile`), so this has no behavioral impact.
- `updateProfile` is unchanged (its upsert issues no SELECT).

This is correct whether or not the backend grant change is deployed to a given environment — those four columns are always granted to `authenticated` — so the client fix is independent of backend deploy ordering.

## Tests

New `src/services/palshub/__tests__/AuthService.test.ts` covering `loadUserProfile`:
- selects only the four granted columns and populates `profile`
- handles the `PGRST116` no-rows path without throwing, leaving `profile` unchanged
- returns early on a permission-denied error without throwing, leaving `profile` unchanged

## Verification

- `yarn typecheck` — PASS
- `yarn lint` (changed files) — 0 errors (pre-existing warnings only, in unrelated files)
- `yarn test` (full suite) — 3734 passed, 2 skipped; 247 suites; global 60% coverage gate PASS
- New AuthService tests — 3/3 green; negative-control confirmed (restoring `.select('*')` fails the column-selection assertion)
- Native changes: none (JS/type-only)

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)