### PR TITLE
[Bug]: add NSLocalNetworkUsageDescription for local-network prompt

### DIFF
--- a/ios/PocketPal/Info.plist
+++ b/ios/PocketPal/Info.plist
@@ -58,6 +58,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>PocketPal uses your camera to capture images and video for local AI analysis only. All processing happens on your device and no images are transmitted to external servers.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>PocketPal connects to AI servers you run on your own network (like Ollama or llama.cpp) when you add them as remote endpoints.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>PocketPal accesses your photo library to select images for local AI analysis only. Selected images are processed entirely on your device and are never transmitted to external servers.</string>
 	<key>NSSiriUsageDescription</key>


### PR DESCRIPTION
## Summary

iOS users running a local AI server (Ollama, llama.cpp) on their own network could not connect from PocketPal. On iOS 18.x, when an app's Info.plist lacks `NSLocalNetworkUsageDescription`, the system silently denies Local Network access: no permission prompt appears, the toggle in Settings → Privacy & Security → Local Network stays off, and requests fail with NSURLError -1009. Manually enabling the Settings toggle was the only workaround (reported by a user on r/PocketPal).

The fix adds the missing usage-description key to `ios/PocketPal/Info.plist`:

> PocketPal connects to AI servers you run on your own network (like Ollama or llama.cpp) when you add them as remote endpoints.

No behavioral code changes and no new dependencies. Intentionally not added:

- `NSBonjourServices` — the app makes only direct HTTP requests to user-configured endpoints; there is no mDNS/Bonjour/zeroconf usage (verified by grep across `src/` and `ios/`).
- Key in any other plist — `ios/PocketPal/Info.plist` is the only app-target plist; App Intents compile into the main target and no extension bundles exist.
- `InfoPlist.strings` localization — the project does not localize its other usage-description keys, so a plain string follows the existing style.

## Verification

- `pod install` — clean, `Podfile.lock` unchanged
- iOS Release build — succeeded; `plutil -extract NSLocalNetworkUsageDescription raw` on the built `PocketPal.app/Info.plist` returns the exact string
- Android release build — succeeded (functionally unaffected; build gate only)
- `yarn lint` / `yarn typecheck` — pass
- Full Jest suite — 247/247 suites, 3740 passed (2 pre-existing skips); coverage 75.5% statements / 70.0% branches

## Suggested manual QA

On a physical iOS device (especially iOS 18.x), add a local endpoint (e.g. Ollama on a Mac) and confirm the Local Network prompt appears with the new text on first connection, and that the connection succeeds after allowing.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
