### PR TITLE
chore(deps): upgrade llama.rn 0.12.4 to 0.12.7

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.4):
+  - llama-rn (0.12.7):
     - boost
     - DoubleConversion
     - fast_float
@@ -3751,7 +3751,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 94584e5009b0d435dbc56f3cca4503da46829484
+  llama-rn: 98cb15ad698ad6264e4e9e7064500f8b66f88d05
   onnxruntime-c: 4a1a1a81da2087869dc9b6357f182952db2df29c
   onnxruntime-react-native: 4451eff6b1aa60589186c6a8422d436fba6a9192
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
     "expr-eval": "^2.0.2",
-    "llama.rn": "0.12.4",
+    "llama.rn": "0.12.7",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6520,10 +6520,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.4:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.4.tgz#3bb0fca305f1c2d03827359afc6ee04d65cf6818"
-  integrity sha512-53oQKv2rzYbsSfFMONcj+KnFfAJ9S5gO9l1FyRi35Zmh8PeLUa7Zzh0FUQ6/+LwZH5SYnCulMeA94GS+ls/y7w==
+llama.rn@0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.7.tgz#20f90bebb3c4f1d26594948a088fec3e32efd416"
+  integrity sha512-n18BLz9g2OuxIyZ9p2Y4ml8C1e0c8xrvNGPL3DIK9pKDp56sZtDSWLOzDMUWfsyVYSVRnbCMmQvGkIX/8YV6Og==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Upgrades `llama.rn` from 0.12.4 to 0.12.7. Dependency bump only — no source changes.

Files: `package.json`, `yarn.lock`, `ios/Podfile.lock`.

## Upstream changes absorbed

- **0.12.5** — sync llama.cpp to b9769, Gemma MTP support.
- **0.12.6** — sync llama.cpp to b9982; fixes: well-formed UTF-8 in generated text, mtmd input text length init, blocking MTP generation timings, trim undecoded final token on stop-word/token-budget stop.
- **0.12.7** — sync llama.cpp to b10054; KV cache reuse across chat turns (recurrent / hybrid / SWA + multimodal).

## Verification

Native (`NATIVE_CHANGES=YES`): `pod install`, iOS build, and Android build all succeed.

- Typecheck clean; unit suite green (262 suites, 3929 tests).
- `quick-smoke` green on iOS simulator and Android emulator, with real inference on SmolLM2-135M (116 tok/s iOS, 295 tok/s Android).
- Feature E2E green on both platforms: context-banner, download-cancel, draft-autosave, graded-effort-override, hub-run, language, pal-greeting, remote-reasoning, remote-server, talent-tool-use, thinking, thinking-pal-override.

Not covered, for environment reasons unrelated to this change:

- `onboarding` — passes per-test in isolation; the spec has no per-test state reset, so tests after the first fail once onboarding is completed. Pre-existing, reproduces independently of this upgrade.
- `remote-vision` — the test server reports `modalities.vision=false` (started without `--mmproj`), so image-attach is correctly disabled.
- `purchase-flow` — store/backend not reachable in this environment.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)