### PR TITLE
[Feat]: Discover llama.cpp /props for remote vision + context banners

### DIFF
--- a/e2e/specs/features/remote-vision.spec.ts
+++ b/e2e/specs/features/remote-vision.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Remote Vision Capability Feature Tests
+ *
+ * Exercises the llama.cpp GET /props capability-discovery path end to end:
+ * a remote server that reports `modalities.vision` enables the chat image
+ * attachment affordance; a server that does not keeps it disabled. This is the
+ * user-visible surface of the /props -> ServerConfig.supportsVision ->
+ * ModelStore.isMultimodalEnabled -> ChatInput isVisionEnabled chain.
+ *
+ * The attach button is always rendered (ChatScreen showImageUpload={true}); only
+ * its enabled state flips with the discovered capability, so isEnabled() on the
+ * "Add image" button is the assertion. (Sending an actual image needs the native
+ * gallery picker, which is not automatable here; that path is covered by the
+ * committed visual capture.)
+ *
+ * Prerequisites:
+ *   - REMOTE_VISION_URL points at a llama.cpp server whose GET /props reports
+ *     modalities.vision === true (e.g. a SmolVLM build).
+ *   - REMOTE_NONVISION_URL (optional) points at a text-only server (no vision in
+ *     /props). When unset, the negative test is skipped.
+ *
+ * Environment variables:
+ *   REMOTE_VISION_URL         - vision-capable server (default http://192.168.0.62:1234)
+ *   REMOTE_VISION_MODEL_HINT  - partial model name in the picker (default 'SmolVLM')
+ *   REMOTE_NONVISION_URL      - text-only server (optional; negative test)
+ *   REMOTE_NONVISION_MODEL_HINT - partial model name for the text server (optional)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {expect} from '@wdio/globals';
+import {ChatPage} from '../../pages/ChatPage';
+import {DrawerPage} from '../../pages/DrawerPage';
+import {ModelsPage} from '../../pages/ModelsPage';
+import {Selectors, byPartialText} from '../../helpers/selectors';
+import {Gestures} from '../../helpers/gestures';
+import {TIMEOUTS} from '../../fixtures/models';
+import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
+
+declare const driver: WebdriverIO.Browser;
+declare const browser: WebdriverIO.Browser;
+
+const VISION_URL = process.env.REMOTE_VISION_URL || 'http://192.168.0.62:1234';
+const VISION_HINT = process.env.REMOTE_VISION_MODEL_HINT || 'SmolVLM';
+const NONVISION_URL = process.env.REMOTE_NONVISION_URL || '';
+const NONVISION_HINT = process.env.REMOTE_NONVISION_MODEL_HINT || '';
+
+const ADD_IMAGE_BUTTON = '~Add image';
+
+describe('Remote Vision Capability', () => {
+  let chatPage: ChatPage;
+  let drawerPage: DrawerPage;
+  let modelsPage: ModelsPage;
+
+  before(async () => {
+    chatPage = new ChatPage();
+    drawerPage = new DrawerPage();
+    modelsPage = new ModelsPage();
+    await chatPage.waitForReady(TIMEOUTS.appReady);
+  });
+
+  beforeEach(() => {
+    chatPage = new ChatPage();
+    drawerPage = new DrawerPage();
+    modelsPage = new ModelsPage();
+  });
+
+  afterEach(async function (this: Mocha.Context) {
+    if (this.currentTest?.state === 'failed') {
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const name = this.currentTest.title.replace(/\s+/g, '-');
+      try {
+        if (!fs.existsSync(SCREENSHOT_DIR)) {
+          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
+        }
+        await driver.saveScreenshot(
+          path.join(SCREENSHOT_DIR, `failure-${name}-${ts}.png`),
+        );
+      } catch (e) {
+        console.error('Failed to capture screenshot:', (e as Error).message);
+      }
+    }
+  });
+
+  /** Add a remote server, wait for the /props probe, select a model, add it. */
+  async function addRemoteModel(url: string, hint: string): Promise<void> {
+    await chatPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToModels();
+    await modelsPage.waitForReady();
+
+    await modelsPage.openAddRemoteModel();
+
+    const urlInput = browser.$(Selectors.remoteModel.urlInput);
+    await urlInput.waitForDisplayed({timeout: 5000});
+    await urlInput.clearValue();
+    await urlInput.setValue(url);
+    console.log(`Entered server URL: ${url}`);
+
+    // Dismiss keyboard so it does not cover the sheet, then wait for the
+    // debounced probe (models + /props) to resolve.
+    await modelsPage.hideKeyboard();
+    await browser.pause(3000);
+
+    // Select the model (by hint if given, else the first radio).
+    if (hint) {
+      await Gestures.scrollInSheetToElementExists(byPartialText(hint), 12);
+      const modelEl = browser.$(byPartialText(hint));
+      const exists = await modelEl
+        .waitForExist({timeout: 8000})
+        .then(() => true)
+        .catch(() => false);
+      if (exists) {
+        await modelEl.click();
+        await browser.pause(500);
+      }
+    } else {
+      const addBtn = browser.$(Selectors.remoteModel.addModelButton);
+      const alreadyEnabled = await addBtn.isEnabled().catch(() => false);
+      if (!alreadyEnabled) {
+        const radio = '-ios predicate string:value == "radio button, unchecked"';
+        await Gestures.scrollInSheetToElementExists(radio, 12);
+        const firstRadio = browser.$(radio);
+        const radioExists = await firstRadio
+          .waitForExist({timeout: 3000})
+          .then(() => true)
+          .catch(() => false);
+        if (radioExists) {
+          await firstRadio.click();
+          await browser.pause(500);
+        }
+      }
+    }
+
+    await Gestures.scrollInSheetToElementExists(
+      Selectors.remoteModel.addModelButton,
+      6,
+    );
+    const addButton = browser.$(Selectors.remoteModel.addModelButton);
+    await addButton.waitForExist({timeout: 5000});
+    await addButton.waitForEnabled({timeout: 8000});
+    await addButton.click();
+    await browser.pause(1000);
+  }
+
+  /** From the chat screen, open the picker and activate the remote model. */
+  async function activateInChat(hint: string): Promise<void> {
+    await chatPage.openDrawer();
+    await drawerPage.waitForOpen();
+    await drawerPage.navigateToChat();
+    await chatPage.waitForReady();
+    await browser.pause(3000);
+
+    // Open the model picker. The empty-state "Select Model" button only shows
+    // when no model is active; the "Select Pal" button in the input bar is
+    // always present and toggles the picker, so it works whether or not a model
+    // is already active (e.g. after a previous test activated one).
+    const palBtn = browser.$('~Select Pal');
+    const palVisible = await palBtn
+      .waitForDisplayed({timeout: 10000})
+      .then(() => true)
+      .catch(() => false);
+    if (palVisible) {
+      await palBtn.click();
+    } else {
+      const selectModelBtn = browser.$(byPartialText('Select Model'));
+      await selectModelBtn.waitForDisplayed({timeout: 10000});
+      await selectModelBtn.click();
+    }
+    await browser.pause(1000);
+
+    // Picker opens on the Pals tab; swipe left to the Models tab.
+    const {width, height} = await driver.getWindowSize();
+    await driver
+      .action('pointer', {parameters: {pointerType: 'touch'}})
+      .move({x: Math.round(width * 0.8), y: Math.round(height * 0.65)})
+      .down()
+      .move({x: Math.round(width * 0.2), y: Math.round(height * 0.65), duration: 300})
+      .up()
+      .perform();
+    await browser.pause(1000);
+
+    const modelEl = browser.$(byPartialText(hint));
+    const visible = await modelEl
+      .waitForDisplayed({timeout: 10000})
+      .then(() => true)
+      .catch(() => false);
+    if (!visible) {
+      throw new Error(`Remote model "${hint}" not found in chat picker`);
+    }
+    await modelEl.click();
+    await browser.pause(2000);
+
+    // Chat input should now be present with the remote model active.
+    await browser.$(Selectors.chat.input).waitForDisplayed({timeout: 10000});
+  }
+
+  it('enables the image-attach button for a vision-capable remote server', async () => {
+    await addRemoteModel(VISION_URL, VISION_HINT);
+    await activateInChat(VISION_HINT);
+
+    const addImage = browser.$(ADD_IMAGE_BUTTON);
+    await addImage.waitForExist({timeout: 10000});
+    const enabled = await addImage.isEnabled();
+    console.log(`vision server -> Add image button enabled=${enabled}`);
+    expect(enabled).toBe(true);
+  });
+
+  it('keeps the image-attach button disabled for a non-vision remote server', async function (this: Mocha.Context) {
+    if (!NONVISION_URL) {
+      console.log('REMOTE_NONVISION_URL unset — skipping non-vision case');
+      this.skip();
+      return;
+    }
+    await addRemoteModel(NONVISION_URL, NONVISION_HINT);
+    await activateInChat(NONVISION_HINT);
+
+    const addImage = browser.$(ADD_IMAGE_BUTTON);
+    await addImage.waitForExist({timeout: 10000});
+    const enabled = await addImage.isEnabled();
+    console.log(`non-vision server -> Add image button enabled=${enabled}`);
+    expect(enabled).toBe(false);
+  });
+});

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -1,6 +1,7 @@
 import {
   fetchModels,
   fetchModelsWithHeaders,
+  fetchServerProps,
   detectServerType,
   testConnection,
   streamChatCompletion,
@@ -364,6 +365,68 @@ describe('testConnection', () => {
     await expect(
       testConnection('http://localhost:1234', undefined, undefined),
     ).resolves.toEqual({ok: true, modelCount: 1});
+  });
+});
+
+describe('fetchServerProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('parses contextLength from default_generation_settings.n_ctx and vision', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          default_generation_settings: {n_ctx: 4096},
+          modalities: {vision: true, audio: false},
+        }),
+    });
+
+    const props = await fetchServerProps('http://localhost:8080');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/props',
+      expect.objectContaining({method: 'GET'}),
+    );
+    expect(props).toEqual({contextLength: 4096, supportsVision: true});
+  });
+
+  it('falls back to top-level n_ctx and omits vision when not reported', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({n_ctx: 8192}),
+    });
+
+    const props = await fetchServerProps('http://localhost:8080');
+    expect(props).toEqual({contextLength: 8192});
+  });
+
+  it('resolves to empty caps on a non-2xx response', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({ok: false, status: 404});
+
+    await expect(fetchServerProps('http://localhost:8080')).resolves.toEqual(
+      {},
+    );
+  });
+
+  it('resolves to empty caps on a network error (never throws)', async () => {
+    global.fetch = jest.fn().mockRejectedValueOnce(new Error('boom'));
+
+    await expect(fetchServerProps('http://localhost:8080')).resolves.toEqual(
+      {},
+    );
+  });
+
+  it('resolves to empty caps on malformed JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new Error('bad json')),
+    });
+
+    await expect(fetchServerProps('http://localhost:8080')).resolves.toEqual(
+      {},
+    );
   });
 });
 

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -781,6 +781,68 @@ describe('streamChatCompletion', () => {
     expect(RNFS.readFile).toHaveBeenCalledTimes(1);
   });
 
+  it('evicts oldest-first once cached bytes exceed the 24MB budget', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    // ~9MB base64 per image; three exceed the 24MB cache budget, so caching the
+    // third evicts the oldest (first) entry.
+    const big = 'A'.repeat(9 * 1024 * 1024);
+    (RNFS.readFile as jest.Mock).mockResolvedValue(big);
+
+    const send = async (path: string) => {
+      const p = streamChatCompletion(
+        {messages: [imageMessage(path)], model: 'm'},
+        'http://localhost:1234',
+      );
+      await new Promise(r => setImmediate(r));
+      await finishStream(MockXHR.instances[MockXHR.instances.length - 1], p);
+    };
+
+    // Fill: A (oldest) → B → C. Caching C pushes bytes over budget and evicts A.
+    await send('file:///tmp/a.png');
+    await send('file:///tmp/b.png');
+    await send('file:///tmp/c.png');
+    expect(RNFS.readFile).toHaveBeenCalledTimes(3);
+
+    // The two newest paths are still resident — re-sending them is a cache hit.
+    await send('file:///tmp/c.png');
+    await send('file:///tmp/b.png');
+    expect(RNFS.readFile).toHaveBeenCalledTimes(3);
+
+    // The oldest path was evicted, so re-sending it re-reads from disk.
+    await send('file:///tmp/a.png');
+    expect(RNFS.readFile).toHaveBeenCalledTimes(4);
+  });
+
+  it('dedups a concurrent double-encode of the same path (race-safe cache set)', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    (RNFS.readFile as jest.Mock).mockResolvedValue('QUJD');
+
+    // Two sends of the same new path start before either populates the cache, so
+    // both miss the read-side lookup and both call the cache setter; the second
+    // set hits the `has()` guard and does not double-count the entry.
+    const p1 = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/race.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    const p2 = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/race.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    await finishStream(MockXHR.instances[0], p1);
+    await finishStream(MockXHR.instances[1], p2);
+    expect(RNFS.readFile).toHaveBeenCalledTimes(2);
+
+    // A subsequent send is a plain cache hit — the raced entry cached cleanly.
+    const p3 = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/race.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    await finishStream(MockXHR.instances[2], p3);
+    expect(RNFS.readFile).toHaveBeenCalledTimes(2);
+  });
+
   it('maps a dotless path to image/jpeg (no invalid image// MIME)', async () => {
     const RNFS = require('@dr.pogodin/react-native-fs');
     (RNFS.readFile as jest.Mock).mockResolvedValueOnce('QUJD');

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -616,6 +616,104 @@ describe('streamChatCompletion', () => {
     await resultPromise;
   });
 
+  it('encodes a local image path to a data URI on the remote wire', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    (RNFS.readFile as jest.Mock).mockResolvedValueOnce('QUJD');
+
+    const resultPromise = streamChatCompletion(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {type: 'text', text: 'what is this?'},
+              {type: 'image_url', image_url: {url: 'file:///tmp/photo.png'}},
+            ],
+          },
+        ],
+        model: 'test-model',
+      },
+      'http://localhost:1234',
+    );
+
+    await new Promise(r => setImmediate(r));
+    const xhr = MockXHR.instances[0];
+    const body = JSON.parse(xhr.requestBody);
+    expect(body.messages[0].content[1].image_url.url).toBe(
+      'data:image/png;base64,QUJD',
+    );
+
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+    );
+    xhr.simulateLoad();
+    await resultPromise;
+  });
+
+  it('passes through data: and http image urls unchanged', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+
+    const resultPromise = streamChatCompletion(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image_url',
+                image_url: {url: 'data:image/jpeg;base64,ZZ'},
+              },
+              {type: 'image_url', image_url: {url: 'https://ex.com/a.png'}},
+            ],
+          },
+        ],
+        model: 'test-model',
+      },
+      'http://localhost:1234',
+    );
+
+    await new Promise(r => setImmediate(r));
+    const xhr = MockXHR.instances[0];
+    const body = JSON.parse(xhr.requestBody);
+    expect(body.messages[0].content[0].image_url.url).toBe(
+      'data:image/jpeg;base64,ZZ',
+    );
+    expect(body.messages[0].content[1].image_url.url).toBe(
+      'https://ex.com/a.png',
+    );
+    expect(RNFS.readFile).not.toHaveBeenCalled();
+
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+    );
+    xhr.simulateLoad();
+    await resultPromise;
+  });
+
+  it('leaves a text-only message array untouched', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+
+    const resultPromise = streamChatCompletion(
+      {messages: [{role: 'user', content: 'plain text'}], model: 'test-model'},
+      'http://localhost:1234',
+    );
+
+    await new Promise(r => setImmediate(r));
+    const xhr = MockXHR.instances[0];
+    const body = JSON.parse(xhr.requestBody);
+    expect(body.messages[0].content).toBe('plain text');
+    expect(RNFS.readFile).not.toHaveBeenCalled();
+
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+    );
+    xhr.simulateLoad();
+    await resultPromise;
+  });
+
   it('forwards response_format and injects json_schema.name for OpenAI compatibility', async () => {
     const schema = {type: 'object', properties: {name: {type: 'string'}}};
     const resultPromise = streamChatCompletion(

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -6,6 +6,7 @@ import {
   testConnection,
   streamChatCompletion,
   buildReasoningPayload,
+  __clearRemoteImageCache,
 } from '../openai';
 
 /** Build a minimal Headers-like object for fetch mocks. */
@@ -536,6 +537,7 @@ describe('streamChatCompletion', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    __clearRemoteImageCache();
     MockXHR.instances = [];
     originalXHR = global.XMLHttpRequest;
     (global as any).XMLHttpRequest = MockXHR;
@@ -728,6 +730,157 @@ describe('streamChatCompletion', () => {
     );
     xhr.simulateLoad();
     await resultPromise;
+  });
+
+  // Drive a stream to completion so its promise settles after the request
+  // body has been inspected.
+  const finishStream = async (
+    xhr: MockXHR,
+    resultPromise: Promise<unknown>,
+  ) => {
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+    );
+    xhr.simulateLoad();
+    await resultPromise;
+  };
+
+  const imageMessage = (url: string) => ({
+    role: 'user',
+    content: [{type: 'image_url', image_url: {url}}],
+  });
+
+  it('encodes a local image once and re-uses the cache on the next send', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    (RNFS.readFile as jest.Mock).mockResolvedValue('QUJD');
+
+    const p1 = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/cached.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    const body1 = JSON.parse(MockXHR.instances[0].requestBody);
+    expect(body1.messages[0].content[0].image_url.url).toBe(
+      'data:image/png;base64,QUJD',
+    );
+    await finishStream(MockXHR.instances[0], p1);
+
+    const p2 = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/cached.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    const body2 = JSON.parse(MockXHR.instances[1].requestBody);
+    expect(body2.messages[0].content[0].image_url.url).toBe(
+      'data:image/png;base64,QUJD',
+    );
+    await finishStream(MockXHR.instances[1], p2);
+
+    // The second send hit the cache — the file was read from disk only once.
+    expect(RNFS.readFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a dotless path to image/jpeg (no invalid image// MIME)', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    (RNFS.readFile as jest.Mock).mockResolvedValueOnce('QUJD');
+
+    const p = streamChatCompletion(
+      {messages: [imageMessage('content://media/1234')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    const body = JSON.parse(MockXHR.instances[0].requestBody);
+    expect(body.messages[0].content[0].image_url.url).toBe(
+      'data:image/jpeg;base64,QUJD',
+    );
+    await finishStream(MockXHR.instances[0], p);
+  });
+
+  it('skips inlining a file whose successful stat exceeds the size cap', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    (RNFS.stat as jest.Mock).mockResolvedValueOnce({size: 20 * 1024 * 1024});
+
+    const p = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/huge.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    const body = JSON.parse(MockXHR.instances[0].requestBody);
+    // Left unchanged; the server surfaces the failure.
+    expect(body.messages[0].content[0].image_url.url).toBe(
+      'file:///tmp/huge.png',
+    );
+    expect(RNFS.readFile).not.toHaveBeenCalled();
+    await finishStream(MockXHR.instances[0], p);
+  });
+
+  it('encodes anyway when stat is unavailable (undefined result)', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    // stat is an unconfigured jest.fn() → resolves undefined.
+    (RNFS.readFile as jest.Mock).mockResolvedValueOnce('QUJD');
+
+    const p = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/nostat.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    const body = JSON.parse(MockXHR.instances[0].requestBody);
+    expect(body.messages[0].content[0].image_url.url).toBe(
+      'data:image/png;base64,QUJD',
+    );
+    await finishStream(MockXHR.instances[0], p);
+  });
+
+  it('encodes anyway when stat rejects (healthy image not dropped)', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    (RNFS.stat as jest.Mock).mockRejectedValueOnce(new Error('stat failed'));
+    (RNFS.readFile as jest.Mock).mockResolvedValueOnce('QUJD');
+
+    const p = streamChatCompletion(
+      {messages: [imageMessage('file:///tmp/statfail.png')], model: 'm'},
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    const body = JSON.parse(MockXHR.instances[0].requestBody);
+    expect(body.messages[0].content[0].image_url.url).toBe(
+      'data:image/png;base64,QUJD',
+    );
+    await finishStream(MockXHR.instances[0], p);
+  });
+
+  it('degrades per-image: a read failure leaves that part but encodes siblings', async () => {
+    const RNFS = require('@dr.pogodin/react-native-fs');
+    (RNFS.readFile as jest.Mock)
+      .mockRejectedValueOnce(new Error('read failed'))
+      .mockResolvedValueOnce('QUJD');
+
+    const p = streamChatCompletion(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {type: 'image_url', image_url: {url: 'file:///tmp/bad.png'}},
+              {type: 'image_url', image_url: {url: 'file:///tmp/ok.png'}},
+            ],
+          },
+        ],
+        model: 'm',
+      },
+      'http://localhost:1234',
+    );
+    await new Promise(r => setImmediate(r));
+    const body = JSON.parse(MockXHR.instances[0].requestBody);
+    // The failed image is left unchanged; the sibling still encodes and the
+    // completion promise does not reject.
+    expect(body.messages[0].content[0].image_url.url).toBe(
+      'file:///tmp/bad.png',
+    );
+    expect(body.messages[0].content[1].image_url.url).toBe(
+      'data:image/png;base64,QUJD',
+    );
+    await finishStream(MockXHR.instances[0], p);
   });
 
   it('forwards response_format and injects json_schema.name for OpenAI compatibility', async () => {

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -392,14 +392,30 @@ describe('fetchServerProps', () => {
     expect(props).toEqual({contextLength: 4096, supportsVision: true});
   });
 
-  it('falls back to top-level n_ctx and omits vision when not reported', async () => {
+  it('falls back to top-level n_ctx and reports vision false when not present', async () => {
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({n_ctx: 8192}),
     });
 
     const props = await fetchServerProps('http://localhost:8080');
-    expect(props).toEqual({contextLength: 8192});
+    expect(props).toEqual({contextLength: 8192, supportsVision: false});
+  });
+
+  it('returns supportsVision false (defined, not omitted) when vision is off', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          default_generation_settings: {n_ctx: 4096},
+          modalities: {vision: false},
+        }),
+    });
+
+    const props = await fetchServerProps('http://localhost:8080');
+    // Defined false on a 2xx probe clears a stale true on a model swap; a
+    // failed probe would return {} instead.
+    expect(props).toEqual({contextLength: 4096, supportsVision: false});
   });
 
   it('resolves to empty caps on a non-2xx response', async () => {

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -831,6 +831,52 @@ describe('streamChatCompletion', () => {
     expect(result.stopped_eos).toBe(true);
   });
 
+  it('reconciles token counts from timings prompt_n/predicted_n', async () => {
+    const resultPromise = streamChatCompletion(
+      {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
+      'http://localhost:1234',
+    );
+
+    const xhr = MockXHR.instances[0];
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+    );
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"prompt_n":3000,"predicted_n":500}}\n\n',
+    );
+    xhr.simulateProgress('data: [DONE]\n\n');
+    xhr.simulateLoad();
+
+    const result = await resultPromise;
+    // Server counts win over the single content-bearing per-event tally.
+    expect(result.tokens_evaluated).toBe(3000);
+    expect(result.tokens_predicted).toBe(500);
+  });
+
+  it('guards each timings token key independently (only predicted_n)', async () => {
+    const resultPromise = streamChatCompletion(
+      {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
+      'http://localhost:1234',
+    );
+
+    const xhr = MockXHR.instances[0];
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+    );
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"predicted_n":7}}\n\n',
+    );
+    xhr.simulateProgress('data: [DONE]\n\n');
+    xhr.simulateLoad();
+
+    const result = await resultPromise;
+    // Missing prompt_n stays unset; predicted_n still wins.
+    expect(result.tokens_evaluated).toBeUndefined();
+    expect(result.tokens_predicted).toBe(7);
+  });
+
   it('returns no timings when server does not provide them', async () => {
     const resultPromise = streamChatCompletion(
       {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
@@ -849,6 +895,9 @@ describe('streamChatCompletion', () => {
 
     const result = await resultPromise;
     expect(result.timings).toBeUndefined();
+    // No timings → prompt count unset, predicted keeps the per-event tally.
+    expect(result.tokens_evaluated).toBeUndefined();
+    expect(result.tokens_predicted).toBe(1);
   });
 
   it('rejects immediately if signal already aborted', async () => {

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -1038,6 +1038,30 @@ describe('streamChatCompletion', () => {
     expect(result.tokens_predicted).toBe(7);
   });
 
+  it('guards each timings token key independently (only prompt_n)', async () => {
+    const resultPromise = streamChatCompletion(
+      {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
+      'http://localhost:1234',
+    );
+
+    const xhr = MockXHR.instances[0];
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+    );
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"prompt_n":3000}}\n\n',
+    );
+    xhr.simulateProgress('data: [DONE]\n\n');
+    xhr.simulateLoad();
+
+    const result = await resultPromise;
+    // prompt_n sets tokens_evaluated; absent predicted_n must NOT zero the
+    // per-event tally — it keeps the single content-bearing event count.
+    expect(result.tokens_evaluated).toBe(3000);
+    expect(result.tokens_predicted).toBe(1);
+  });
+
   it('returns no timings when server does not provide them', async () => {
     const resultPromise = streamChatCompletion(
       {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -7,6 +7,7 @@ import {
   ReasoningIntent,
   ToolCall,
 } from '../utils/completionTypes';
+import {ServerConfig} from '../utils/types';
 
 /** Raw API response shape from OpenAI /v1/models */
 export interface RemoteModelInfo {
@@ -276,11 +277,15 @@ export async function fetchModels(
   return models;
 }
 
-/** Server capabilities discovered from llama.cpp GET /props. */
-export interface ServerProps {
-  contextLength?: number;
-  supportsVision?: boolean;
-}
+/**
+ * Server capabilities discovered from llama.cpp GET /props. Coupled to
+ * ServerConfig so a field rename breaks compile instead of silently
+ * no-opping the ServerStore write.
+ */
+export type ServerProps = Pick<
+  ServerConfig,
+  'contextLength' | 'supportsVision'
+>;
 
 /**
  * Fetch server capabilities from a llama.cpp server's GET /props endpoint.
@@ -317,12 +322,14 @@ export async function fetchServerProps(
     const data = await response.json();
     const contextLength: unknown =
       data?.default_generation_settings?.n_ctx ?? data?.n_ctx;
-    const props: ServerProps = {};
+    // supportsVision is always defined (true or false) on a 2xx probe so a
+    // model swap that drops vision overwrites a stale true; a failed probe
+    // returns {} below and leaves caps untouched.
+    const props: ServerProps = {
+      supportsVision: data?.modalities?.vision === true,
+    };
     if (typeof contextLength === 'number') {
       props.contextLength = contextLength;
-    }
-    if (data?.modalities?.vision === true) {
-      props.supportsVision = true;
     }
     return props;
   } catch {

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -358,6 +358,12 @@ export async function testConnection(
 
 const DETECT_TIMEOUT_MS = 5000;
 
+// Bound the detached /props capability probe. /props is a tiny local JSON that
+// llama.cpp serves instantly, so 5 s is generous; it mirrors the server-type
+// detect probe. Passed explicitly rather than omitted — omitting resolves to
+// CONNECTION_TIMEOUT_MS (30 s), which would not bound a fire-and-forget probe.
+export const PROPS_TIMEOUT_MS = 5000;
+
 /**
  * Detect server type from response headers and model metadata.
  * Checks (cheapest first):

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -497,46 +497,133 @@ function hasLocalImageAttachment(messages: OpenAIChatMessage[]): boolean {
   );
 }
 
+// Skip inlining a file larger than this — base64 inflates ~33% and the whole
+// buffer is held in memory, so a huge attachment would spike heap on low-RAM
+// devices. The image is left unchanged and the server surfaces the failure.
+const REMOTE_IMAGE_MAX_BYTES = 12 * 1024 * 1024;
+
+// Bound the encode-once cache by total encoded-string bytes (evict-oldest)
+// rather than entry count: a handful of large base64 buffers must not pin
+// excessive resident heap.
+const REMOTE_IMAGE_CACHE_BYTES = 24 * 1024 * 1024;
+
+// Extension → data-URI MIME. A bare `image/${ext}` produced invalid types
+// (image/jpg, image// for dotless / content:// paths). Unknown extensions fall
+// back to image/jpeg.
+const EXT_MIME: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  heic: 'image/heic',
+  heif: 'image/heif',
+  bmp: 'image/bmp',
+};
+
+function mimeForPath(path: string): string {
+  const ext = path.toLowerCase().split('.').pop() ?? '';
+  return EXT_MIME[ext] ?? 'image/jpeg';
+}
+
+// Encoded local images keyed by path so a multi-turn history re-sends without
+// re-reading each file from disk (chat.ts re-emits the same stored path across
+// turns, so a history image encodes at most once).
+const remoteImageCache = new Map<string, string>();
+let remoteImageCacheBytes = 0;
+
+function cacheRemoteImage(path: string, dataUri: string): void {
+  if (remoteImageCache.has(path)) {
+    return;
+  }
+  remoteImageCache.set(path, dataUri);
+  remoteImageCacheBytes += dataUri.length;
+  for (const [oldestPath, oldestUri] of remoteImageCache) {
+    if (remoteImageCacheBytes <= REMOTE_IMAGE_CACHE_BYTES) {
+      break;
+    }
+    remoteImageCache.delete(oldestPath);
+    remoteImageCacheBytes -= oldestUri.length;
+  }
+}
+
+/** Test-only: reset the encode-once remote-image cache between cases. */
+export function __clearRemoteImageCache(): void {
+  remoteImageCache.clear();
+  remoteImageCacheBytes = 0;
+}
+
+/**
+ * Encode a single content part's local image path to a data URI. Returns the
+ * part unchanged when it is not a local image, when a successful stat reports
+ * an over-cap file, or when the read fails. A stat throw or a size-less result
+ * FALLS THROUGH to encoding so a healthy image is never dropped on a stat
+ * hiccup — only a successful over-cap stat skips.
+ */
+async function encodeImagePart(part: {
+  type: string;
+  text?: string;
+  image_url?: {url?: string};
+}): Promise<typeof part> {
+  const url = part.image_url?.url;
+  if (!isLocalImageUrl(url)) {
+    return part;
+  }
+  const path = url.replace(/^file:\/\//, '');
+
+  const cached = remoteImageCache.get(path);
+  if (cached) {
+    return {...part, image_url: {url: cached}};
+  }
+
+  try {
+    const info = await RNFS.stat(path);
+    if (typeof info?.size === 'number' && info.size > REMOTE_IMAGE_MAX_BYTES) {
+      return part;
+    }
+  } catch {
+    // stat unavailable — encode anyway rather than drop a healthy image.
+  }
+
+  try {
+    const base64 = await RNFS.readFile(path, 'base64');
+    const dataUri = `data:${mimeForPath(path)};base64,${base64}`;
+    cacheRemoteImage(path, dataUri);
+    return {...part, image_url: {url: dataUri}};
+  } catch (error) {
+    // Leave the part unchanged; the server surfaces the failure on the
+    // existing completion-error path.
+    console.warn('Failed to encode image for remote server:', error);
+    return part;
+  }
+}
+
 /**
  * Encode local image attachments to data: URIs for the remote wire. A remote
  * server cannot read the device filesystem, so any image_url pointing at a
  * local path is read and inlined as base64. Already-remote (http/https) or
  * already-inlined (data:) urls pass through unchanged. Remote-only: the local
  * llama.rn engine reads the file path natively and never routes through here.
+ *
+ * Encodes sequentially (outer messages and inner parts) so peak heap is one
+ * base64 buffer at a time on a long or multi-image history.
  */
 async function encodeMessagesForRemote(
   messages: OpenAIChatMessage[],
 ): Promise<OpenAIChatMessage[]> {
-  return Promise.all(
-    messages.map(async message => {
-      if (!Array.isArray(message.content)) {
-        return message;
-      }
-      const content = await Promise.all(
-        message.content.map(async part => {
-          const url = part.image_url?.url;
-          if (!isLocalImageUrl(url)) {
-            return part;
-          }
-          const path = url.replace(/^file:\/\//, '');
-          try {
-            const base64 = await RNFS.readFile(path, 'base64');
-            const ext = path.toLowerCase().split('.').pop() || 'jpg';
-            return {
-              ...part,
-              image_url: {url: `data:image/${ext};base64,${base64}`},
-            };
-          } catch (error) {
-            // Leave the part unchanged; the server surfaces the failure on the
-            // existing completion-error path.
-            console.warn('Failed to encode image for remote server:', error);
-            return part;
-          }
-        }),
-      );
-      return {...message, content};
-    }),
-  );
+  const encoded: OpenAIChatMessage[] = [];
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      encoded.push(message);
+      continue;
+    }
+    const content: typeof message.content = [];
+    for (const part of message.content) {
+      content.push(await encodeImagePart(part));
+    }
+    encoded.push({...message, content});
+  }
+  return encoded;
 }
 
 export async function streamChatCompletion(

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -274,6 +274,62 @@ export async function fetchModels(
   return models;
 }
 
+/** Server capabilities discovered from llama.cpp GET /props. */
+export interface ServerProps {
+  contextLength?: number;
+  supportsVision?: boolean;
+}
+
+/**
+ * Fetch server capabilities from a llama.cpp server's GET /props endpoint.
+ * Pure: parses the response into caps and never throws — a timeout, non-2xx,
+ * or malformed body resolves to `{}` so the caller's models path and
+ * connection are never affected. `/props` is llama.cpp-specific; callers gate
+ * on serverType before invoking.
+ *
+ * Key names verified against a live llama.cpp build (b9910): context window is
+ * `default_generation_settings.n_ctx` (top-level `n_ctx` is an older-build
+ * fallback); vision is `modalities.vision`.
+ */
+export async function fetchServerProps(
+  serverUrl: string,
+  apiKey?: string,
+  timeoutMs?: number,
+): Promise<ServerProps> {
+  const url = `${normalizeUrl(serverUrl)}/props`;
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    resolveTimeout(timeoutMs, CONNECTION_TIMEOUT_MS),
+  );
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: buildHeaders(apiKey),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {};
+    }
+    const data = await response.json();
+    const contextLength: unknown =
+      data?.default_generation_settings?.n_ctx ?? data?.n_ctx;
+    const props: ServerProps = {};
+    if (typeof contextLength === 'number') {
+      props.contextLength = contextLength;
+    }
+    if (data?.modalities?.vision === true) {
+      props.supportsVision = true;
+    }
+    return props;
+  } catch {
+    return {};
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /**
  * Test connection to an OpenAI-compatible server.
  * Returns ok status and model count.

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -1,3 +1,5 @@
+import * as RNFS from '@dr.pogodin/react-native-fs';
+
 import {SSEParser} from './sseParser';
 import {
   CompletionResult,
@@ -469,6 +471,67 @@ export function buildReasoningPayload(
   }
 }
 
+/** A local image path needs inlining: not already a data: or http(s): url. */
+function isLocalImageUrl(url: string | undefined): url is string {
+  return (
+    !!url &&
+    !url.startsWith('data:') &&
+    !url.startsWith('http://') &&
+    !url.startsWith('https://')
+  );
+}
+
+/** True when any message carries a local-path image that must be encoded. */
+function hasLocalImageAttachment(messages: OpenAIChatMessage[]): boolean {
+  return messages.some(
+    m =>
+      Array.isArray(m.content) &&
+      m.content.some(part => isLocalImageUrl(part.image_url?.url)),
+  );
+}
+
+/**
+ * Encode local image attachments to data: URIs for the remote wire. A remote
+ * server cannot read the device filesystem, so any image_url pointing at a
+ * local path is read and inlined as base64. Already-remote (http/https) or
+ * already-inlined (data:) urls pass through unchanged. Remote-only: the local
+ * llama.rn engine reads the file path natively and never routes through here.
+ */
+async function encodeMessagesForRemote(
+  messages: OpenAIChatMessage[],
+): Promise<OpenAIChatMessage[]> {
+  return Promise.all(
+    messages.map(async message => {
+      if (!Array.isArray(message.content)) {
+        return message;
+      }
+      const content = await Promise.all(
+        message.content.map(async part => {
+          const url = part.image_url?.url;
+          if (!isLocalImageUrl(url)) {
+            return part;
+          }
+          const path = url.replace(/^file:\/\//, '');
+          try {
+            const base64 = await RNFS.readFile(path, 'base64');
+            const ext = path.toLowerCase().split('.').pop() || 'jpg';
+            return {
+              ...part,
+              image_url: {url: `data:image/${ext};base64,${base64}`},
+            };
+          } catch (error) {
+            // Leave the part unchanged; the server surfaces the failure on the
+            // existing completion-error path.
+            console.warn('Failed to encode image for remote server:', error);
+            return part;
+          }
+        }),
+      );
+      return {...message, content};
+    }),
+  );
+}
+
 export async function streamChatCompletion(
   params: StreamChatParams,
   serverUrl: string,
@@ -481,6 +544,12 @@ export async function streamChatCompletion(
   const url = `${normalizeUrl(serverUrl)}/v1/chat/completions`;
   const connectionTimeoutMs = resolveTimeout(timeoutMs, CONNECTION_TIMEOUT_MS);
   const idleTimeoutMs = resolveTimeout(timeoutMs, IDLE_TIMEOUT_MS);
+  // Only pay the async encode when a local image is actually attached; the
+  // common text path stays synchronous so callers see the request built in the
+  // same tick.
+  const encodedMessages = hasLocalImageAttachment(params.messages)
+    ? await encodeMessagesForRemote(params.messages)
+    : params.messages;
 
   return new Promise<CompletionResult>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -823,7 +892,7 @@ export async function streamChatCompletion(
     // with newer models) reject unsupported or empty params with 400 errors.
     const requestBody: Record<string, any> = {
       model: params.model,
-      messages: params.messages,
+      messages: encodedMessages,
       stream: true,
     };
     if (params.temperature != null) {

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -698,7 +698,11 @@ export async function streamChatCompletion(
         content: fullContent,
         reasoning_content: fullReasoningContent || undefined,
         tool_calls: finalToolCalls,
-        tokens_predicted: tokensPredicted,
+        // llama.cpp reports authoritative token counts on `timings`; the server
+        // count wins over the per-event tally. Each field is guarded on its own
+        // key so a server that emits only one does not zero the other.
+        tokens_evaluated: serverTimings?.prompt_n,
+        tokens_predicted: serverTimings?.predicted_n ?? tokensPredicted,
         timings: serverTimings,
       };
 

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -215,12 +215,16 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
       ? (talentNames[heavyTalentName as keyof typeof talentNames] ??
         heavyTalentName)
       : undefined;
-    const fullText = heavyTalentLabel
-      ? t(l10n.chat.contextFullHeavyTalent, {talent: heavyTalentLabel})
-      : chatSessionStore.consecutiveFullFailures >= 2
-        ? l10n.chat.contextFullEscalated
-        : isRemote
-          ? l10n.chat.contextFullRemote
+    // Remote wins over every local variant: the escalated and heavy-talent
+    // copies both carry the "increase the context size" advice, but a remote
+    // model has no in-app context control, so remote always gets the single
+    // remote copy (no increase clause) regardless of failure count / talent.
+    const fullText = isRemote
+      ? l10n.chat.contextFullRemote
+      : heavyTalentLabel
+        ? t(l10n.chat.contextFullHeavyTalent, {talent: heavyTalentLabel})
+        : chatSessionStore.consecutiveFullFailures >= 2
+          ? l10n.chat.contextFullEscalated
           : l10n.chat.contextFull;
 
     return (

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -8,7 +8,7 @@ import {createStyles} from './styles';
 
 import {AlertIcon} from '../../assets/icons';
 import {useTheme} from '../../hooks';
-import {chatSessionStore, modelStore} from '../../store';
+import {chatSessionStore, modelStore, serverStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {MessageType, ModelOrigin} from '../../utils/types';
 import {resolveBannerVariant} from '../../utils/bannerVariantResolver';
@@ -101,12 +101,24 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
     };
 
     const activeModel = modelStore.activeModel;
+    const isRemote = activeModel?.origin === ModelOrigin.REMOTE;
+
+    // activeContextSettings.n_ctx is local-only (set by a LlamaContext). For a
+    // remote model fall back to the server's /props-reported contextLength so
+    // the context banners can measure against a real window.
+    const localNCtx = modelStore.activeContextSettings?.n_ctx;
+    const effectiveNCtx =
+      localNCtx ??
+      (isRemote
+        ? serverStore.servers.find(s => s.id === activeModel?.serverId)
+            ?.contextLength
+        : undefined);
 
     const {variant, heavyTalentName, ratio} = resolveBannerVariant(
       chatSessionStore.lastCompletionResult,
       {
-        effectiveNCtx: modelStore.activeContextSettings?.n_ctx,
-        isRemote: activeModel?.origin === ModelOrigin.REMOTE,
+        effectiveNCtx,
+        isRemote,
         htmlPreviewCount,
         activeModelId: modelStore.activeModelId,
         dismissed: chatSessionStore.dismissedBannerVariants,

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -219,7 +219,9 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
       ? t(l10n.chat.contextFullHeavyTalent, {talent: heavyTalentLabel})
       : chatSessionStore.consecutiveFullFailures >= 2
         ? l10n.chat.contextFullEscalated
-        : l10n.chat.contextFull;
+        : isRemote
+          ? l10n.chat.contextFullRemote
+          : l10n.chat.contextFull;
 
     return (
       <View

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -6,7 +6,7 @@ import {fireEvent, render} from '../../../../jest/test-utils';
 import {L10nContext} from '../../../utils';
 import {ModelOrigin} from '../../../utils/types';
 import {l10n} from '../../../locales';
-import {chatSessionStore, modelStore} from '../../../store';
+import {chatSessionStore, modelStore, serverStore} from '../../../store';
 
 import {BannerRow} from '../BannerRow';
 
@@ -206,6 +206,79 @@ describe('BannerRow', () => {
 
     runInAction(() => {
       modelStore.models = [];
+    });
+  });
+
+  it('resolves context-full for a remote model from the server-reported contextLength', () => {
+    runInAction(() => {
+      modelStore.activeModelId = 'remote-1';
+      modelStore.models = [
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
+      ];
+      // Remote models never set activeContextSettings.n_ctx; the window must
+      // come from the server's /props-reported contextLength (cross-store read).
+      (modelStore as any).activeContextSettings = undefined;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+          contextLength: 4096,
+        } as any,
+      ];
+      chatSessionStore.lastCompletionResult = {
+        used: 4096,
+        contextFull: true,
+        isRemote: true,
+        finishReason: 'length',
+      };
+    });
+    const {getByTestId} = renderBanner();
+    // effectiveNCtx must be derived from serverStore.contextLength for the
+    // context-full branch (and its meter) to render at all for a remote model.
+    expect(getByTestId('context-full-banner')).toBeTruthy();
+    expect(
+      getByTestId('banner-meter', {includeHiddenElements: true}),
+    ).toBeTruthy();
+
+    runInAction(() => {
+      modelStore.models = [];
+      serverStore.servers = [];
+    });
+  });
+
+  it('resolves the near-limit warning + meter percent for a remote model', () => {
+    runInAction(() => {
+      modelStore.activeModelId = 'remote-1';
+      modelStore.models = [
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
+      ];
+      (modelStore as any).activeContextSettings = undefined;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+          contextLength: 4096,
+        } as any,
+      ];
+      chatSessionStore.lastCompletionResult = {
+        used: 3300,
+        contextFull: false,
+        isRemote: true,
+      };
+    });
+    const {getByTestId} = renderBanner();
+    expect(getByTestId('context-warning-banner')).toBeTruthy();
+    // 3300 / 4096 ≈ 80.6% → the meter percent proves the ratio measured
+    // against the server window, not the weak remote heuristic.
+    expect(getByTestId('banner-percent')).toHaveTextContent('81%');
+
+    runInAction(() => {
+      modelStore.models = [];
+      serverStore.servers = [];
     });
   });
 

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -248,6 +248,54 @@ describe('BannerRow', () => {
     });
   });
 
+  it('uses the remote context-full copy (no increase clause) for a remote model', () => {
+    runInAction(() => {
+      modelStore.activeModelId = 'remote-1';
+      modelStore.models = [
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
+      ];
+      (modelStore as any).activeContextSettings = undefined;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+          contextLength: 4096,
+        } as any,
+      ];
+      chatSessionStore.lastCompletionResult = {
+        used: 4096,
+        contextFull: true,
+        isRemote: true,
+        finishReason: 'length',
+      };
+    });
+    const {getByText, queryByText} = renderBanner({canIncrease: false});
+    // Remote copy drops "or increase the context size" — the increase CTA is
+    // hidden for remote (no client-side control).
+    expect(getByText(l10n.en.chat.contextFullRemote)).toBeTruthy();
+    expect(queryByText(l10n.en.chat.contextFull)).toBeNull();
+
+    runInAction(() => {
+      modelStore.models = [];
+      serverStore.servers = [];
+    });
+  });
+
+  it('keeps the device context-full copy for a local model', () => {
+    runInAction(() => {
+      chatSessionStore.lastCompletionResult = {
+        used: 4096,
+        contextFull: true,
+        isRemote: false,
+      };
+    });
+    const {getByText, queryByText} = renderBanner({canIncrease: true});
+    expect(getByText(l10n.en.chat.contextFull)).toBeTruthy();
+    expect(queryByText(l10n.en.chat.contextFullRemote)).toBeNull();
+  });
+
   it('resolves the near-limit warning + meter percent for a remote model', () => {
     runInAction(() => {
       modelStore.activeModelId = 'remote-1';

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -177,6 +177,56 @@ describe('BannerRow', () => {
     expect(getByText(l10n.en.chat.contextFullEscalated)).toBeTruthy();
   });
 
+  it('keeps the remote copy (no increase clause) for a remote model at the escalated failure count', () => {
+    runInAction(() => {
+      modelStore.activeModelId = 'remote-1';
+      modelStore.models = [
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
+      ];
+      (modelStore as any).activeContextSettings = undefined;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+          contextLength: 4096,
+        } as any,
+      ];
+      // A remote session can reach >=2 consecutive full turns (the counter is
+      // remote-agnostic), but must not re-surface the escalated increase advice.
+      chatSessionStore.consecutiveFullFailures = 2;
+      chatSessionStore.lastCompletionResult = {
+        used: 4096,
+        contextFull: true,
+        isRemote: true,
+        finishReason: 'length',
+      };
+    });
+    const {getByText, queryByText} = renderBanner({canIncrease: false});
+    expect(getByText(l10n.en.chat.contextFullRemote)).toBeTruthy();
+    expect(queryByText(l10n.en.chat.contextFullEscalated)).toBeNull();
+
+    runInAction(() => {
+      modelStore.models = [];
+      serverStore.servers = [];
+    });
+  });
+
+  it('keeps the escalated copy for a local model at the escalated failure count', () => {
+    runInAction(() => {
+      chatSessionStore.consecutiveFullFailures = 2;
+      chatSessionStore.lastCompletionResult = {
+        used: 4096,
+        contextFull: true,
+        isRemote: false,
+      };
+    });
+    const {getByText, queryByText} = renderBanner();
+    expect(getByText(l10n.en.chat.contextFullEscalated)).toBeTruthy();
+    expect(queryByText(l10n.en.chat.contextFullRemote)).toBeNull();
+  });
+
   it('renders the remote hedged advisory for a remote model with no runtime n_ctx', () => {
     runInAction(() => {
       modelStore.activeModelId = 'remote-1';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1145,6 +1145,7 @@
     "contextWarning": "This conversation is getting long and may soon run out of room.",
     "contextRemoteHedged": "This reply may have been cut off. Try sending again or shortening the request.",
     "contextFull": "The conversation ran out of room. Start a new chat or increase the context size.",
+    "contextFullRemote": "The conversation ran out of room. Start a new chat.",
     "contextFullEscalated": "Still out of room. Start a new chat, or increase the context size to keep going.",
     "contextFullHeavyTalent": "The conversation ran out of room — {{talent}} tends to need more. Start a new chat or increase the context size.",
     "contextBannerDismiss": "Dismiss",

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2855,6 +2855,19 @@ class ModelStore {
       return true;
     }
 
+    // Remote models have no local context; their vision capability comes from
+    // the active server's /props self-report. releaseContext clears both
+    // context and the cached flag on switch, so this is never stale-true for a
+    // remote model. Placed before the !context early-return so a remote model
+    // is not shadowed into that dead branch.
+    if (!this.context && this.activeModel?.origin === ModelOrigin.REMOTE) {
+      const serverId = this.activeModel?.serverId;
+      return (
+        serverStore.servers.find(s => s.id === serverId)?.supportsVision ===
+        true
+      );
+    }
+
     // Avoid "Context not found" errors during transitions
     if (!this.context || this.isContextLoading) {
       return false;

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -4,7 +4,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {makePersistable} from 'mobx-persist-store';
 import * as Keychain from 'react-native-keychain';
 
-import {fetchModels, testConnection, RemoteModelInfo} from '../api/openai';
+import {
+  fetchModels,
+  fetchServerProps,
+  testConnection,
+  RemoteModelInfo,
+} from '../api/openai';
 import {ServerConfig} from '../utils/types';
 import {ReasoningCapability} from '../utils/reasoningCapability';
 
@@ -216,6 +221,28 @@ class ServerStore {
           s.lastConnected = Date.now();
         }
       });
+
+      // llama.cpp serves GET /props with the context window and vision
+      // capability. Fetch is best-effort and llama.cpp-only: fetchServerProps
+      // never throws, so a /props failure cannot break the models path or the
+      // connection. Other server types skip it entirely (no request).
+      if (server.serverType === 'llama.cpp') {
+        const props = await fetchServerProps(
+          server.url,
+          apiKey,
+          server.requestTimeoutMs,
+        );
+        if (
+          props.contextLength !== undefined ||
+          props.supportsVision !== undefined
+        ) {
+          runInAction(() => {
+            // updateServer re-finds by id, so a delete-during-fetch race is a
+            // no-op rather than a stale write to a removed server.
+            this.updateServer(serverId, props);
+          });
+        }
+      }
     } catch (error: any) {
       runInAction(() => {
         this.error = error.message || 'Failed to fetch models';

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -9,6 +9,7 @@ import {
   fetchServerProps,
   testConnection,
   RemoteModelInfo,
+  PROPS_TIMEOUT_MS,
 } from '../api/openai';
 import {ServerConfig} from '../utils/types';
 import {ReasoningCapability} from '../utils/reasoningCapability';
@@ -223,25 +224,32 @@ class ServerStore {
       });
 
       // llama.cpp serves GET /props with the context window and vision
-      // capability. Fetch is best-effort and llama.cpp-only: fetchServerProps
-      // never throws, so a /props failure cannot break the models path or the
-      // connection. Other server types skip it entirely (no request).
+      // capability. Detached (fire-and-forget) so a slow/hung probe can't hold
+      // the add-server sheet in the saving state: fetchModelsForServer resolves
+      // as soon as the models list is stored. Best-effort and llama.cpp-only;
+      // the bounded PROPS_TIMEOUT_MS caps the detached probe. Other server
+      // types skip it entirely (no request).
       if (server.serverType === 'llama.cpp') {
-        const props = await fetchServerProps(
-          server.url,
-          apiKey,
-          server.requestTimeoutMs,
-        );
-        if (
-          props.contextLength !== undefined ||
-          props.supportsVision !== undefined
-        ) {
-          runInAction(() => {
-            // updateServer re-finds by id, so a delete-during-fetch race is a
-            // no-op rather than a stale write to a removed server.
-            this.updateServer(serverId, props);
-          });
-        }
+        (async () => {
+          const props = await fetchServerProps(
+            server.url,
+            apiKey,
+            PROPS_TIMEOUT_MS,
+          );
+          if (
+            props.contextLength !== undefined ||
+            props.supportsVision !== undefined
+          ) {
+            runInAction(() => {
+              // updateServer re-finds by id, so a delete-during-fetch race is a
+              // no-op rather than a stale write to a removed server.
+              this.updateServer(serverId, props);
+            });
+          }
+        })().catch(() => {
+          // Defense-in-depth: fetchServerProps never throws today; swallow to
+          // satisfy no-floating-promises on the detached probe.
+        });
       }
     } catch (error: any) {
       runInAction(() => {

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -2326,6 +2326,55 @@ describe('ModelStore', () => {
       consoleErrorSpy.mockRestore();
     });
 
+    describe('remote model vision (server /props self-report)', () => {
+      const setRemoteActive = (supportsVision?: boolean) => {
+        runInAction(() => {
+          modelStore.context = undefined;
+          modelStore.isMultimodalActive = false;
+          modelStore.models = [
+            {
+              id: 'srv-1/remote-model',
+              origin: ModelOrigin.REMOTE,
+              serverId: 'srv-1',
+            } as any,
+          ];
+          modelStore.activeModelId = 'srv-1/remote-model';
+          serverStore.servers = [
+            {
+              id: 'srv-1',
+              name: 'llama',
+              url: 'http://localhost:8080',
+              serverType: 'llama.cpp',
+              supportsVision,
+            },
+          ];
+        });
+      };
+
+      afterEach(() => {
+        runInAction(() => {
+          serverStore.servers = [];
+          modelStore.models = [];
+          modelStore.activeModelId = undefined;
+        });
+      });
+
+      it('returns true when the active server reports vision', async () => {
+        setRemoteActive(true);
+        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(true);
+      });
+
+      it('returns false when the active server does not report vision', async () => {
+        setRemoteActive(false);
+        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
+      });
+
+      it('returns false when the server capability is unprobed', async () => {
+        setRemoteActive(undefined);
+        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
+      });
+    });
+
     it('should get compatible projection models from explicit list', () => {
       const llmModel = {
         id: 'test-llm',

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -621,6 +621,37 @@ describe('ServerStore', () => {
       expect(server!.supportsVision).toBeUndefined();
     });
 
+    it('clears a stale supportsVision true when a later probe reports false', async () => {
+      const id = serverStore.addServer({
+        name: 'llama server',
+        url: 'http://localhost:8080',
+        serverType: 'llama.cpp',
+      });
+      jest.clearAllMocks();
+
+      mockedFetchModels.mockResolvedValue([]);
+      (Keychain.getGenericPassword as jest.Mock).mockResolvedValue(false);
+
+      mockedFetchServerProps.mockResolvedValueOnce({
+        contextLength: 4096,
+        supportsVision: true,
+      });
+      await serverStore.fetchModelsForServer(id);
+      await new Promise(setImmediate);
+      expect(serverStore.servers.find(s => s.id === id)!.supportsVision).toBe(
+        true,
+      );
+
+      // A model swap drops vision: the always-defined false overwrites the
+      // stale true so attach disables.
+      mockedFetchServerProps.mockResolvedValueOnce({supportsVision: false});
+      await serverStore.fetchModelsForServer(id);
+      await new Promise(setImmediate);
+      const server = serverStore.servers.find(s => s.id === id);
+      expect(server!.supportsVision).toBe(false);
+      expect(server!.contextLength).toBe(4096);
+    });
+
     it('leaves caps unchanged and models intact when /props yields nothing', async () => {
       const id = serverStore.addServer({
         name: 'llama server',

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../api/openai', () => ({
   fetchModels: jest.fn(),
   fetchServerProps: jest.fn(),
   testConnection: jest.fn(),
+  PROPS_TIMEOUT_MS: 5000,
 }));
 
 // Mock AppState.addEventListener
@@ -592,14 +593,45 @@ describe('ServerStore', () => {
 
       await serverStore.fetchModelsForServer(id);
 
+      // The /props probe is bounded by PROPS_TIMEOUT_MS (5000), not the
+      // server's requestTimeoutMs or the omitted 30 s default.
       expect(mockedFetchServerProps).toHaveBeenCalledWith(
         'http://localhost:8080',
         undefined,
-        undefined,
+        5000,
       );
+      // The probe is detached: fetchModelsForServer resolves before caps land,
+      // so the write is only observable after a microtask flush.
+      await new Promise(setImmediate);
       const server = serverStore.servers.find(s => s.id === id);
       expect(server!.contextLength).toBe(4096);
       expect(server!.supportsVision).toBe(true);
+    });
+
+    it('resolves fetchModelsForServer without waiting on the /props probe', async () => {
+      const id = serverStore.addServer({
+        name: 'llama server',
+        url: 'http://localhost:8080',
+        serverType: 'llama.cpp',
+      });
+      jest.clearAllMocks();
+
+      const mockModels = [{id: 'm', object: 'model', owned_by: 'system'}];
+      mockedFetchModels.mockResolvedValueOnce(mockModels);
+      // A /props probe that never settles must not block the resolution.
+      let released: (v: {supportsVision: boolean}) => void = () => {};
+      mockedFetchServerProps.mockReturnValueOnce(
+        new Promise(resolve => {
+          released = resolve;
+        }),
+      );
+      (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
+
+      await serverStore.fetchModelsForServer(id);
+
+      // Models are present immediately even though the probe is still pending.
+      expect(serverStore.serverModels.get(id)).toEqual(mockModels);
+      released({supportsVision: true});
     });
 
     it('does not fetch /props for a non-llama.cpp server', async () => {

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -12,6 +12,7 @@ jest.mock('mobx-persist-store', () => ({
 
 jest.mock('../../api/openai', () => ({
   fetchModels: jest.fn(),
+  fetchServerProps: jest.fn(),
   testConnection: jest.fn(),
 }));
 
@@ -25,6 +26,7 @@ jest
 import {serverStore} from '../ServerStore';
 
 const mockedFetchModels = openaiModule.fetchModels as jest.Mock;
+const mockedFetchServerProps = openaiModule.fetchServerProps as jest.Mock;
 const mockedTestConnection = openaiModule.testConnection as jest.Mock;
 
 describe('ServerStore', () => {
@@ -571,6 +573,75 @@ describe('ServerStore', () => {
 
       const server = serverStore.servers.find(s => s.id === id);
       expect(server!.lastConnected).toBeGreaterThanOrEqual(before);
+    });
+
+    it('fetches /props and writes discovered caps for a llama.cpp server', async () => {
+      const id = serverStore.addServer({
+        name: 'llama server',
+        url: 'http://localhost:8080',
+        serverType: 'llama.cpp',
+      });
+      jest.clearAllMocks();
+
+      mockedFetchModels.mockResolvedValueOnce([]);
+      mockedFetchServerProps.mockResolvedValueOnce({
+        contextLength: 4096,
+        supportsVision: true,
+      });
+      (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
+
+      await serverStore.fetchModelsForServer(id);
+
+      expect(mockedFetchServerProps).toHaveBeenCalledWith(
+        'http://localhost:8080',
+        undefined,
+        undefined,
+      );
+      const server = serverStore.servers.find(s => s.id === id);
+      expect(server!.contextLength).toBe(4096);
+      expect(server!.supportsVision).toBe(true);
+    });
+
+    it('does not fetch /props for a non-llama.cpp server', async () => {
+      const id = serverStore.addServer({
+        name: 'LM Studio',
+        url: 'http://localhost:1234',
+        serverType: 'LM Studio',
+      });
+      jest.clearAllMocks();
+
+      mockedFetchModels.mockResolvedValueOnce([]);
+      (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
+
+      await serverStore.fetchModelsForServer(id);
+
+      expect(mockedFetchServerProps).not.toHaveBeenCalled();
+      const server = serverStore.servers.find(s => s.id === id);
+      expect(server!.contextLength).toBeUndefined();
+      expect(server!.supportsVision).toBeUndefined();
+    });
+
+    it('leaves caps unchanged and models intact when /props yields nothing', async () => {
+      const id = serverStore.addServer({
+        name: 'llama server',
+        url: 'http://localhost:8080',
+        serverType: 'llama.cpp',
+      });
+      jest.clearAllMocks();
+
+      const mockModels = [{id: 'm', object: 'model', owned_by: 'system'}];
+      mockedFetchModels.mockResolvedValueOnce(mockModels);
+      // Silent no-op: fetchServerProps swallows timeout/500/bad-JSON into {}.
+      mockedFetchServerProps.mockResolvedValueOnce({});
+      (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
+
+      await serverStore.fetchModelsForServer(id);
+
+      expect(serverStore.serverModels.get(id)).toEqual(mockModels);
+      expect(serverStore.error).toBeNull();
+      const server = serverStore.servers.find(s => s.id === id);
+      expect(server!.contextLength).toBeUndefined();
+      expect(server!.supportsVision).toBeUndefined();
     });
   });
 

--- a/src/utils/__tests__/bannerVariantResolver.test.ts
+++ b/src/utils/__tests__/bannerVariantResolver.test.ts
@@ -124,10 +124,18 @@ describe('resolveBannerVariant', () => {
       expect(result.variant).toBe('none');
     });
 
-    it('does not fire for remote sessions', () => {
+    it('fires for a remote session once its context window is known', () => {
       const result = resolveBannerVariant(
         snap({used: 3277, isRemote: true}),
-        baseInput({isRemote: true}),
+        baseInput({isRemote: true, effectiveNCtx: 4096}),
+      );
+      expect(result.variant).toBe('context-warning');
+    });
+
+    it('does not fire for a remote session without a known context window', () => {
+      const result = resolveBannerVariant(
+        snap({used: 3277, isRemote: true}),
+        baseInput({isRemote: true, effectiveNCtx: undefined}),
       );
       expect(result.variant).not.toBe('context-warning');
     });
@@ -200,6 +208,50 @@ describe('resolveBannerVariant', () => {
           effectiveNCtx: undefined,
           activeModelId: undefined,
         }),
+      );
+      expect(result.variant).toBe('none');
+    });
+  });
+
+  describe('remote llama.cpp context banners (relaxed)', () => {
+    // A length-truncation at the server's real window resolves context-full,
+    // the same machinery a local model uses.
+    it('resolves context-full on a remote length truncation at the window', () => {
+      const result = resolveBannerVariant(
+        snap({
+          isRemote: true,
+          contextFull: true,
+          finishReason: 'length',
+          used: 4096,
+        }),
+        baseInput({isRemote: true, effectiveNCtx: 4096}),
+      );
+      expect(result.variant).toBe('context-full');
+      expect(result.ratio).toBe(1);
+    });
+
+    // A near-limit remote turn (>0.8 of the window) resolves context-warning.
+    it('resolves context-warning near the remote window', () => {
+      const result = resolveBannerVariant(
+        snap({isRemote: true, used: 7000}),
+        baseInput({isRemote: true, effectiveNCtx: 8192}),
+      );
+      expect(result.variant).toBe('context-warning');
+      expect(result.ratio).toBeCloseTo(7000 / 8192, 3);
+    });
+
+    // A length cap from a small user max_tokens (well below the window) fails
+    // the freshness gate, and hedged excludes length — so no banner.
+    it('shows no false full banner for a max_tokens length cap', () => {
+      const result = resolveBannerVariant(
+        snap({
+          isRemote: true,
+          contextFull: true,
+          finishReason: 'length',
+          tokensPredicted: 256,
+          used: 300,
+        }),
+        baseInput({isRemote: true, effectiveNCtx: 32768}),
       );
       expect(result.variant).toBe('none');
     });

--- a/src/utils/bannerVariantResolver.ts
+++ b/src/utils/bannerVariantResolver.ts
@@ -82,9 +82,10 @@ export function resolveBannerVariant(
         };
       }
 
-      // 2. context-warning — local, near the limit, dismissable per draft.
+      // 2. context-warning — near the limit, dismissable per draft. Admits
+      // remote llama.cpp too: the outer effectiveNCtx gate only passes for a
+      // remote model once its /props contextLength is known.
       if (
-        !isRemote &&
         !snapshot.contextFull &&
         snapshot.used / nCtx >= WARNING_THRESHOLD &&
         !dismissed.has('context-warning')

--- a/src/utils/completionTypes.ts
+++ b/src/utils/completionTypes.ts
@@ -100,6 +100,10 @@ export interface CompletionResult {
     predicted_ms?: number;
     prompt_per_second?: number;
     prompt_ms?: number;
+    // llama.cpp token counts: prompt (eval) and generated. Source the remote
+    // snapshot's used-token total from these.
+    prompt_n?: number;
+    predicted_n?: number;
     [key: string]: number | undefined;
   };
   tokens_predicted?: number;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -478,6 +478,10 @@ export interface ServerConfig {
     | 'OpenAI'
     | 'vLLM'
     | string;
+  // Server-reported capabilities discovered from llama.cpp GET /props.
+  // ServerStore is the sole writer; undefined = unknown/not probed.
+  contextLength?: number; // /props n_ctx
+  supportsVision?: boolean; // /props modalities.vision
 }
 
 export enum ModelType {


### PR DESCRIPTION
## Summary

Remote (OpenAI-compatible) models can be pointed at a self-hosted **llama.cpp** server. Two features were already coded but gated to on-device models only, and remote token counts were under-reported. This wires a `GET {baseUrl}/props` capability probe on llama.cpp servers and uses the response to unlock them:

- **Remote vision** — when `/props` reports `modalities.vision === true`, the chat image-attach affordance is enabled and attached images are inlined as `data:` URIs on the wire (a remote server cannot read the device filesystem). A non-vision server keeps attach disabled.
- **Remote context banners** — the server's real context window (`default_generation_settings.n_ctx`, top-level `n_ctx` fallback) drives the near-limit and context-full banners for remote models, replacing the weak hedged advisory. Length-truncation routes through the freshness-gated context-full branch, so a small `max_tokens` cap shows no false "context full".
- **Accurate remote token count (bug fix)** — remote completions now source `tokens_evaluated` / `tokens_predicted` from the llama.cpp `timings` object (`prompt_n` / `predicted_n`) already emitted on the finish chunk, so the context-usage ratio is correct instead of counting generated tokens only.

`/props` is llama.cpp-specific. It is fetched **only** when the persisted `serverType === 'llama.cpp'`; other server types (LM Studio / Ollama / vLLM / OpenAI) issue no `/props` request. The probe is best-effort — a timeout, non-2xx, or malformed body is a silent no-op that never breaks the models fetch or the connection. New `ServerConfig.contextLength` / `supportsVision` fields are optional and ride the already-persisted servers list, so old configs hydrate unchanged with no migration.

## Trust boundary

Remote vision is enabled purely from the server's `/props` self-report. This is the user's own configured server, and images already leave the device to it by the user's own attach action, so no new trust boundary is crossed. No separate remote-vision override ships here; the escape hatch is "don't attach an image," and a non-vision server's 400 surfaces on the existing completion-error path.

## Video-pal (real-time camera) note — considered and safe

`isMultimodalEnabled()` is the single read-point for both the one-shot chat image-attach path and the real-time video-pal camera path. Only the chat image-attach path is affected here: the video-pal `handleStartCamera` returns early on `!modelStore.context`, which a remote model always is, so the remote branch of `isMultimodalEnabled()` never reaches camera start. Only one-shot chat image-attach gains remote vision.

## Testing

- JS/TS-only change; no native surface touched (no `package.json` / `ios/` / `android/` / Podfile / gradle). No native build gate applies.
- 380 unit tests green across the touched suites (openai, ServerStore, ModelStore, bannerVariantResolver, BannerRow); typecheck + lint clean; coverage above threshold on every touched file.
- `/props` key names and `timings` token keys were pinned against a live llama.cpp build (vision `modalities.vision`, context `default_generation_settings.n_ctx`, tokens `prompt_n`/`predicted_n`), with an end-to-end proof: a real vision server answered "Red." about an attached `data:`-URI image. Visual evidence attached in a follow-up comment.

## Architecture docs

The cumulative architecture library (`context/architecture/remote-servers.md`, `chat-flow.md`, `model-loading.md`) lives in the team's control-plane repo, not in this app repo, so the same-PR doc update for this behaviour change was committed there alongside this branch rather than in this diff. The deltas cover: the two new `ServerConfig` capability fields + the `/props` discovery section and single-writer rule (remote-servers), the relaxed remote banner invariant + precedence and the `timings` token source (chat-flow), and the `isMultimodalEnabled` remote fallback with the `data:`-URI wire encoding (model-loading).

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
