### PR TITLE
[Feat]: Add Polish and European Portuguese

### DIFF
--- a/e2e/specs/features/language.spec.ts
+++ b/e2e/specs/features/language.spec.ts
@@ -57,6 +57,16 @@ const LANGUAGE_ASSERTIONS: Record<
     screenTitle: 'Tetapan',
     firstCardTitle: 'Tetapan Permulaan Model',
   },
+  pl: {
+    screenTitle: 'Ustawienia',
+    firstCardTitle: 'Ustawienia Inicjalizacji Modelu',
+  },
+  // pt shares both of these strings with pt_BR, so this spec proves the switch
+  // works but not that the two locales are distinct — locales.test.ts covers that.
+  pt: {
+    screenTitle: 'Configurações',
+    firstCardTitle: 'Configurações de Inicialização do Modelo',
+  },
   pt_BR: {
     screenTitle: 'Configurações',
     firstCardTitle: 'Configurações de Inicialização do Modelo',
@@ -80,7 +90,7 @@ const LANGUAGE_ASSERTIONS: Record<
 };
 
 // Order: start with non-English, end with English to restore default state
-const LANGUAGE_ORDER = ['fa', 'he', 'id', 'ja', 'ko', 'ms', 'pt_BR', 'ru', 'uk', 'zh', 'zh_Hant', 'en'];
+const LANGUAGE_ORDER = ['fa', 'he', 'id', 'ja', 'ko', 'ms', 'pl', 'pt', 'pt_BR', 'ru', 'uk', 'zh', 'zh_Hant', 'en'];
 
 describe('Language Switching', () => {
   let chatPage: ChatPage;

--- a/scripts/__tests__/verify-fonts.test.js
+++ b/scripts/__tests__/verify-fonts.test.js
@@ -177,6 +177,23 @@ describe('verify-fonts.js', () => {
     expect(result.output).toContain("add 'pl' to NON_LATIN_LOCALES");
   });
 
+  it('refuses to declare success when NON_LATIN_LOCALES cannot be parsed', () => {
+    // The glyph check is regex-driven, so the parse-failure branch is the
+    // safety net for the whole design: it must exit non-zero rather than
+    // quietly skipping coverage.
+    const src = fs.readFileSync(TYPOGRAPHY_PATH, 'utf-8');
+    const mangled = src.replace(
+      'NON_LATIN_LOCALES: ReadonlyArray<AvailableLanguage> = [',
+      'NON_LATIN_LOCALES = [',
+    );
+    expect(mangled).not.toBe(src);
+    const result = runWithOverrides({
+      files: {'src/theme/tokens/typography.ts': mangled},
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output).toContain('refusing to declare success');
+  });
+
   it('fails when typography.ts references an unknown family', () => {
     // Inject a reference to 'Comic-Sans-Regular' (or any name) by
     // appending a fake constant assignment. The script's regex will pick

--- a/scripts/__tests__/verify-fonts.test.js
+++ b/scripts/__tests__/verify-fonts.test.js
@@ -24,6 +24,7 @@ const ANDROID_DIR = path.join(
   'fonts',
 );
 const INFO_PLIST = path.join(ROOT, 'ios', 'PocketPal', 'Info.plist');
+const LOCALES_DIR = path.join(ROOT, 'src', 'locales');
 
 /**
  * Run verify-fonts.js against a temp workspace. The temp workspace
@@ -43,6 +44,7 @@ function runWithOverrides(overrides = {}) {
       {recursive: true},
     );
     fs.mkdirSync(path.join(tmp, 'ios', 'PocketPal'), {recursive: true});
+    fs.mkdirSync(path.join(tmp, 'src', 'locales'), {recursive: true});
 
     fs.copyFileSync(
       TYPOGRAPHY_PATH,
@@ -65,6 +67,15 @@ function runWithOverrides(overrides = {}) {
       INFO_PLIST,
       path.join(tmp, 'ios', 'PocketPal', 'Info.plist'),
     );
+    // index.ts + the locale JSONs feed the headline glyph-coverage check.
+    for (const f of fs.readdirSync(LOCALES_DIR)) {
+      if (f === 'index.ts' || f.endsWith('.json')) {
+        fs.copyFileSync(
+          path.join(LOCALES_DIR, f),
+          path.join(tmp, 'src', 'locales', f),
+        );
+      }
+    }
 
     // Apply overrides — relative paths.
     for (const [relPath, content] of Object.entries(overrides.files || {})) {
@@ -149,6 +160,21 @@ describe('verify-fonts.js', () => {
     expect(result.output).toContain(
       'JetBrainsMono-Regular: missing <string>JetBrainsMono-Regular.ttf</string>',
     );
+  });
+
+  it('fails when a Fraunces-rendered locale needs glyphs the subset lacks', () => {
+    // Drop 'pl' from NON_LATIN_LOCALES. Polish is Latin script but needs
+    // Latin Extended-A, which the bundled Fraunces subset does not carry,
+    // so headlines would render with missing glyphs.
+    const src = fs.readFileSync(TYPOGRAPHY_PATH, 'utf-8');
+    const withoutPl = src.replace(/^\s*'pl',\n/m, '');
+    expect(withoutPl).not.toBe(src);
+    const result = runWithOverrides({
+      files: {'src/theme/tokens/typography.ts': withoutPl},
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output).toContain('not in the bundled Fraunces subset');
+    expect(result.output).toContain("add 'pl' to NON_LATIN_LOCALES");
   });
 
   it('fails when typography.ts references an unknown family', () => {

--- a/scripts/sync-weblate.js
+++ b/scripts/sync-weblate.js
@@ -60,6 +60,8 @@ async function downloadTranslations() {
     'ja',
     'ko',
     'ms',
+    'pl',
+    'pt',
     'pt_BR',
     'ru',
     'uk',

--- a/scripts/verify-fonts.js
+++ b/scripts/verify-fonts.js
@@ -111,6 +111,146 @@ function plistTtfNames(plistPath) {
   return out;
 }
 
+/**
+ * Read a TrueType `cmap` and return the set of covered codepoints.
+ * Handles subtable formats 4 and 12, which is everything our TTFs use.
+ */
+function fontCodepoints(ttfPath) {
+  const buf = fs.readFileSync(ttfPath);
+  const numTables = buf.readUInt16BE(4);
+  let cmapOff = null;
+  for (let i = 0; i < numTables; i++) {
+    const rec = 12 + 16 * i;
+    if (buf.toString('ascii', rec, rec + 4) === 'cmap') {
+      cmapOff = buf.readUInt32BE(rec + 8);
+    }
+  }
+  if (cmapOff === null) {
+    throw new Error(`${path.basename(ttfPath)}: no cmap table`);
+  }
+
+  const covered = new Set();
+  const numSub = buf.readUInt16BE(cmapOff + 2);
+  for (let i = 0; i < numSub; i++) {
+    const off = cmapOff + buf.readUInt32BE(cmapOff + 4 + 8 * i + 4);
+    const format = buf.readUInt16BE(off);
+    if (format === 4) {
+      const segX2 = buf.readUInt16BE(off + 6);
+      const seg = segX2 / 2;
+      const endsAt = off + 14;
+      const startsAt = off + 16 + segX2;
+      for (let s = 0; s < seg; s++) {
+        const start = buf.readUInt16BE(startsAt + 2 * s);
+        const end = buf.readUInt16BE(endsAt + 2 * s);
+        if (start === 0xffff) {
+          continue;
+        }
+        for (let c = start; c <= end && c !== 0x10000; c++) {
+          covered.add(c);
+        }
+      }
+    } else if (format === 12) {
+      const nGroups = buf.readUInt32BE(off + 12);
+      for (let g = 0; g < nGroups; g++) {
+        const go = off + 16 + 12 * g;
+        const start = buf.readUInt32BE(go);
+        const end = Math.min(buf.readUInt32BE(go + 4), 0x2fff);
+        for (let c = start; c <= end; c++) {
+          covered.add(c);
+        }
+      }
+    }
+  }
+  return covered;
+}
+
+const LETTER_RE = /\p{L}/u;
+
+function localeLetters(localeJsonPath) {
+  const used = new Set();
+  const walk = node => {
+    if (typeof node === 'string') {
+      for (const ch of node) {
+        if (LETTER_RE.test(ch)) {
+          used.add(ch.codePointAt(0));
+        }
+      }
+    } else if (node && typeof node === 'object') {
+      for (const v of Object.values(node)) {
+        walk(v);
+      }
+    }
+  };
+  walk(JSON.parse(fs.readFileSync(localeJsonPath, 'utf-8')));
+  return used;
+}
+
+/**
+ * Every wired locale NOT listed in NON_LATIN_LOCALES must have all of its
+ * letters covered by the bundled Fraunces subset, because those locales
+ * render headlines in Fraunces. Locales that ARE listed fall back to Inter
+ * and are exempt.
+ *
+ * This exists because the Fraunces subset stops at Latin-1: Polish is Latin
+ * script but needs Latin Extended-A, so "it's Latin, it's fine" is wrong.
+ * Only letters are checked — shared punctuation (— • … → ✓) is absent from
+ * Fraunces for every locale including `en`, and is not a regression.
+ */
+function verifyHeadlineGlyphCoverage() {
+  const localesDir = path.join(ROOT, 'src', 'locales');
+  const indexPath = path.join(localesDir, 'index.ts');
+  const fraunces = path.join(ASSETS_DIR, 'Fraunces-Regular.ttf');
+  // A missing Fraunces asset is already reported by the bundling check;
+  // don't crash here and mask it.
+  if (!fs.existsSync(indexPath) || !fs.existsSync(fraunces)) {
+    return [];
+  }
+  const indexSrc = fs.readFileSync(indexPath, 'utf-8');
+  const typographySrc = fs.readFileSync(TYPOGRAPHY_PATH, 'utf-8');
+
+  const registryBlock = indexSrc.match(
+    /const languageRegistry = \{([\s\S]*?)\n\} as const;/,
+  );
+  const exemptBlock = typographySrc.match(
+    /NON_LATIN_LOCALES: ReadonlyArray<AvailableLanguage> = \[([\s\S]*?)\];/,
+  );
+  if (!registryBlock || !exemptBlock) {
+    console.error(
+      'verify-fonts: could not parse languageRegistry / NON_LATIN_LOCALES — refusing to declare success.',
+    );
+    process.exit(2);
+  }
+
+  const wired = [...registryBlock[1].matchAll(/^\s*(\w+):/gm)].map(m => m[1]);
+  const exempt = new Set(
+    [...exemptBlock[1].matchAll(/'([^']+)'/g)].map(m => m[1]),
+  );
+
+  const covered = fontCodepoints(fraunces);
+  const errors = [];
+  for (const lang of wired) {
+    if (exempt.has(lang)) {
+      continue;
+    }
+    const jsonPath = path.join(localesDir, `${lang}.json`);
+    if (!fs.existsSync(jsonPath)) {
+      continue;
+    }
+    const missing = [...localeLetters(jsonPath)].filter(c => !covered.has(c));
+    if (missing.length > 0) {
+      const sample = missing
+        .slice(0, 20)
+        .map(c => String.fromCodePoint(c))
+        .join('');
+      errors.push(
+        `${lang}: ${missing.length} letter(s) not in the bundled Fraunces subset (${sample}) — ` +
+          `add '${lang}' to NON_LATIN_LOCALES in src/theme/tokens/typography.ts so headlines fall back to Inter`,
+      );
+    }
+  }
+  return errors;
+}
+
 function main() {
   const families = new Set([
     ...extractFontFamilies(TYPOGRAPHY_PATH),
@@ -150,6 +290,8 @@ function main() {
     console.log('  ' + name);
   }
 
+  errors.push(...verifyHeadlineGlyphCoverage());
+
   if (errors.length > 0) {
     console.error('\nverify-fonts: FAIL');
     for (const e of errors) {
@@ -158,7 +300,10 @@ function main() {
     process.exit(1);
   }
 
-  console.log('\nverify-fonts: OK — all families bundled on all platforms.');
+  console.log(
+    '\nverify-fonts: OK — all families bundled on all platforms, ' +
+      'and every Fraunces-rendered locale is covered by the bundled subset.',
+  );
 }
 
 main();

--- a/scripts/verify-fonts.js
+++ b/scripts/verify-fonts.js
@@ -114,6 +114,12 @@ function plistTtfNames(plistPath) {
 /**
  * Read a TrueType `cmap` and return the set of covered codepoints.
  * Handles subtable formats 4 and 12, which is everything our TTFs use.
+ *
+ * Simplification: format-4 segments are treated as fully covered without
+ * resolving idDelta/idRangeOffset, so a codepoint a segment maps to glyph 0
+ * (.notdef) would count as covered. Verified against a glyph-resolving parser
+ * across all bundled TTFs with zero divergence, but it is the one direction
+ * this check could fail *unsafe* — revisit if a font vendor/cut changes.
  */
 function fontCodepoints(ttfPath) {
   const buf = fs.readFileSync(ttfPath);
@@ -154,6 +160,10 @@ function fontCodepoints(ttfPath) {
       for (let g = 0; g < nGroups; g++) {
         const go = off + 16 + 12 * g;
         const start = buf.readUInt32BE(go);
+        // Cap the scan: only low-BMP letters matter for this check and a
+        // format-12 group can span a huge range (emoji, CJK Ext).
+        // Under-reporting coverage is safe — it can only produce a spurious
+        // "add to NON_LATIN_LOCALES" failure, never a false pass.
         const end = Math.min(buf.readUInt32BE(go + 4), 0x2fff);
         for (let c = start; c <= end; c++) {
           covered.add(c);
@@ -195,14 +205,28 @@ function localeLetters(localeJsonPath) {
  * script but needs Latin Extended-A, so "it's Latin, it's fine" is wrong.
  * Only letters are checked — shared punctuation (— • … → ✓) is absent from
  * Fraunces for every locale including `en`, and is not a regression.
+ *
+ * Deliberately over-approximate: it scans the whole locale JSON, not just the
+ * strings that land in headline slots. So one stray non-Latin-1 letter in a
+ * body string would push an otherwise-fine locale onto the fallback list and
+ * cost it the serif headline. That trade is intentional — mapping keys to
+ * headline slots is brittle, and a false fallback is cosmetic while a false
+ * pass ships tofu.
  */
 function verifyHeadlineGlyphCoverage() {
   const localesDir = path.join(ROOT, 'src', 'locales');
   const indexPath = path.join(localesDir, 'index.ts');
-  const fraunces = path.join(ASSETS_DIR, 'Fraunces-Regular.ttf');
+  // Headlines use Regular, Medium and the italics, so require coverage in
+  // every cut — a future re-cut of one weight would otherwise slip past.
+  const frauncesCuts = fs.existsSync(ASSETS_DIR)
+    ? fs
+        .readdirSync(ASSETS_DIR)
+        .filter(n => /^Fraunces-.*\.ttf$/.test(n))
+        .map(n => path.join(ASSETS_DIR, n))
+    : [];
   // A missing Fraunces asset is already reported by the bundling check;
   // don't crash here and mask it.
-  if (!fs.existsSync(indexPath) || !fs.existsSync(fraunces)) {
+  if (!fs.existsSync(indexPath) || frauncesCuts.length === 0) {
     return [];
   }
   const indexSrc = fs.readFileSync(indexPath, 'utf-8');
@@ -226,7 +250,12 @@ function verifyHeadlineGlyphCoverage() {
     [...exemptBlock[1].matchAll(/'([^']+)'/g)].map(m => m[1]),
   );
 
-  const covered = fontCodepoints(fraunces);
+  // Intersection across cuts: a letter counts as covered only if every
+  // Fraunces weight can render it.
+  const perCut = frauncesCuts.map(fontCodepoints);
+  const covered = new Set(
+    [...perCut[0]].filter(c => perCut.every(set => set.has(c))),
+  );
   const errors = [];
   for (const lang of wired) {
     if (exempt.has(lang)) {

--- a/src/hooks/__tests__/useTheme.test.tsx
+++ b/src/hooks/__tests__/useTheme.test.tsx
@@ -11,7 +11,7 @@ import {useTheme} from '../useTheme';
 import {uiStore} from '../../store';
 
 import {darkTheme, lightTheme} from '../../utils/theme';
-import {FONT_FAMILIES} from '../../theme/tokens';
+import {FONT_FAMILIES, NON_LATIN_LOCALES} from '../../theme/tokens';
 
 describe('useTheme', () => {
   beforeEach(() => {
@@ -109,11 +109,10 @@ describe('useTheme', () => {
       }
     });
 
-    it('headlineH1 swaps for every non-Latin / non-Latin-script locale', () => {
-      const fallbackLocales: Array<
-        'fa' | 'he' | 'ja' | 'ko' | 'ru' | 'uk' | 'zh' | 'zh_Hant'
-      > = ['fa', 'he', 'ja', 'ko', 'ru', 'uk', 'zh', 'zh_Hant'];
-      for (const lang of fallbackLocales) {
+    it('headlineH1 swaps for every Fraunces-fallback locale', () => {
+      // Derived, not hand-listed — a hardcoded copy silently rots when a
+      // locale joins the fallback set (as pl did).
+      for (const lang of NON_LATIN_LOCALES) {
         uiStore.setLanguage(lang);
         const {result} = renderHook(() => useTheme());
         expect(result.current.typography.headlineH1.fontFamily).toBe(

--- a/src/locales/__tests__/locales.test.ts
+++ b/src/locales/__tests__/locales.test.ts
@@ -46,6 +46,8 @@ const ALL_LANGUAGES: AvailableLanguage[] = [
   'ja',
   'ko',
   'ms',
+  'pl',
+  'pt',
   'pt_BR',
   'ru',
   'uk',
@@ -85,6 +87,8 @@ describe('l10n object', () => {
     'ja',
     'ko',
     'ms',
+    'pl',
+    'pt',
     'pt_BR',
     'ru',
     'uk',
@@ -106,6 +110,8 @@ describe('l10n object', () => {
     'ja',
     'ko',
     'ms',
+    'pl',
+    'pt',
     'pt_BR',
     'ru',
     'uk',
@@ -156,6 +162,8 @@ describe('l10n object', () => {
     expect('ja' in l10n).toBe(true);
     expect('ko' in l10n).toBe(true);
     expect('ms' in l10n).toBe(true);
+    expect('pl' in l10n).toBe(true);
+    expect('pt' in l10n).toBe(true);
     expect('pt_BR' in l10n).toBe(true);
     expect('ru' in l10n).toBe(true);
     expect('uk' in l10n).toBe(true);
@@ -221,6 +229,8 @@ describe('exports', () => {
     expect(languageDisplayNames.ja).toBe('\u65E5\u672C\u8A9E (JA)');
     expect(languageDisplayNames.ko).toBe('\uD55C\uAD6D\uC5B4 (KO)');
     expect(languageDisplayNames.ms).toBe('Melayu (MS)');
+    expect(languageDisplayNames.pl).toBe('Polski (PL)');
+    expect(languageDisplayNames.pt).toBe('Português (PT)');
     expect(languageDisplayNames.pt_BR).toBe('Português (PT_BR)');
     expect(languageDisplayNames.ru).toBe(
       '\u0420\u0443\u0441\u0441\u043A\u0438\u0439 (RU)',
@@ -231,6 +241,15 @@ describe('exports', () => {
     expect(languageDisplayNames.zh).toBe('\u4E2D\u6587 (ZH)');
     expect(languageDisplayNames.zh_Hant).toBe(
       '\u7E41\u9AD4\u4E2D\u6587 (ZH_HANT)',
+    );
+  });
+
+  it('resolves pt and pt_BR to different translations', () => {
+    // European vs Brazilian Portuguese are separate locales, and their
+    // Settings header strings happen to be identical — so a wiring mistake
+    // that pointed both at one JSON would not show up on screen.
+    expect(l10n.pt.settings.useMmapDescription).not.toBe(
+      l10n.pt_BR.settings.useMmapDescription,
     );
   });
 
@@ -267,6 +286,8 @@ describe('lazy loading', () => {
     'ja',
     'ko',
     'ms',
+    'pl',
+    'pt',
     'pt_BR',
     'ru',
     'uk',
@@ -326,6 +347,8 @@ describe('type safety', () => {
       'ja',
       'ko',
       'ms',
+      'pl',
+      'pt',
       'pt_BR',
       'ru',
       'uk',

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -7,7 +7,12 @@ import type {Translations} from './types';
 
 // ─── Language Registry (single source of truth) ──────────────────────
 // To add a language: 1) add entry here, 2) place JSON in src/locales/,
-// 3) add case to requireLanguageData(), 4) add getter to l10n object.
+// 3) add case to requireLanguageData(), 4) add getter to l10n object,
+// 5) add the dayjs locale to initLocale(), 6) run `yarn verify:fonts` — if it
+// reports letters missing from the bundled Fraunces subset, add the locale to
+// NON_LATIN_LOCALES in src/theme/tokens/typography.ts so headlines fall back
+// to Inter. Step 6 is not optional and not decidable by eye: Polish is Latin
+// script but still needs the fallback.
 const languageRegistry = {
   en: {displayName: 'English (EN)'},
   fa: {displayName: 'فارسی (FA)'},

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -16,6 +16,8 @@ const languageRegistry = {
   ja: {displayName: '日本語 (JA)'},
   ko: {displayName: '한국어 (KO)'},
   ms: {displayName: 'Melayu (MS)'},
+  pl: {displayName: 'Polski (PL)'},
+  pt: {displayName: 'Português (PT)'},
   pt_BR: {displayName: 'Português (PT_BR)'},
   ru: {displayName: 'Русский (RU)'},
   uk: {displayName: 'Українська (UK)'},
@@ -36,6 +38,8 @@ export const languageDisplayNames: Record<AvailableLanguage, string> = {
   ja: languageRegistry.ja.displayName,
   ko: languageRegistry.ko.displayName,
   ms: languageRegistry.ms.displayName,
+  pl: languageRegistry.pl.displayName,
+  pt: languageRegistry.pt.displayName,
   pt_BR: languageRegistry.pt_BR.displayName,
   ru: languageRegistry.ru.displayName,
   uk: languageRegistry.uk.displayName,
@@ -63,6 +67,10 @@ function requireLanguageData(lang: AvailableLanguage): object | null {
       return require('./ko.json');
     case 'ms':
       return require('./ms.json');
+    case 'pl':
+      return require('./pl.json');
+    case 'pt':
+      return require('./pt.json');
     case 'pt_BR':
       return require('./pt_BR.json');
     case 'ru':
@@ -120,6 +128,12 @@ export const l10n = {
   get ms(): Translations {
     return getTranslations('ms');
   },
+  get pl(): Translations {
+    return getTranslations('pl');
+  },
+  get pt(): Translations {
+    return getTranslations('pt');
+  },
   get pt_BR(): Translations {
     return getTranslations('pt_BR');
   },
@@ -165,6 +179,8 @@ export const initLocale = (locale?: AvailableLanguage) => {
     ja: require('dayjs/locale/ja'),
     ko: require('dayjs/locale/ko'),
     ms: require('dayjs/locale/ms'),
+    pl: require('dayjs/locale/pl'),
+    pt: require('dayjs/locale/pt'),
     pt_BR: require('dayjs/locale/pt-br'),
     ru: require('dayjs/locale/ru'),
     uk: require('dayjs/locale/uk'),

--- a/src/store/__tests__/UIStore.test.ts
+++ b/src/store/__tests__/UIStore.test.ts
@@ -104,6 +104,8 @@ describe('UIStore', () => {
         'ja',
         'ko',
         'ms',
+        'pl',
+        'pt',
         'pt_BR',
         'ru',
         'uk',

--- a/src/theme/tokens/__tests__/typography.test.ts
+++ b/src/theme/tokens/__tests__/typography.test.ts
@@ -47,7 +47,10 @@ describe('typography tokens', () => {
   });
 
   describe('Latin locales render Fraunces', () => {
-    const latinLocales: AvailableLanguage[] = ['en', 'id', 'ms'];
+    // pt / pt_BR are load-bearing here: Portuguese diacritics are all Latin-1
+    // and covered by the bundled Fraunces subset, so these locales must NOT
+    // fall back to Inter the way pl does.
+    const latinLocales: AvailableLanguage[] = ['en', 'id', 'ms', 'pt', 'pt_BR'];
 
     it.each(latinLocales)(
       'headlineH1 in %s resolves to Fraunces-Medium at 36 / 50',

--- a/src/theme/tokens/typography.ts
+++ b/src/theme/tokens/typography.ts
@@ -38,22 +38,31 @@ export const FONT_FAMILIES = {
 } as const;
 
 /**
- * Locales whose primary script is not covered by the bundled Fraunces
- * font subset. For these, Fraunces tokens fall back to Inter (which
- * covers Latin + Cyrillic) so the headline renders in a known family
- * instead of an unpredictable system fallback for missing glyphs.
+ * Locales whose script is not covered by the bundled Fraunces font
+ * subset. For these, Fraunces tokens fall back to Inter (which covers
+ * Latin + Latin Extended-A + Cyrillic) so the headline renders in a
+ * known family instead of an unpredictable system fallback for missing
+ * glyphs.
  *
  * Why Cyrillic (ru, uk) is on this list: the bundled Fraunces TTFs are
  * the Latin-only subset from Fontsource and contain no Cyrillic
  * codepoints. CJK / Hebrew / Arabic / Persian / Hangul are intentionally
  * not bundled — Inter passes those glyphs through to the platform
  * system font.
+ *
+ * Why Polish is on this list despite being Latin script: that Fraunces
+ * subset stops at Latin-1 and has no Latin Extended-A, so it is missing
+ * ą ć ę ł ń ś ź ż and their capitals — 16 of Polish's 18 diacritics.
+ * The membership test is glyph coverage, not script family; check a new
+ * locale's characters against the bundled TTFs before omitting it here.
+ * Portuguese needs only Latin-1 (ã õ ç á é í ó ú â ê ô à) and is covered.
  */
 export const NON_LATIN_LOCALES: ReadonlyArray<AvailableLanguage> = [
   'fa',
   'he',
   'ja',
   'ko',
+  'pl',
   'ru',
   'uk',
   'zh',


### PR DESCRIPTION
Wires Polish (`pl`) and European Portuguese (`pt`) into the language registry. Both locale files already landed via Weblate; this makes them selectable.

| locale | key coverage | translated |
| --- | --- | --- |
| `pl` | 97.0% | 93.1% |
| `pt` | 94.0% | 90.9% |

Untranslated keys fall back to English through `_.merge(enData, langData)`, so partial coverage degrades gracefully.

## Polish needs the Inter fallback

`pl` is added to `NON_LATIN_LOCALES` even though Polish is Latin script. The bundled Fraunces TTFs are the Latin-only Fontsource subset (199 codepoints) and stop at Latin-1 — they carry no Latin Extended-A, so `ą ć ę ł ń ś ź ż` and their capitals are missing: 16 of Polish's 18 diacritics. Verified by parsing the `cmap` table of `src/assets/fonts/Fraunces-{Regular,Medium}.ttf`. Inter covers all of them.

Without this, every Polish headline would render with missing glyphs. Portuguese needs only Latin-1 and stays on Fraunces.

The membership test for that list is **glyph coverage, not script family**. `yarn verify:fonts` now enforces it: for every wired locale not exempt, each letter used in its JSON must exist in the bundled Fraunces subset. Only letters are checked — the shared `— • … → ✓` punctuation is absent from Fraunces for every locale including `en` and is not a regression. A negative test in `scripts/__tests__/verify-fonts.test.js` removes `pl` from the exempt list and asserts the check fails.

## pt vs pt_BR

These are genuinely distinct locales, not duplicates: `ficheiros`/`arquivos`, `detetado`/`detectado`, `pormenores`/`detalhes`, enclitic `guia-o`/`te guia`; 25 `settings.*` keys differ. They happen to share both Settings header strings, so the e2e language spec cannot tell them apart — a unit test asserts they resolve to different translations instead of adding a scroll-dependent (flaky) e2e assertion.

## Verification

- `yarn test` — 262 suites, 3943 passed, 0 failed
- `yarn lint` — 0 errors; `yarn typecheck` — clean
- `yarn verify:fonts` — passes, and fails as expected when `pl` is removed from the exempt list
- `yarn l10n:validate` — all locale files valid
- Not a native change: no `package.json`, native module, `ios/`, `android/`, Podfile or build.gradle edits. Fonts already ship.

Visual evidence in a follow-up comment.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)