### PR TITLE
[Feat]: Searchable language picker in Settings

### DIFF
--- a/__mocks__/external/@gorhom/bottom-sheet.js
+++ b/__mocks__/external/@gorhom/bottom-sheet.js
@@ -23,7 +23,18 @@ const BottomSheetBase = React.forwardRef((props, ref) => {
 // Mock FlatList that actually renders items
 const BottomSheetFlatList = React.forwardRef((props, ref) => {
   React.useImperativeHandle(ref, createMockRef, []);
-  const {data, renderItem, keyExtractor, ...restProps} = props;
+  const {data, renderItem, keyExtractor, ListEmptyComponent, ...restProps} =
+    props;
+
+  if (!data?.length && ListEmptyComponent) {
+    return React.createElement(
+      View,
+      {...restProps},
+      React.isValidElement(ListEmptyComponent)
+        ? ListEmptyComponent
+        : React.createElement(ListEmptyComponent),
+    );
+  }
 
   return React.createElement(
     View,

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -384,6 +384,12 @@ export const Selectors = {
     get languageSelectorButton(): string {
       return byTestId('language-selector-button');
     },
+    get languageSheet(): string {
+      return byTestId('language-sheet');
+    },
+    get languageSearch(): string {
+      return byTestId('language-search');
+    },
     get displayMemoryUsageSwitch(): string {
       return byTestId('display-memory-usage-switch');
     },

--- a/e2e/pages/SettingsPage.ts
+++ b/e2e/pages/SettingsPage.ts
@@ -78,20 +78,24 @@ export class SettingsPage extends BasePage {
   }
 
   /**
-   * Tap the language selector button to open the language menu.
+   * Tap the language selector button and wait for the picker sheet to settle.
    */
   async openLanguageMenu(): Promise<void> {
     await this.tap(Selectors.settings.languageSelectorButton);
-    // Brief pause for menu animation
-    await browser.pause(500);
+    await this.waitForElement(Selectors.settings.languageSheet);
   }
 
   /**
-   * Select a language from the open language menu.
+   * Select a language from the open language picker.
+   * The list is virtualized, so the row is filtered into view by typing the
+   * language code before tapping it.
    * @param lang - Language code (e.g., 'en', 'id', 'ja', 'zh')
    */
   async selectLanguage(lang: string): Promise<void> {
+    await this.typeText(Selectors.settings.languageSearch, lang);
     await this.tap(Selectors.settings.languageOption(lang));
+    // The sheet animates out; a lingering backdrop would eat the next gesture.
+    await this.waitForElementToDisappear(Selectors.settings.languageSheet);
     // Wait for re-render after language change
     await browser.pause(1000);
   }

--- a/src/assets/icons/check-md.svg
+++ b/src/assets/icons/check-md.svg
@@ -1,3 +1,3 @@
-<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 11.8658 8.53311" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 11.8658 8.53311" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path id="Union" d="M10.8418 0.17569C11.0761 -0.0585329 11.4561 -0.0585939 11.6904 0.17569C11.9243 0.409948 11.9243 0.789132 11.6904 1.02335L4.35738 8.35733C4.24492 8.46978 4.0916 8.53304 3.93257 8.53311C3.77373 8.53303 3.62115 8.46955 3.50874 8.35733L0.175736 5.02335C-0.0585785 4.78903 -0.0585787 4.41 0.175736 4.17569C0.410058 3.94147 0.789108 3.94141 1.02339 4.17569L3.93257 7.08389L10.8418 0.17569Z" fill="#181715"/>
 </svg>

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -1,0 +1,66 @@
+import React, {useContext, useMemo, useState} from 'react';
+import {Text} from 'react-native';
+import {observer} from 'mobx-react';
+
+import {ChevronDownIcon} from '../../assets/icons';
+import {useTheme} from '../../hooks';
+import {AvailableLanguage, languageDisplayNames} from '../../locales';
+import {uiStore} from '../../store';
+import {L10nContext} from '../../utils';
+import {SearchableSelectSheet} from '../SearchableSelectSheet';
+import {Pressable} from '../ui/primitives/Pressable';
+
+import {createStyles} from './styles';
+
+/**
+ * App-language control: a content-sized trigger plus the shared searchable
+ * sheet. Search keeps every locale reachable by typing its Latin code even
+ * when the UI is in a script the user cannot read.
+ */
+export const LanguageSelector: React.FC = observer(() => {
+  const theme = useTheme();
+  const l10n = useContext(L10nContext);
+  const styles = createStyles(theme);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const options = useMemo(
+    () =>
+      uiStore.supportedLanguages.map(lang => ({
+        value: lang,
+        label: languageDisplayNames[lang],
+      })),
+    [],
+  );
+
+  return (
+    <>
+      <Pressable
+        testID="language-selector-button"
+        accessibilityRole="button"
+        accessibilityLabel={languageDisplayNames[uiStore.language]}
+        onPress={() => setSheetOpen(true)}
+        style={styles.trigger}>
+        <Text style={styles.triggerLabel} numberOfLines={1}>
+          {languageDisplayNames[uiStore.language]}
+        </Text>
+        <ChevronDownIcon
+          width={18}
+          height={18}
+          stroke={theme.colors.onSurface}
+        />
+      </Pressable>
+      <SearchableSelectSheet
+        testID="language-sheet"
+        searchTestID="language-search"
+        optionTestIDPrefix="language-option"
+        isVisible={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        title={l10n.settings.languageSheetTitle}
+        searchPlaceholder={l10n.settings.languageSearchPlaceholder}
+        options={options}
+        value={uiStore.language}
+        onSelect={value => uiStore.setLanguage(value as AvailableLanguage)}
+      />
+    </>
+  );
+});

--- a/src/components/LanguageSelector/index.ts
+++ b/src/components/LanguageSelector/index.ts
@@ -1,0 +1,1 @@
+export {LanguageSelector} from './LanguageSelector';

--- a/src/components/LanguageSelector/styles.ts
+++ b/src/components/LanguageSelector/styles.ts
@@ -1,0 +1,25 @@
+import {StyleSheet} from 'react-native';
+
+import {Theme} from '../../utils/types';
+
+export const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    // Content-sized: no width, so a long endonym is never clipped.
+    trigger: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flexShrink: 1,
+      gap: 8,
+      minHeight: 44,
+      paddingHorizontal: 14,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: theme.colors.outlineVariant,
+      backgroundColor: theme.colors.surface,
+    },
+    triggerLabel: {
+      flexShrink: 1,
+      color: theme.colors.onSurface,
+      fontSize: 16,
+    },
+  });

--- a/src/components/SearchableSelectSheet/SearchableSelectSheet.tsx
+++ b/src/components/SearchableSelectSheet/SearchableSelectSheet.tsx
@@ -61,7 +61,6 @@ export const SearchableSelectSheet: React.FC<SearchableSelectSheetProps> = ({
     return options.filter(o => o.label.toLowerCase().includes(q));
   }, [options, query]);
 
-  // Reset the query on every close path so a reopen starts unfiltered.
   const handleClose = () => {
     setQuery('');
     onClose();
@@ -100,10 +99,8 @@ export const SearchableSelectSheet: React.FC<SearchableSelectSheetProps> = ({
       onClose={handleClose}
       title={title}
       snapPoints={['75%']}
-      // Keep the header on screen when the keyboard opens. The default
-      // ("interactive") translates the whole sheet up by the keyboard height,
-      // which pushes the title and search field under the status bar; the list
-      // scrolls on its own, so extending is what we want.
+      // Default "interactive" slides the whole sheet up by the keyboard
+      // height, putting the header under the status bar.
       keyboardBehavior="extend"
       enablePanDownToClose
       enableContentPanningGesture={false}>

--- a/src/components/SearchableSelectSheet/SearchableSelectSheet.tsx
+++ b/src/components/SearchableSelectSheet/SearchableSelectSheet.tsx
@@ -100,6 +100,11 @@ export const SearchableSelectSheet: React.FC<SearchableSelectSheetProps> = ({
       onClose={handleClose}
       title={title}
       snapPoints={['75%']}
+      // Keep the header on screen when the keyboard opens. The default
+      // ("interactive") translates the whole sheet up by the keyboard height,
+      // which pushes the title and search field under the status bar; the list
+      // scrolls on its own, so extending is what we want.
+      keyboardBehavior="extend"
       enablePanDownToClose
       enableContentPanningGesture={false}>
       {isVisible ? (

--- a/src/components/SearchableSelectSheet/SearchableSelectSheet.tsx
+++ b/src/components/SearchableSelectSheet/SearchableSelectSheet.tsx
@@ -1,9 +1,10 @@
-import React, {useMemo, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import {View, Text} from 'react-native';
 import {BottomSheetFlatList} from '@gorhom/bottom-sheet';
 
 import {CheckMdIcon, SearchIcon} from '../../assets/icons';
 import {useTheme} from '../../hooks';
+import {L10nContext} from '../../utils';
 import {Pressable} from '../ui/primitives/Pressable';
 import {Sheet} from '../Sheet';
 
@@ -48,6 +49,7 @@ export const SearchableSelectSheet: React.FC<SearchableSelectSheetProps> = ({
   optionTestIDPrefix = 'searchable-select-option',
 }) => {
   const theme = useTheme();
+  const l10n = useContext(L10nContext);
   const styles = createStyles(theme);
   const [query, setQuery] = useState('');
 
@@ -59,15 +61,15 @@ export const SearchableSelectSheet: React.FC<SearchableSelectSheetProps> = ({
     return options.filter(o => o.label.toLowerCase().includes(q));
   }, [options, query]);
 
-  const handleSelect = (next: string) => {
-    onSelect(next);
-    onClose();
-  };
-
-  // Reset the query whenever the sheet is dismissed so a reopen starts clean.
+  // Reset the query on every close path so a reopen starts unfiltered.
   const handleClose = () => {
     setQuery('');
     onClose();
+  };
+
+  const handleSelect = (next: string) => {
+    onSelect(next);
+    handleClose();
   };
 
   const renderItem = ({item}: {item: SearchableSelectOption}) => {
@@ -126,6 +128,11 @@ export const SearchableSelectSheet: React.FC<SearchableSelectSheetProps> = ({
             keyboardShouldPersistTaps="handled"
             style={styles.list}
             contentContainerStyle={styles.listContent}
+            ListEmptyComponent={
+              <Text testID={`${testID}-empty`} style={styles.emptyText}>
+                {l10n.common.noResults}
+              </Text>
+            }
           />
         </View>
       ) : null}

--- a/src/components/SearchableSelectSheet/__tests__/SearchableSelectSheet.test.tsx
+++ b/src/components/SearchableSelectSheet/__tests__/SearchableSelectSheet.test.tsx
@@ -78,6 +78,39 @@ describe('SearchableSelectSheet', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('clears the query on the selection path so a reopen is unfiltered', () => {
+    const {getByTestId, queryByTestId, rerender} = renderSheet();
+    fireEvent.changeText(getByTestId('searchable-select-search'), 'JAP');
+    expect(queryByTestId('searchable-select-option-ar')).toBeNull();
+
+    fireEvent.press(getByTestId('searchable-select-option-ja'));
+
+    rerender(
+      <SearchableSelectSheet
+        isVisible
+        onClose={jest.fn()}
+        title="Language"
+        searchPlaceholder="Search languages"
+        options={options}
+        value="ja"
+        onSelect={jest.fn()}
+      />,
+    );
+    expect(getByTestId('searchable-select-search').props.value).toBe('');
+    expect(getByTestId('searchable-select-option-na')).toBeTruthy();
+    expect(getByTestId('searchable-select-option-ar')).toBeTruthy();
+    expect(getByTestId('searchable-select-option-ja')).toBeTruthy();
+  });
+
+  it('renders an empty state when the query matches nothing', () => {
+    const {getByTestId, queryByTestId} = renderSheet();
+    fireEvent.changeText(getByTestId('searchable-select-search'), 'zzz');
+    expect(getByTestId('searchable-select-sheet-empty')).toBeTruthy();
+    expect(queryByTestId('searchable-select-option-na')).toBeNull();
+    expect(queryByTestId('searchable-select-option-ar')).toBeNull();
+    expect(queryByTestId('searchable-select-option-ja')).toBeNull();
+  });
+
   it('honours custom testID prefixes', () => {
     const {getByTestId} = renderSheet({
       testID: 'tts-language-sheet',

--- a/src/components/SearchableSelectSheet/styles.ts
+++ b/src/components/SearchableSelectSheet/styles.ts
@@ -48,7 +48,11 @@ export const createStyles = (theme: Theme) =>
       flex: 1,
       color: theme.colors.onSurface,
       fontSize: 16,
-      textAlign: I18nManager.isRTL ? 'right' : 'left',
+      // Plain 'left', NOT a ternary: RN mirrors left/right for <Text> under
+      // RTL (RCTTextAttributes), so 'left' resolves to the layout start in
+      // both directions. An isRTL ternary double-flips and pushes rows to the
+      // layout end. <TextInput> does not get that mirroring — see searchInput.
+      textAlign: 'left',
     },
     rowLabelSelected: {
       fontWeight: '700',
@@ -56,6 +60,9 @@ export const createStyles = (theme: Theme) =>
     emptyText: {
       color: theme.colors.onSurfaceVariant,
       fontSize: 14,
+      // Same mirroring rule as rowLabel — this string is localized, so
+      // leaving it unset would natural-align it by first strong character.
+      textAlign: 'left',
       paddingHorizontal: 16,
       paddingVertical: 16,
     },

--- a/src/components/SearchableSelectSheet/styles.ts
+++ b/src/components/SearchableSelectSheet/styles.ts
@@ -25,10 +25,8 @@ export const createStyles = (theme: Theme) =>
       color: theme.colors.onSurface,
       fontSize: 16,
       padding: 0,
-      // Ternary required: unlike <Text>, <TextInput> is not auto-mirrored, so
-      // 'left' would stay left under RTL. ('start' is not a legal textAlign
-      // value in RN.) 'auto' is wrong too — it aligns by first strong
-      // character, flipping the field as soon as a Latin query is typed.
+      // TextInput is not auto-mirrored the way Text is, so this needs the
+      // explicit ternary. See rowLabel.
       textAlign: I18nManager.isRTL ? 'right' : 'left',
     },
     list: {
@@ -49,12 +47,9 @@ export const createStyles = (theme: Theme) =>
       flex: 1,
       color: theme.colors.onSurface,
       fontSize: 16,
-      // 'left' means "start" here. RN's textAlign has no start/end (unlike
-      // CSS, and unlike RN's own paddingStart/marginStart), but it mirrors
-      // left/right for <Text> under RTL, so 'left' lands at the layout start
-      // in both directions. Writing isRTL ? 'right' : 'left' mirrors a second
-      // time and pushes rows to the layout end. <TextInput> gets no such
-      // mirroring, so searchInput does need the ternary.
+      // 'left' is how "start" is spelled: RN has no textAlign start/end, and
+      // auto-mirrors left/right for Text. An isRTL ternary mirrors twice and
+      // lands at the end.
       textAlign: 'left',
     },
     rowLabelSelected: {
@@ -63,8 +58,6 @@ export const createStyles = (theme: Theme) =>
     emptyText: {
       color: theme.colors.onSurfaceVariant,
       fontSize: 14,
-      // Same mirroring rule as rowLabel — this string is localized, so
-      // leaving it unset would natural-align it by first strong character.
       textAlign: 'left',
       paddingHorizontal: 16,
       paddingVertical: 16,

--- a/src/components/SearchableSelectSheet/styles.ts
+++ b/src/components/SearchableSelectSheet/styles.ts
@@ -25,9 +25,10 @@ export const createStyles = (theme: Theme) =>
       color: theme.colors.onSurface,
       fontSize: 16,
       padding: 0,
-      // Follow the layout direction, not the content's first strong character:
-      // 'auto' would flip the field as soon as a Latin query is typed in an
-      // RTL UI.
+      // Ternary required: unlike <Text>, <TextInput> is not auto-mirrored, so
+      // 'left' would stay left under RTL. ('start' is not a legal textAlign
+      // value in RN.) 'auto' is wrong too — it aligns by first strong
+      // character, flipping the field as soon as a Latin query is typed.
       textAlign: I18nManager.isRTL ? 'right' : 'left',
     },
     list: {
@@ -48,10 +49,12 @@ export const createStyles = (theme: Theme) =>
       flex: 1,
       color: theme.colors.onSurface,
       fontSize: 16,
-      // Plain 'left', NOT a ternary: RN mirrors left/right for <Text> under
-      // RTL (RCTTextAttributes), so 'left' resolves to the layout start in
-      // both directions. An isRTL ternary double-flips and pushes rows to the
-      // layout end. <TextInput> does not get that mirroring — see searchInput.
+      // 'left' means "start" here. RN's textAlign has no start/end (unlike
+      // CSS, and unlike RN's own paddingStart/marginStart), but it mirrors
+      // left/right for <Text> under RTL, so 'left' lands at the layout start
+      // in both directions. Writing isRTL ? 'right' : 'left' mirrors a second
+      // time and pushes rows to the layout end. <TextInput> gets no such
+      // mirroring, so searchInput does need the ternary.
       textAlign: 'left',
     },
     rowLabelSelected: {

--- a/src/components/SearchableSelectSheet/styles.ts
+++ b/src/components/SearchableSelectSheet/styles.ts
@@ -1,4 +1,4 @@
-import {StyleSheet} from 'react-native';
+import {I18nManager, StyleSheet} from 'react-native';
 
 import {Theme} from '../../utils/types';
 
@@ -25,6 +25,10 @@ export const createStyles = (theme: Theme) =>
       color: theme.colors.onSurface,
       fontSize: 16,
       padding: 0,
+      // Follow the layout direction, not the content's first strong character:
+      // 'auto' would flip the field as soon as a Latin query is typed in an
+      // RTL UI.
+      textAlign: I18nManager.isRTL ? 'right' : 'left',
     },
     list: {
       flex: 1,
@@ -44,6 +48,7 @@ export const createStyles = (theme: Theme) =>
       flex: 1,
       color: theme.colors.onSurface,
       fontSize: 16,
+      textAlign: I18nManager.isRTL ? 'right' : 'left',
     },
     rowLabelSelected: {
       fontWeight: '700',

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,6 +32,7 @@ export * from './HubRunSheetHost';
 export * from './SuggestedPromptsRow';
 export * from './ImageMessage';
 export * from './KeyboardAccessoryView';
+export * from './LanguageSelector';
 export * from './LoadingBubble';
 export * from './MarkdownView';
 export * from './PendingIndicator';

--- a/src/locales/__tests__/locales.test.ts
+++ b/src/locales/__tests__/locales.test.ts
@@ -223,8 +223,6 @@ describe('exports', () => {
   });
 
   it('every display name carries its parenthesised locale code', () => {
-    // The Latin code is the only part of an endonym a user stranded in an
-    // unreadable locale can type into the picker's search field.
     for (const lang of supportedLanguages) {
       expect(languageDisplayNames[lang]).toContain(`(${lang.toUpperCase()})`);
     }

--- a/src/locales/__tests__/locales.test.ts
+++ b/src/locales/__tests__/locales.test.ts
@@ -222,8 +222,17 @@ describe('exports', () => {
     }
   });
 
+  it('every display name carries its parenthesised locale code', () => {
+    // The Latin code is the only part of an endonym a user stranded in an
+    // unreadable locale can type into the picker's search field.
+    for (const lang of supportedLanguages) {
+      expect(languageDisplayNames[lang]).toContain(`(${lang.toUpperCase()})`);
+    }
+  });
+
   it('languageDisplayNames contains expected values', () => {
     expect(languageDisplayNames.en).toBe('English (EN)');
+    expect(languageDisplayNames.fa).toBe('\u0641\u0627\u0631\u0633\u06CC (FA)');
     expect(languageDisplayNames.he).toBe('\u05E2\u05D1\u05E8\u05D9\u05EA (HE)');
     expect(languageDisplayNames.id).toBe('Indonesia (ID)');
     expect(languageDisplayNames.ja).toBe('\u65E5\u672C\u8A9E (JA)');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,7 +31,8 @@
     "ok": "OK",
     "close": "Close",
     "clear": "Clear All",
-    "gallery": "Gallery"
+    "gallery": "Gallery",
+    "noResults": "No results"
   },
   "settings": {
     "modelInitializationSettings": "Model Initialization Settings",
@@ -98,6 +99,8 @@
     "autoNavigateToChatDescription": "Navigate to chat when loading starts.",
     "appSettings": "App Settings",
     "language": "Language",
+    "languageSheetTitle": "Language",
+    "languageSearchPlaceholder": "Search languages",
     "darkMode": "Dark Mode",
     "displayMemoryUsage": "Display Memory Usage",
     "displayMemoryUsageDescription": "Display memory usage in the chat page.",

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -40,6 +40,7 @@ import {
   Menu,
   Divider,
   HFTokenSheet,
+  LanguageSelector,
   SearchProviderKeySheet,
   InputSlider,
 } from '../../components';
@@ -55,7 +56,6 @@ import {
   ttsStore,
   searchProviderStore,
 } from '../../store';
-import {languageDisplayNames} from '../../locales';
 import type {SearchProviderId} from '../../services/search/types';
 
 import {CacheType} from '../../utils/types';
@@ -92,7 +92,6 @@ export const SettingsScreen: React.FC = observer(() => {
   const inputRef = useRef<RNTextInput>(null);
   const [showKeyCacheMenu, setShowKeyCacheMenu] = useState(false);
   const [showValueCacheMenu, setShowValueCacheMenu] = useState(false);
-  const [showLanguageMenu, setShowLanguageMenu] = useState(false);
   const [showHfTokenDialog, setShowHfTokenDialog] = useState(false);
   const [showSearchProviderMenu, setShowSearchProviderMenu] = useState(false);
   const [searchProviderAnchor, setSearchProviderAnchor] = useState<{
@@ -110,17 +109,12 @@ export const SettingsScreen: React.FC = observer(() => {
     x: number;
     y: number;
   }>({x: 0, y: 0});
-  const [languageAnchor, setLanguageAnchor] = useState<{x: number; y: number}>({
-    x: 0.0,
-    y: 0.0,
-  });
   const [deviceOptions, setDeviceOptions] = useState<DeviceOption[]>([]);
   const [currentBackend, setCurrentBackend] = useState<
     'metal' | 'opencl' | 'hexagon' | 'cpu' | 'blas'
   >(Platform.OS === 'ios' ? 'metal' : 'cpu');
   const keyCacheButtonRef = useRef<View>(null);
   const valueCacheButtonRef = useRef<View>(null);
-  const languageButtonRef = useRef<View>(null);
   const debouncedUpdateStore = useRef(
     debounce((value: number) => {
       modelStore.setNContext(value);
@@ -193,7 +187,6 @@ export const SettingsScreen: React.FC = observer(() => {
     setIsValidInput(true);
     setShowKeyCacheMenu(false);
     setShowValueCacheMenu(false);
-    setShowLanguageMenu(false);
   };
 
   const handleContextSizeChange = (text: string) => {
@@ -291,13 +284,6 @@ export const SettingsScreen: React.FC = observer(() => {
         setShowValueCacheMenu(true);
       },
     );
-  };
-
-  const handleLanguagePress = () => {
-    languageButtonRef.current?.measure((x, y, width, height, pageX, pageY) => {
-      setLanguageAnchor({x: pageX, y: pageY + height});
-      setShowLanguageMenu(true);
-    });
   };
 
   const handleSearchProviderPress = () => {
@@ -921,39 +907,7 @@ export const SettingsScreen: React.FC = observer(() => {
                       </Text>
                     </View>
                   </View>
-                  <View style={styles.menuContainer}>
-                    <Button
-                      ref={languageButtonRef}
-                      testID="language-selector-button"
-                      mode="outlined"
-                      onPress={handleLanguagePress}
-                      style={styles.menuButton}
-                      contentStyle={styles.buttonContent}
-                      icon={({size, color}) => (
-                        <Icon source="chevron-down" size={size} color={color} />
-                      )}>
-                      {languageDisplayNames[uiStore.language]}
-                    </Button>
-                    <Menu
-                      visible={showLanguageMenu}
-                      onDismiss={() => setShowLanguageMenu(false)}
-                      anchor={languageAnchor}
-                      selectable>
-                      {uiStore.supportedLanguages.map(lang => (
-                        <Menu.Item
-                          key={lang}
-                          testID={`language-option-${lang}`}
-                          style={styles.menu}
-                          label={languageDisplayNames[lang]}
-                          selected={lang === uiStore.language}
-                          onPress={() => {
-                            uiStore.setLanguage(lang);
-                            setShowLanguageMenu(false);
-                          }}
-                        />
-                      ))}
-                    </Menu>
-                  </View>
+                  <LanguageSelector />
                 </View>
                 <Divider />
 


### PR DESCRIPTION
Replaces the Settings language dropdown with the app's existing searchable bottom sheet.

## Problem

The picker did not scale with the locale count. Two defects, both visible in the PR #826 evidence:

- **Truncation** — a hardcoded `width: 170` on every menu item clipped labels: `Português (PT_B…`, `繁體中文 (ZH_HA…`. Wiring `pt` in #826 made it worse, putting the truncated `Português (PT_BR)` directly under `Português (PT)`.
- **Unmanaged height** — the menu had no `maxHeight`. At 14 locales it spanned nearly the full screen, with the last row against the screen edge. `de`, `et`, `fr` and `it` are already sitting unwired.

## Approach

No new component and no new dependency: `SearchableSelectSheet` already exists and has been in production since the TTS Supertonic picker needed to handle **31** languages. Same problem, larger list, already solved. Full-bleed rows make truncation impossible; a fixed snap point over a virtualised list bounds the height regardless of locale count.

Alternatives considered and rejected: capping the Paper `Menu` — hand-rolls content sizing, `maxHeight` and RTL anchor maths onto a primitive the design system is migrating away from, and its `width: 170` is shared by three other menus; the DS `Dropdown` — wraps the same Paper `Menu`, so it inherits the exact defect being fixed.

The design system has no language-picker frame, so this is not a parity slice — but the DS idiom for a multi-option setting is a row + value + chevron opening a scrimmed bottom card, which is what this is.

## Also fixed

Two real defects in the shared sheet, which also fix the TTS picker:

1. `handleSelect` called the `onClose` prop directly, bypassing the query reset — so reopening after a filtered selection showed a stale filtered list.
2. No `ListEmptyComponent` — a non-matching query rendered a blank sheet, with an `emptyText` style defined and unused.

Both change behaviour on a shipped surface, so both are covered by new unit tests and a manual smoke check.

## RTL

Text alignment is pinned to the layout direction, **not** `textAlign: 'auto'` — but the two element types need different expressions, which a forced-RTL device capture settled:

- **`Text`** (row label, empty state): plain `textAlign: 'left'`. React Native already mirrors `left`/`right` for `Text` under RTL, so `'left'` lands at the layout start in both directions. An `isRTL` ternary here **double-flips** and pushes rows to the layout end.
- **`TextInput`** (search field): `isRTL ? 'right' : 'left'`. `TextInput` gets no such mirroring, so the ternary is required. `auto` resolves to *natural* alignment from the first strong character, so in an RTL UI the field starts right-aligned under the Hebrew placeholder and then flips to the left the moment a Latin code is typed — which is the one interaction this design is built around. In an LTR UI the same setting would detach the `עברית (HE)` and `فارسی (FA)` rows to the opposite edge from every other row.

## Notes

- e2e testIDs are unchanged: `optionTestIDPrefix="language-option"` reproduces `language-option-<lang>` exactly, so `language.spec.ts` is byte-identical. Only the page object changed — it now waits on the sheet instead of a fixed `pause(500)`, and types the locale code to defeat list virtualisation.
- A new unit test asserts every display name carries its parenthesised locale code. That invariant is what makes search-by-code work, and it was previously unguarded — the existing test hardcoded 13 literals and omitted `fa`.
- `styles.menu` is deliberately untouched: it is shared by the key-cache, value-cache and search-provider menus, which keep the same truncation as a deferred cleanup.

## Verification

- `yarn test` — 262 suites, 3949 passed (baseline 3946), 0 failed
- `yarn lint` 0 errors · `yarn typecheck` clean · `yarn l10n:validate` · `yarn verify:fonts` pass
- Not a native change: no `package.json`, native module, `ios/`, `android/`, Podfile or build.gradle edit.

Visual evidence to follow in a comment.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
