### PR TITLE
[Bug]: gate PalsHub buy button on real purchase eligibility, not device locale

### DIFF
--- a/__mocks__/stores/palStore.ts
+++ b/__mocks__/stores/palStore.ts
@@ -3,7 +3,7 @@ import {migrateLegacyPalToNew} from '../../src/utils/pal-migration';
 
 class MockPalStore {
   pals: Pal[] = [];
-  isUSRegion: boolean = false;
+  isCheckoutEligible: boolean = false;
 
   constructor() {
     // makeAutoObservable(this);

--- a/android/app/src/main/java/com/pocketpalai/ExternalContentLinkModule.kt
+++ b/android/app/src/main/java/com/pocketpalai/ExternalContentLinkModule.kt
@@ -54,6 +54,59 @@ class ExternalContentLinkModule(reactContext: ReactApplicationContext) :
         }
 
     val settled = AtomicBoolean(false)
+    connectAndCheckAvailability(
+        onAvailability = { client, result ->
+          if (result.responseCode != BillingClient.BillingResponseCode.OK) {
+            Log.w(
+                TAG,
+                "program unavailable: code=${result.responseCode} msg=${result.debugMessage}")
+            endAndResolve(client, promise, settled, OUTCOME_INELIGIBLE)
+          } else {
+            mintToken(client, activity, linkUri, promise, settled)
+          }
+        },
+        onConnectionError = { client ->
+          endAndResolve(client, promise, settled, OUTCOME_ERROR)
+        })
+  }
+
+  /**
+   * Side-effect-free render-time eligibility probe. Connects, queries
+   * EXTERNAL_CONTENT_LINK availability, resolves the boolean, and disconnects.
+   * It never mints a token, launches a link-out, or shows a disclosure (that
+   * stays exclusively in prepareExternalLink), and takes no currentActivity —
+   * there is nothing to launch, so there is no Activity to gate on. Any setup
+   * failure / disconnect / unavailable result resolves false (fail-closed).
+   */
+  override fun isExternalContentLinkAvailable(promise: Promise) {
+    val settled = AtomicBoolean(false)
+    connectAndCheckAvailability(
+        onAvailability = { client, result ->
+          val available = result.responseCode == BillingClient.BillingResponseCode.OK
+          if (!available) {
+            Log.w(
+                TAG,
+                "availability probe: program unavailable code=${result.responseCode} msg=${result.debugMessage}")
+          }
+          endAndResolveBoolean(client, promise, settled, available)
+        },
+        onConnectionError = { client ->
+          endAndResolveBoolean(client, promise, settled, false)
+        })
+  }
+
+  /**
+   * Shared connect + availability query for the prep link-out and the render-time
+   * probe. Builds a BillingClient with EXTERNAL_CONTENT_LINK enabled, starts the
+   * connection, gates on a successful setup, then runs
+   * isBillingProgramAvailableAsync and hands the result (with the still-open
+   * client) to [onAvailability]. A failed setup or a disconnect routes to
+   * [onConnectionError]. Callers own closing the connection (via endAndResolve*).
+   */
+  private fun connectAndCheckAvailability(
+      onAvailability: (client: BillingClient, result: BillingResult) -> Unit,
+      onConnectionError: (client: BillingClient) -> Unit
+  ) {
     val client =
         BillingClient.newBuilder(appContext)
             .enableBillingProgram(BillingProgram.EXTERNAL_CONTENT_LINK)
@@ -66,38 +119,21 @@ class ExternalContentLinkModule(reactContext: ReactApplicationContext) :
               Log.w(
                   TAG,
                   "billing setup failed: code=${result.responseCode} msg=${result.debugMessage}")
-              endAndResolve(client, promise, settled, OUTCOME_ERROR)
+              onConnectionError(client)
               return
             }
-            checkEligibility(client, activity, linkUri, promise, settled)
+            client.isBillingProgramAvailableAsync(BillingProgram.EXTERNAL_CONTENT_LINK) {
+                availabilityResult,
+                _ ->
+              onAvailability(client, availabilityResult)
+            }
           }
 
           override fun onBillingServiceDisconnected() {
             Log.w(TAG, "billing service disconnected during setup")
-            endAndResolve(client, promise, settled, OUTCOME_ERROR)
+            onConnectionError(client)
           }
         })
-  }
-
-  private fun checkEligibility(
-      client: BillingClient,
-      activity: android.app.Activity,
-      linkUri: Uri,
-      promise: Promise,
-      settled: AtomicBoolean
-  ) {
-    client.isBillingProgramAvailableAsync(BillingProgram.EXTERNAL_CONTENT_LINK) {
-        result,
-        _ ->
-      if (result.responseCode != BillingClient.BillingResponseCode.OK) {
-        Log.w(
-            TAG,
-            "program unavailable: code=${result.responseCode} msg=${result.debugMessage}")
-        endAndResolve(client, promise, settled, OUTCOME_INELIGIBLE)
-        return@isBillingProgramAvailableAsync
-      }
-      mintToken(client, activity, linkUri, promise, settled)
-    }
   }
 
   private fun mintToken(
@@ -206,6 +242,21 @@ class ExternalContentLinkModule(reactContext: ReactApplicationContext) :
       client.endConnection()
     } catch (_: Exception) {}
     promise.resolve(map)
+  }
+
+  private fun endAndResolveBoolean(
+      client: BillingClient,
+      promise: Promise,
+      settled: AtomicBoolean,
+      available: Boolean
+  ) {
+    if (!settled.compareAndSet(false, true)) {
+      return
+    }
+    try {
+      client.endConnection()
+    } catch (_: Exception) {}
+    promise.resolve(available)
   }
 
   companion object {

--- a/android/app/src/main/java/com/pocketpalai/ExternalContentLinkModule.kt
+++ b/android/app/src/main/java/com/pocketpalai/ExternalContentLinkModule.kt
@@ -70,14 +70,8 @@ class ExternalContentLinkModule(reactContext: ReactApplicationContext) :
         })
   }
 
-  /**
-   * Side-effect-free render-time eligibility probe. Connects, queries
-   * EXTERNAL_CONTENT_LINK availability, resolves the boolean, and disconnects.
-   * It never mints a token, launches a link-out, or shows a disclosure (that
-   * stays exclusively in prepareExternalLink), and takes no currentActivity —
-   * there is nothing to launch, so there is no Activity to gate on. Any setup
-   * failure / disconnect / unavailable result resolves false (fail-closed).
-   */
+  // Availability-only eligibility probe: no token/launch/disclosure, no Activity.
+  // Any setup failure or unavailable result resolves false.
   override fun isExternalContentLinkAvailable(promise: Promise) {
     val settled = AtomicBoolean(false)
     connectAndCheckAvailability(
@@ -95,14 +89,10 @@ class ExternalContentLinkModule(reactContext: ReactApplicationContext) :
         })
   }
 
-  /**
-   * Shared connect + availability query for the prep link-out and the render-time
-   * probe. Builds a BillingClient with EXTERNAL_CONTENT_LINK enabled, starts the
-   * connection, gates on a successful setup, then runs
-   * isBillingProgramAvailableAsync and hands the result (with the still-open
-   * client) to [onAvailability]. A failed setup or a disconnect routes to
-   * [onConnectionError]. Callers own closing the connection (via endAndResolve*).
-   */
+  // Shared connect + availability query for prepareExternalLink and the probe.
+  // On setup OK, runs isBillingProgramAvailableAsync and hands the result plus
+  // the still-open client to onAvailability; setup failure/disconnect routes to
+  // onConnectionError. Callers close the connection (via endAndResolve*).
   private fun connectAndCheckAvailability(
       onAvailability: (client: BillingClient, result: BillingResult) -> Unit,
       onConnectionError: (client: BillingClient) -> Unit

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3827,7 +3827,7 @@ SPEC CHECKSUMS:
   React-utils: f06ff240e06e2bd4b34e48f1b34cac00866e8979
   React-webperformancenativemodule: b3398f8175fa96d992c071b1fa59bd6f9646b840
   ReactAppDependencyProvider: a45ef34bb22dc1c9b2ac1f74167d9a28af961176
-  ReactCodegen: 40eb16e701afb975828bb0a5a3da056cf28e970e
+  ReactCodegen: d1a48d66bfd02e0338145955b528809647d96897
   ReactCommon: 801eff8cb9c940c04d3a89ce399c343ee3eff654
   ReactNativeFs: 70ff2d31487aa2dbe1518c9d480f9ece37942ad2
   RNCAsyncStorage: fd44f4b03e007e642e98df6726737bc66e9ba609

--- a/src/components/PalsHub/PalDetailSheet/PalDetailSheet.tsx
+++ b/src/components/PalsHub/PalDetailSheet/PalDetailSheet.tsx
@@ -400,10 +400,10 @@ export const PalDetailSheet: React.FC<PalDetailSheetProps> = observer(
               </>
             )}
 
-          {/* Show buy button (US) or informational text (non-US) for premium pals */}
+          {/* Show buy button (eligible) or informational text (ineligible) for premium pals */}
           {palLabel.type === 'premium' &&
             !displayPal.is_owned &&
-            (palStore.isUSRegion ? (
+            (palStore.isCheckoutEligible ? (
               <View style={styles.buyActionColumn}>
                 <Button
                   testID="buy-button"

--- a/src/components/PalsHub/PalDetailSheet/__tests__/PalDetailSheet.test.tsx
+++ b/src/components/PalsHub/PalDetailSheet/__tests__/PalDetailSheet.test.tsx
@@ -552,14 +552,14 @@ describe('PalDetailSheet', () => {
     });
   });
 
-  describe('Premium Buy Button (US region)', () => {
+  describe('Premium Buy Button (eligible vs ineligible)', () => {
     beforeEach(() => {
       (palsHubService.getPal as jest.Mock).mockResolvedValue(
         mockPremiumPalsHubPal,
       );
     });
 
-    it('shows buy button for US users viewing unowned premium pals', async () => {
+    it('shows buy button for eligible users viewing unowned premium pals', async () => {
       (palStore as any).isCheckoutEligible = true;
 
       const {getByTestId} = render(
@@ -571,7 +571,7 @@ describe('PalDetailSheet', () => {
       });
     });
 
-    it('shows info text (not buy button) for non-US users viewing unowned premium pals', async () => {
+    it('shows info text (not buy button) for ineligible users viewing unowned premium pals', async () => {
       (palStore as any).isCheckoutEligible = false;
 
       const {queryByTestId} = render(

--- a/src/components/PalsHub/PalDetailSheet/__tests__/PalDetailSheet.test.tsx
+++ b/src/components/PalsHub/PalDetailSheet/__tests__/PalDetailSheet.test.tsx
@@ -73,8 +73,8 @@ describe('PalDetailSheet', () => {
     );
     // Reset downloadPalsHubPal to resolve successfully
     (palStore.downloadPalsHubPal as jest.Mock).mockResolvedValue(undefined);
-    // Reset isUSRegion to false (default non-US)
-    (palStore as any).isUSRegion = false;
+    // Reset isCheckoutEligible to false (default ineligible)
+    (palStore as any).isCheckoutEligible = false;
     // Default to logged-out; authenticated tests opt in explicitly.
     (authService as any).isAuthenticated = false;
     // Reset checkout flow state between tests
@@ -560,7 +560,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('shows buy button for US users viewing unowned premium pals', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
 
       const {getByTestId} = render(
         <PalDetailSheet {...defaultProps} pal={mockPremiumPalsHubPal} />,
@@ -572,7 +572,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('shows info text (not buy button) for non-US users viewing unowned premium pals', async () => {
-      (palStore as any).isUSRegion = false;
+      (palStore as any).isCheckoutEligible = false;
 
       const {queryByTestId} = render(
         <PalDetailSheet {...defaultProps} pal={mockPremiumPalsHubPal} />,
@@ -584,7 +584,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('starts the in-app checkout on iOS when buy button is pressed', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (authService as any).isAuthenticated = true;
 
       const {getByTestId} = render(
@@ -606,7 +606,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('opens sign-in instead of checkout when logged out', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (authService as any).isAuthenticated = false;
       const onSignInPress = jest.fn();
 
@@ -631,7 +631,7 @@ describe('PalDetailSheet', () => {
     it('opens sign-in on Android when logged out', async () => {
       const original = Platform.OS;
       Platform.OS = 'android';
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (authService as any).isAuthenticated = false;
       const onSignInPress = jest.fn();
 
@@ -656,7 +656,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('flips Buy to Download after the purchase reconciles to owned', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (authService as any).isAuthenticated = true;
       // Initially not owned -> buy button shows.
       (palsHubService.getPal as jest.Mock).mockResolvedValue(
@@ -687,7 +687,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('does not show buy button for owned premium pals', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (palsHubService.getPal as jest.Mock).mockResolvedValue(
         mockOwnedPremiumPal,
       );
@@ -702,7 +702,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('does not show buy button for free pals', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (palsHubService.getPal as jest.Mock).mockResolvedValue(mockPalsHubPal);
 
       const {queryByTestId} = render(
@@ -717,7 +717,7 @@ describe('PalDetailSheet', () => {
     it('starts checkout directly on Android (no app disclosure; Play renders it)', async () => {
       const original = Platform.OS;
       Platform.OS = 'android';
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (authService as any).isAuthenticated = true;
       (palsHubService.getPal as jest.Mock).mockResolvedValue(
         mockPremiumPalsHubPal,
@@ -745,7 +745,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('starts checkout directly on iOS (no app disclosure gate)', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (authService as any).isAuthenticated = true;
       (palsHubService.getPal as jest.Mock).mockResolvedValue(
         mockPremiumPalsHubPal,
@@ -768,7 +768,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('shows the finalizing indicator while the purchase settles', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       runInAction(() => {
         checkoutFlowStore.status = 'finalizing';
         checkoutFlowStore.palId = mockPremiumPalsHubPal.id;
@@ -784,7 +784,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('shows the processing-deferred message after webhook lag', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       runInAction(() => {
         checkoutFlowStore.status = 'processing_deferred';
         checkoutFlowStore.palId = mockPremiumPalsHubPal.id;
@@ -800,7 +800,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('shows the not-available message on a 404 error without a sign-in control', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       runInAction(() => {
         checkoutFlowStore.status = 'error';
         checkoutFlowStore.errorKind = '404';
@@ -819,7 +819,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('disables the buy button while a checkout is creating', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       runInAction(() => {
         checkoutFlowStore.status = 'creating';
         checkoutFlowStore.palId = mockPremiumPalsHubPal.id;
@@ -841,7 +841,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('resets the checkout flow when the sheet is closed', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
 
       const {getByTestId} = render(
         <PalDetailSheet {...defaultProps} pal={mockPremiumPalsHubPal} />,
@@ -857,7 +857,7 @@ describe('PalDetailSheet', () => {
     });
 
     it('renders "Sign in again" on a 401 error and calls onSignInPress', async () => {
-      (palStore as any).isUSRegion = true;
+      (palStore as any).isCheckoutEligible = true;
       (palsHubService.getPal as jest.Mock).mockResolvedValue(
         mockPremiumPalsHubPal,
       );

--- a/src/specs/NativeExternalContentLink.ts
+++ b/src/specs/NativeExternalContentLink.ts
@@ -2,6 +2,10 @@ import type {TurboModule} from 'react-native';
 import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
+  // Side-effect-free render-time eligibility probe: connect ->
+  // isBillingProgramAvailableAsync(EXTERNAL_CONTENT_LINK) -> resolve boolean ->
+  // disconnect. Never mints a token, launches a link-out, or shows a disclosure.
+  isExternalContentLinkAvailable(): Promise<boolean>;
   // Eligibility gate -> fresh external-transaction token -> Play link-out.
   // outcome: 'launched' (open the URL), 'user_canceled', 'ineligible', 'error'.
   prepareExternalLink(checkoutUrl: string): Promise<{

--- a/src/store/PalStore.ts
+++ b/src/store/PalStore.ts
@@ -58,8 +58,8 @@ class PalStore {
   searchFilters: SearchFilters = {};
   syncState: SyncState = {status: 'idle'};
 
-  // Region state
-  isUSRegion: boolean = false;
+  // Checkout eligibility state
+  isCheckoutEligible: boolean = false;
 
   // Migration state
   isMigrating: boolean = false;
@@ -94,8 +94,8 @@ class PalStore {
       // Register talent engines (idempotent)
       registerDefaultTalents();
 
-      // Check storefront region for buy button gating
-      this.checkRegion();
+      // Check checkout eligibility for buy button gating
+      this.checkCheckoutEligibility();
 
       console.log('Pal store initialization completed');
 
@@ -112,12 +112,12 @@ class PalStore {
     }
   }
 
-  private async checkRegion() {
-    // E2E builds have no App Store storefront, so force the US branch to
+  private async checkCheckoutEligibility() {
+    // E2E builds have no App Store storefront, so force eligibility to
     // exercise the buy button. Compiled out of prod (`__E2E__` is false).
     if (__E2E__) {
       runInAction(() => {
-        this.isUSRegion = true;
+        this.isCheckoutEligible = true;
       });
       return;
     }
@@ -125,7 +125,7 @@ class PalStore {
     try {
       const isUS = await isUSStorefront();
       runInAction(() => {
-        this.isUSRegion = isUS;
+        this.isCheckoutEligible = isUS;
       });
     } catch (error) {
       console.warn('Failed to check storefront region:', error);

--- a/src/store/PalStore.ts
+++ b/src/store/PalStore.ts
@@ -138,6 +138,9 @@ class PalStore {
       });
     } catch (error) {
       console.warn('Failed to check checkout eligibility:', error);
+      runInAction(() => {
+        this.isCheckoutEligible = false;
+      });
     }
   }
 

--- a/src/store/PalStore.ts
+++ b/src/store/PalStore.ts
@@ -18,6 +18,7 @@
 
 import {v4 as uuidv4} from 'uuid';
 import {makeAutoObservable, runInAction} from 'mobx';
+import {Platform} from 'react-native';
 
 import {HF_DOMAIN} from '../config/urls';
 
@@ -26,6 +27,7 @@ import {palRepository} from '../repositories/PalRepository';
 import {hfAsModel} from '../utils';
 import {resolveHFModelForDownload} from '../utils/hfResolve';
 import {isUSStorefront} from '../utils/region';
+import NativeExternalContentLink from '../specs/NativeExternalContentLink';
 import {palsHubService} from '../services';
 import {registerDefaultTalents} from '../services/talents';
 import {LOOKIE_DEFAULT_MODEL} from './builtinPalModels';
@@ -123,12 +125,19 @@ class PalStore {
     }
 
     try {
-      const isUS = await isUSStorefront();
+      // Gate on real purchase eligibility per platform, not device locale:
+      // Android queries Play EXTERNAL_CONTENT_LINK availability; iOS keeps the
+      // StoreKit storefront signal. A null Android module or a thrown probe
+      // leaves the flag false (fail-closed → info-text fallback).
+      const eligible =
+        Platform.OS === 'android'
+          ? await NativeExternalContentLink?.isExternalContentLinkAvailable()
+          : await isUSStorefront();
       runInAction(() => {
-        this.isCheckoutEligible = isUS;
+        this.isCheckoutEligible = eligible === true;
       });
     } catch (error) {
-      console.warn('Failed to check storefront region:', error);
+      console.warn('Failed to check checkout eligibility:', error);
     }
   }
 

--- a/src/store/__tests__/PalStore.test.ts
+++ b/src/store/__tests__/PalStore.test.ts
@@ -1,6 +1,8 @@
 import {runInAction} from 'mobx';
+import {Platform} from 'react-native';
 import {palStore} from '../PalStore';
 import {palsHubService} from '../../services';
+import {isUSStorefront} from '../../utils/region';
 import {palRepository} from '../../repositories/PalRepository';
 import type {Pal} from '../../types/pal';
 import type {PalsHubPal} from '../../types/palshub';
@@ -45,6 +47,23 @@ jest.mock('../../services', () => ({
 // Mock MobX persist
 jest.mock('mobx-persist-store', () => ({
   makePersistable: jest.fn(),
+}));
+
+// Eligibility writer dependencies: iOS StoreKit storefront + Android probe.
+jest.mock('../../utils/region', () => ({
+  isUSStorefront: jest.fn(),
+}));
+
+// Toggle the Android external-content-link module per test through a getter so
+// the null-module fail-closed path can be exercised in the same file.
+let mockExternalContentLink: {
+  isExternalContentLinkAvailable: jest.Mock;
+} | null = {isExternalContentLinkAvailable: jest.fn()};
+jest.mock('../../specs/NativeExternalContentLink', () => ({
+  __esModule: true,
+  get default() {
+    return mockExternalContentLink;
+  },
 }));
 
 describe('PalStore', () => {
@@ -184,6 +203,90 @@ describe('PalStore', () => {
       ).mock.calls.find(call => call[0]?.name === 'Lookie');
       expect(lookieCreate).toBeUndefined();
       expect(resolveHFModelForDownload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkout eligibility writer', () => {
+    const originalOS = Platform.OS;
+    const originalE2E = (global as any).__E2E__;
+
+    const runWriter = () => (palStore as any).checkCheckoutEligibility();
+
+    beforeEach(() => {
+      // Exercise the real per-platform branch (prod path), not the E2E override.
+      (global as any).__E2E__ = false;
+      mockExternalContentLink = {isExternalContentLinkAvailable: jest.fn()};
+      (isUSStorefront as jest.Mock).mockReset();
+      runInAction(() => {
+        (palStore as any).isCheckoutEligible = false;
+      });
+    });
+
+    afterEach(() => {
+      Platform.OS = originalOS;
+      (global as any).__E2E__ = originalE2E;
+    });
+
+    it('Android: EXTERNAL_CONTENT_LINK available -> eligible (locale irrelevant)', async () => {
+      Platform.OS = 'android';
+      mockExternalContentLink!.isExternalContentLinkAvailable.mockResolvedValue(
+        true,
+      );
+
+      await runWriter();
+
+      expect(
+        mockExternalContentLink!.isExternalContentLinkAvailable,
+      ).toHaveBeenCalledTimes(1);
+      expect(isUSStorefront).not.toHaveBeenCalled();
+      expect(palStore.isCheckoutEligible).toBe(true);
+    });
+
+    it('Android: program unavailable -> ineligible (info text)', async () => {
+      Platform.OS = 'android';
+      mockExternalContentLink!.isExternalContentLinkAvailable.mockResolvedValue(
+        false,
+      );
+
+      await runWriter();
+
+      expect(palStore.isCheckoutEligible).toBe(false);
+    });
+
+    it('Android: null module -> ineligible (fail-closed)', async () => {
+      Platform.OS = 'android';
+      mockExternalContentLink = null;
+
+      await runWriter();
+
+      expect(isUSStorefront).not.toHaveBeenCalled();
+      expect(palStore.isCheckoutEligible).toBe(false);
+    });
+
+    it('Android: probe throws -> ineligible (fail-closed)', async () => {
+      Platform.OS = 'android';
+      mockExternalContentLink!.isExternalContentLinkAvailable.mockRejectedValue(
+        new Error('billing setup failed'),
+      );
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await runWriter();
+
+      expect(palStore.isCheckoutEligible).toBe(false);
+      warnSpy.mockRestore();
+    });
+
+    it('iOS: keeps StoreKit storefront signal, never probes Play', async () => {
+      Platform.OS = 'ios';
+      (isUSStorefront as jest.Mock).mockResolvedValue(true);
+
+      await runWriter();
+
+      expect(isUSStorefront).toHaveBeenCalledTimes(1);
+      expect(
+        mockExternalContentLink!.isExternalContentLinkAvailable,
+      ).not.toHaveBeenCalled();
+      expect(palStore.isCheckoutEligible).toBe(true);
     });
   });
 

--- a/src/store/__tests__/PalStore.test.ts
+++ b/src/store/__tests__/PalStore.test.ts
@@ -56,9 +56,17 @@ jest.mock('../../utils/region', () => ({
 
 // Toggle the Android external-content-link module per test through a getter so
 // the null-module fail-closed path can be exercised in the same file.
-let mockExternalContentLink: {
-  isExternalContentLinkAvailable: jest.Mock;
-} | null = {isExternalContentLinkAvailable: jest.fn()};
+// prepareExternalLink / reportExternalContentLink are stubbed so a test can
+// assert the eligibility probe is side-effect-free (never mints a token,
+// launches a link-out, or reports — I-E1).
+const makeExternalContentLink = () => ({
+  isExternalContentLinkAvailable: jest.fn(),
+  prepareExternalLink: jest.fn(),
+  reportExternalContentLink: jest.fn(),
+});
+let mockExternalContentLink: ReturnType<
+  typeof makeExternalContentLink
+> | null = makeExternalContentLink();
 jest.mock('../../specs/NativeExternalContentLink', () => ({
   __esModule: true,
   get default() {
@@ -215,7 +223,7 @@ describe('PalStore', () => {
     beforeEach(() => {
       // Exercise the real per-platform branch (prod path), not the E2E override.
       (global as any).__E2E__ = false;
-      mockExternalContentLink = {isExternalContentLinkAvailable: jest.fn()};
+      mockExternalContentLink = makeExternalContentLink();
       (isUSStorefront as jest.Mock).mockReset();
       runInAction(() => {
         (palStore as any).isCheckoutEligible = false;
@@ -239,6 +247,12 @@ describe('PalStore', () => {
         mockExternalContentLink!.isExternalContentLinkAvailable,
       ).toHaveBeenCalledTimes(1);
       expect(isUSStorefront).not.toHaveBeenCalled();
+      // The probe is side-effect-free: it never mints a token, launches a
+      // link-out, or reports (I-E1 / scenario D, JS-observable portion).
+      expect(mockExternalContentLink!.prepareExternalLink).not.toHaveBeenCalled();
+      expect(
+        mockExternalContentLink!.reportExternalContentLink,
+      ).not.toHaveBeenCalled();
       expect(palStore.isCheckoutEligible).toBe(true);
     });
 
@@ -274,6 +288,19 @@ describe('PalStore', () => {
 
       expect(palStore.isCheckoutEligible).toBe(false);
       warnSpy.mockRestore();
+    });
+
+    it('E2E build: forces eligibility without probing the platform', async () => {
+      Platform.OS = 'android';
+      (global as any).__E2E__ = true;
+
+      await runWriter();
+
+      expect(palStore.isCheckoutEligible).toBe(true);
+      expect(
+        mockExternalContentLink!.isExternalContentLinkAvailable,
+      ).not.toHaveBeenCalled();
+      expect(isUSStorefront).not.toHaveBeenCalled();
     });
 
     it('iOS: keeps StoreKit storefront signal, never probes Play', async () => {

--- a/src/store/__tests__/PalStore.test.ts
+++ b/src/store/__tests__/PalStore.test.ts
@@ -275,8 +275,10 @@ describe('PalStore', () => {
       expect(palStore.isCheckoutEligible).toBe(false);
     });
 
-    it('Android: probe throws -> ineligible (fail-closed)', async () => {
+    it('Android: probe throws -> ineligible (fail-closed, resets a stale true)', async () => {
       Platform.OS = 'android';
+      // Pre-seed true so this guards the catch resetting the flag, not the default.
+      (palStore as any).isCheckoutEligible = true;
       mockExternalContentLink!.isExternalContentLinkAvailable.mockRejectedValue(
         new Error('billing setup failed'),
       );

--- a/src/store/__tests__/PalStore.test.ts
+++ b/src/store/__tests__/PalStore.test.ts
@@ -64,9 +64,8 @@ const makeExternalContentLink = () => ({
   prepareExternalLink: jest.fn(),
   reportExternalContentLink: jest.fn(),
 });
-let mockExternalContentLink: ReturnType<
-  typeof makeExternalContentLink
-> | null = makeExternalContentLink();
+let mockExternalContentLink: ReturnType<typeof makeExternalContentLink> | null =
+  makeExternalContentLink();
 jest.mock('../../specs/NativeExternalContentLink', () => ({
   __esModule: true,
   get default() {
@@ -249,7 +248,9 @@ describe('PalStore', () => {
       expect(isUSStorefront).not.toHaveBeenCalled();
       // The probe is side-effect-free: it never mints a token, launches a
       // link-out, or reports (I-E1 / scenario D, JS-observable portion).
-      expect(mockExternalContentLink!.prepareExternalLink).not.toHaveBeenCalled();
+      expect(
+        mockExternalContentLink!.prepareExternalLink,
+      ).not.toHaveBeenCalled();
       expect(
         mockExternalContentLink!.reportExternalContentLink,
       ).not.toHaveBeenCalled();

--- a/src/store/__tests__/PalStore.test.ts
+++ b/src/store/__tests__/PalStore.test.ts
@@ -54,11 +54,9 @@ jest.mock('../../utils/region', () => ({
   isUSStorefront: jest.fn(),
 }));
 
-// Toggle the Android external-content-link module per test through a getter so
-// the null-module fail-closed path can be exercised in the same file.
-// prepareExternalLink / reportExternalContentLink are stubbed so a test can
-// assert the eligibility probe is side-effect-free (never mints a token,
-// launches a link-out, or reports — I-E1).
+// Toggle the module per test via a getter so the null-module fail-closed path
+// can be exercised here. prepareExternalLink / reportExternalContentLink are
+// stubbed so a test can assert the probe never mints a token, launches, or reports.
 const makeExternalContentLink = () => ({
   isExternalContentLinkAvailable: jest.fn(),
   prepareExternalLink: jest.fn(),
@@ -246,8 +244,7 @@ describe('PalStore', () => {
         mockExternalContentLink!.isExternalContentLinkAvailable,
       ).toHaveBeenCalledTimes(1);
       expect(isUSStorefront).not.toHaveBeenCalled();
-      // The probe is side-effect-free: it never mints a token, launches a
-      // link-out, or reports (I-E1 / scenario D, JS-observable portion).
+      // Probe is side-effect-free: never mints a token, launches, or reports.
       expect(
         mockExternalContentLink!.prepareExternalLink,
       ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

The premium-pal buy button on the pal detail sheet was gated, on Android, on `Locale.getDefault().country`. Device locale reflects a *language* preference, not the Play store-account region or actual purchase eligibility. As a result, a US Play account on a German-locale device saw **no** buy button at all — even though that account is fully able to purchase.

## Fix

Gate the buy button on real per-platform purchase eligibility instead of device locale:

- **Android** now probes Play `EXTERNAL_CONTENT_LINK` program availability via a new side-effect-free `isExternalContentLinkAvailable()` method on the `NativeExternalContentLink` TurboModule. It connects, runs `isBillingProgramAvailableAsync(EXTERNAL_CONTENT_LINK)`, resolves a boolean, and disconnects — it never mints an external-transaction token, launches a link-out, or renders a Play disclosure. Token mint, launch, and disclosure stay exclusively in the existing `prepareExternalLink` path, which now shares a single connect + availability helper with the probe (link-out behaviour unchanged).
- **iOS** is unchanged: it keeps deriving eligibility from the StoreKit storefront signal.
- The gate **fails closed**: a null Android module or a thrown probe leaves the flag `false`, so the existing informational text is shown instead of a dead button.

The eligibility flag (`palStore.isCheckoutEligible`, renamed from the old region flag) is written once at store init by a single writer that branches per platform; `PalDetailSheet` reads it read-only to decide buy-button vs info-text. Device locale is no longer consulted for the gate on either platform.

## Tests

- Full unit suite: 247 suites, 3740 passed, 2 skipped.
- Coverage: 75.45% statements (project gate is 60%).
- New `PalStore` tests cover: Android eligibility via the availability probe, US-account/non-US-locale (buy button shown), ineligible account (info text), iOS StoreKit path unchanged, E2E force-on, and fail-closed on null module / thrown probe.
- New assertions verify the availability probe is side-effect-free (never invokes the link-out / token path) and the buy-gate render reads the eligibility flag.
- `PalDetailSheet` tests updated for the eligibility-based gate.
- Lint: 0 errors. Typecheck: clean.

## Native verification

This change touches native code (Android Kotlin module, the TurboModule spec, `ios/Podfile.lock`), so both platforms were built:

- `pod install` regenerated the codegen pod for the new spec method; `ios/Podfile.lock` codegen checksum committed.
- iOS Release build (`yarn ios:build`): green. Codegen picked up the new method.
- Android release build (`assembleProdDebug`): green. Codegen picked up the new method.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
