### PR TITLE
[Bug]: scope the llama.cpp /props capability probe to a model

### DIFF
--- a/__mocks__/stores/modelStore.ts
+++ b/__mocks__/stores/modelStore.ts
@@ -293,11 +293,6 @@ class MockModelStore {
     return this.availableModels.some(model => model.id === modelId);
   }
 
-  async isMultimodalEnabled(): Promise<boolean> {
-    // Mock implementation - return false by default for tests
-    return false;
-  }
-
   async getModelFullPath(model: Model): Promise<string> {
     // Mock implementation - return a simple path for tests
     return `/mock/path/${model.filename || model.name}`;

--- a/__mocks__/stores/modelStore.ts
+++ b/__mocks__/stores/modelStore.ts
@@ -3,11 +3,21 @@ import {computed, makeAutoObservable, observable} from 'mobx';
 import {modelsList} from '../../jest/fixtures/models';
 
 import {downloadManager} from '../services/downloads';
+import {mockServerStore} from './serverStore';
 
-import {Model, ContextInitParams} from '../../src/utils/types';
+import {
+  Model,
+  ContextInitParams,
+  RemoteSessionBinding,
+} from '../../src/utils/types';
 import {LlamaContext} from 'llama.rn';
 import {CompletionEngine} from '../../src/utils/completionTypes';
 import {createDefaultContextInitParams} from '../../src/utils/contextInitParamsVersions';
+import {resolveModelCaps} from '../../src/utils/modelCaps';
+import type {
+  CapabilityEnv,
+  ModelCapabilityView,
+} from '../../src/utils/modelCaps';
 
 class MockModelStore {
   models = modelsList;
@@ -20,6 +30,9 @@ class MockModelStore {
   isStreaming = false;
   context: LlamaContext | undefined = undefined;
   engine: CompletionEngine | undefined = undefined;
+  isMultimodalActive: boolean = false;
+  activeContextSettings: ContextInitParams | undefined = undefined;
+  activeRemoteBinding: RemoteSessionBinding | undefined = undefined;
 
   // Memory calibration variables
   availableMemoryCeiling: number | undefined = 5 * 1e9; // 5GB ceiling
@@ -122,6 +135,7 @@ class MockModelStore {
       contextId: computed,
       lastUsedModel: computed,
       activeModel: computed,
+      activeModelCaps: computed,
       displayModels: computed,
       availableModels: computed,
       isDownloading: computed,
@@ -240,6 +254,26 @@ class MockModelStore {
 
   get activeModel() {
     return this.models.find(model => model.id === this.activeModelId);
+  }
+
+  // Delegates to the real resolver over the live mock stores rather than
+  // returning a fixed answer, so consumer suites exercise the actual
+  // capability chain and stay reactive to store mutations.
+  private get capabilityEnv(): CapabilityEnv {
+    return {
+      remoteCaps: mockServerStore.remoteCaps,
+      binding: this.activeRemoteBinding,
+      isMultimodalActive: this.isMultimodalActive,
+      activeContextSettings: this.activeContextSettings,
+      activeModelId: this.activeModelId,
+    };
+  }
+
+  capsFor = (model: Model | undefined): ModelCapabilityView =>
+    resolveModelCaps(model, this.capabilityEnv);
+
+  get activeModelCaps(): ModelCapabilityView {
+    return this.capsFor(this.activeModel);
   }
 
   get displayModels(): Model[] {

--- a/__mocks__/stores/modelStore.ts
+++ b/__mocks__/stores/modelStore.ts
@@ -262,6 +262,7 @@ class MockModelStore {
   private get capabilityEnv(): CapabilityEnv {
     return {
       remoteCaps: mockServerStore.remoteCaps,
+      listCaps: mockServerStore.listCaps,
       binding: this.activeRemoteBinding,
       isMultimodalActive: this.isMultimodalActive,
       activeContextSettings: this.activeContextSettings,

--- a/__mocks__/stores/serverStore.ts
+++ b/__mocks__/stores/serverStore.ts
@@ -3,10 +3,20 @@ import {makeAutoObservable, observable} from 'mobx';
 import {RemoteModelCaps, ServerConfig} from '../../src/utils/types';
 import {ReasoningCapability} from '../../src/utils/reasoningCapability';
 import {RemoteModelInfo} from '../../src/api/openai';
+import {deriveListCapsMap} from '../../src/utils/listCaps';
 
 class MockServerStore {
   servers: ServerConfig[] = [];
   serverModels: Map<string, RemoteModelInfo[]> = observable.map();
+
+  // Derived from the live mock state, exactly as the real store derives it, so
+  // a suite that mutates `servers` or `serverModels` exercises the real
+  // derivation and stays reactive. A fixed answer here would let the card
+  // scenarios pass with the derivation broken.
+  get listCaps() {
+    return deriveListCapsMap(this.servers, this.serverModels);
+  }
+
   userSelectedModels: Array<{serverId: string; remoteModelId: string}> = [];
   remoteReasoning: Record<string, ReasoningCapability> = {};
   remoteCaps: Record<string, RemoteModelCaps> = {};

--- a/__mocks__/stores/serverStore.ts
+++ b/__mocks__/stores/serverStore.ts
@@ -21,6 +21,7 @@ class MockServerStore {
   getApiKey: jest.Mock;
   removeApiKey: jest.Mock;
   fetchModelsForServer: jest.Mock;
+  fetchRemoteModelCaps: jest.Mock;
   fetchAllRemoteModels: jest.Mock;
   testServerConnection: jest.Mock;
   acknowledgePrivacyNotice: jest.Mock;
@@ -41,6 +42,7 @@ class MockServerStore {
       getApiKey: false,
       removeApiKey: false,
       fetchModelsForServer: false,
+      fetchRemoteModelCaps: false,
       fetchAllRemoteModels: false,
       testServerConnection: false,
       acknowledgePrivacyNotice: false,
@@ -59,6 +61,7 @@ class MockServerStore {
     this.getApiKey = jest.fn().mockResolvedValue(undefined);
     this.removeApiKey = jest.fn().mockResolvedValue(undefined);
     this.fetchModelsForServer = jest.fn().mockResolvedValue(undefined);
+    this.fetchRemoteModelCaps = jest.fn().mockResolvedValue(undefined);
     this.fetchAllRemoteModels = jest.fn().mockResolvedValue(undefined);
     this.testServerConnection = jest
       .fn()

--- a/__mocks__/stores/serverStore.ts
+++ b/__mocks__/stores/serverStore.ts
@@ -1,6 +1,6 @@
 import {makeAutoObservable, observable} from 'mobx';
 
-import {ServerConfig} from '../../src/utils/types';
+import {RemoteModelCaps, ServerConfig} from '../../src/utils/types';
 import {ReasoningCapability} from '../../src/utils/reasoningCapability';
 import {RemoteModelInfo} from '../../src/api/openai';
 
@@ -9,6 +9,7 @@ class MockServerStore {
   serverModels: Map<string, RemoteModelInfo[]> = observable.map();
   userSelectedModels: Array<{serverId: string; remoteModelId: string}> = [];
   remoteReasoning: Record<string, ReasoningCapability> = {};
+  remoteCaps: Record<string, RemoteModelCaps> = {};
   isLoading = false;
   error: string | null = null;
   privacyNoticeAcknowledged = false;

--- a/e2e/specs/features/remote-vision.spec.ts
+++ b/e2e/specs/features/remote-vision.spec.ts
@@ -4,8 +4,12 @@
  * Exercises the llama.cpp GET /props capability-discovery path end to end:
  * a remote server that reports `modalities.vision` enables the chat image
  * attachment affordance; a server that does not keeps it disabled. This is the
- * user-visible surface of the /props -> ServerConfig.supportsVision ->
- * ModelStore.isMultimodalEnabled -> ChatInput isVisionEnabled chain.
+ * user-visible surface of the /props -> ServerStore.remoteCaps ->
+ * resolveRemoteCaps -> ChatInput isVisionEnabled chain.
+ *
+ * Capabilities are discovered per model, on model activation, so the assertion
+ * is valid against a multi-model router too: selecting a vision model enables
+ * attach, selecting a text-only sibling on the same server disables it again.
  *
  * The attach button is always rendered (ChatScreen showImageUpload={true}); only
  * its enabled state flips with the discovered capability, so isEnabled() on the
@@ -18,6 +22,11 @@
  *     modalities.vision === true (e.g. a SmolVLM build).
  *   - REMOTE_NONVISION_URL (optional) points at a text-only server (no vision in
  *     /props). When unset, the negative test is skipped.
+ *   - REMOTE_SERVER_API_KEY must be EMPTY when either URL points at llama.cpp:
+ *     the suite sends the key unconditionally and llama.cpp rejects a request
+ *     carrying one it was not started with.
+ *   - Use a LAN address for a plain-HTTP server. iOS ATS blocks cleartext to a
+ *     Tailscale CGNAT address.
  *
  * Environment variables:
  *   REMOTE_VISION_URL         - vision-capable server (default http://192.168.0.62:1234)

--- a/jest/fixtures/models.ts
+++ b/jest/fixtures/models.ts
@@ -308,6 +308,26 @@ export const remoteModel: Model = createModel({
   remoteModelId: 'gpt-3.5-turbo',
 });
 
+// A second model on the same server, so capability cases can show that entries
+// are per model and not per server.
+export const remoteModelSibling: Model = createModel({
+  id: 'server1/text-only-model',
+  name: 'text-only-model',
+  author: 'Test LM Studio',
+  origin: ModelOrigin.REMOTE,
+  isDownloaded: true,
+  isLocal: false,
+  size: 0,
+  params: 0,
+  downloadUrl: '',
+  hfUrl: '',
+  progress: 0,
+  filename: '',
+  serverId: 'server1',
+  serverName: 'Test LM Studio',
+  remoteModelId: 'text-only-model',
+});
+
 export const modelsList: Model[] = [
   basicModel,
   downloadedModel,

--- a/jest/fixtures/remoteModelList.ts
+++ b/jest/fixtures/remoteModelList.ts
@@ -1,0 +1,331 @@
+/**
+ * Verbatim `GET /v1/models` bodies, captured from a live llama.cpp router
+ * (47 models, trimmed to the five rows below) and from two of its children
+ * reached directly. The two forms differ in shape, and `deriveListCaps` reads
+ * both, so hand-written stand-ins would test the parser against a shape no
+ * server emits.
+ *
+ * Only host-identifying values inside `status.args` and `status.preset` are
+ * replaced — absolute paths keep their last two segments; the bind-address
+ * flag and its value become placeholders. Every key, every array element and
+ * every ordering
+ * is as it arrived: `--ctx-size` and its value are adjacent by position, so a
+ * redaction that dropped or merged an element would quietly change what the
+ * parser sees.
+ *
+ * The rows were chosen to carry one distinct shape each:
+ *   gemma-4-e2b                            loaded, image, meta.n_ctx, --mmproj
+ *   ggml-org/gemma-4-31B-it-GGUF:Q8_0      unloaded, image, no meta
+ *   gemma-3-4b                             loaded, text-only, meta.n_ctx
+ *   bartowski/Qwen_Qwen3-1.7B-GGUF:Q4_K_M  unloaded, text-only, --hf-repo
+ *   bonsai-27b-q1                          unloaded, text-only, --model
+ *
+ * Of the five router rows declaring `image`, one carries `--mmproj`; that is
+ * why vision is read from `architecture`, not from the launch arguments.
+ */
+export const routerModelsBody = {
+  data: [
+    {
+      id: 'gemma-4-e2b',
+      aliases: [],
+      tags: [],
+      object: 'model',
+      owned_by: 'llamacpp',
+      created: 1784820254,
+      status: {
+        value: 'loaded',
+        args: [
+          '/redacted/bin/llama-server',
+          '--redacted-flag',
+          'redacted-host',
+          '--jinja',
+          '--port',
+          '50693',
+          '--alias',
+          'gemma-4-e2b',
+          '--ctx-size',
+          '8192',
+          '--flash-attn',
+          'auto',
+          '--model',
+          '/redacted/gemma-4-E2B-it-GGUF/gemma-4-E2B-it-Q4_K_M.gguf',
+          '--mmproj',
+          '/redacted/gemma-4-E2B-it-GGUF/mmproj-gemma-4-E2B-it-BF16.gguf',
+          '--n-gpu-layers',
+          '999',
+        ],
+        preset:
+          '[gemma-4-e2b]\njinja = true\nctx-size = 8192\nflash-attn = auto\nmodel = /redacted/gemma-4-E2B-it-GGUF/gemma-4-E2B-it-Q4_K_M.gguf\nmmproj = /redacted/gemma-4-E2B-it-GGUF/mmproj-gemma-4-E2B-it-BF16.gguf\nn-gpu-layers = 999\n\n',
+      },
+      architecture: {
+        input_modalities: ['text', 'image', 'audio'],
+        output_modalities: ['text'],
+      },
+      source: 'preset',
+      can_remove: false,
+      meta: {
+        vocab_type: 2,
+        n_vocab: 262144,
+        n_ctx: 8192,
+        n_ctx_train: 131072,
+        n_embd: 1536,
+        n_params: 4647450147,
+        size: 3412060300,
+        ftype: 'Q4_K - Medium',
+      },
+    },
+    {
+      id: 'ggml-org/gemma-4-31B-it-GGUF:Q8_0',
+      aliases: [],
+      tags: [],
+      object: 'model',
+      owned_by: 'llamacpp',
+      created: 1784820254,
+      status: {
+        value: 'unloaded',
+        args: [
+          '/redacted/bin/llama-server',
+          '--redacted-flag',
+          'redacted-host',
+          '--jinja',
+          '--port',
+          '0',
+          '--alias',
+          'ggml-org/gemma-4-31B-it-GGUF:Q8_0',
+          '--ctx-size',
+          '8192',
+          '--flash-attn',
+          'auto',
+          '--hf-repo',
+          'ggml-org/gemma-4-31B-it-GGUF:Q8_0',
+          '--n-gpu-layers',
+          '999',
+        ],
+        preset:
+          '[ggml-org/gemma-4-31B-it-GGUF:Q8_0]\njinja = true\nctx-size = 8192\nflash-attn = auto\nhf-repo = ggml-org/gemma-4-31B-it-GGUF:Q8_0\nn-gpu-layers = 999\n\n',
+      },
+      architecture: {
+        input_modalities: ['text', 'image'],
+        output_modalities: ['text'],
+      },
+      source: 'cache',
+      can_remove: true,
+    },
+    {
+      id: 'gemma-3-4b',
+      aliases: [],
+      tags: [],
+      object: 'model',
+      owned_by: 'llamacpp',
+      created: 1784820254,
+      status: {
+        value: 'loaded',
+        args: [
+          '/redacted/bin/llama-server',
+          '--redacted-flag',
+          'redacted-host',
+          '--jinja',
+          '--port',
+          '36129',
+          '--alias',
+          'gemma-3-4b',
+          '--ctx-size',
+          '8192',
+          '--flash-attn',
+          'auto',
+          '--model',
+          '/redacted/gemma-3-4b-it-GGUF/gemma-3-4b-it-Q4_K_M.gguf',
+          '--n-gpu-layers',
+          '999',
+        ],
+        preset:
+          '[gemma-3-4b]\njinja = true\nctx-size = 8192\nflash-attn = auto\nmodel = /redacted/gemma-3-4b-it-GGUF/gemma-3-4b-it-Q4_K_M.gguf\nn-gpu-layers = 999\n\n',
+      },
+      architecture: {
+        input_modalities: ['text'],
+        output_modalities: ['text'],
+      },
+      source: 'preset',
+      can_remove: false,
+      meta: {
+        vocab_type: 1,
+        n_vocab: 262144,
+        n_ctx: 8192,
+        n_ctx_train: 131072,
+        n_embd: 2560,
+        n_params: 3880099328,
+        size: 2483218432,
+        ftype: 'Q4_K - Medium',
+      },
+    },
+    {
+      id: 'bartowski/Qwen_Qwen3-1.7B-GGUF:Q4_K_M',
+      aliases: [],
+      tags: [],
+      object: 'model',
+      owned_by: 'llamacpp',
+      created: 1784820254,
+      status: {
+        value: 'unloaded',
+        args: [
+          '/redacted/bin/llama-server',
+          '--redacted-flag',
+          'redacted-host',
+          '--jinja',
+          '--port',
+          '40611',
+          '--alias',
+          'bartowski/Qwen_Qwen3-1.7B-GGUF:Q4_K_M',
+          '--ctx-size',
+          '8192',
+          '--flash-attn',
+          'auto',
+          '--hf-repo',
+          'bartowski/Qwen_Qwen3-1.7B-GGUF:Q4_K_M',
+          '--n-gpu-layers',
+          '999',
+        ],
+        preset:
+          '[bartowski/Qwen_Qwen3-1.7B-GGUF:Q4_K_M]\njinja = true\nctx-size = 8192\nflash-attn = auto\nhf-repo = bartowski/Qwen_Qwen3-1.7B-GGUF:Q4_K_M\nn-gpu-layers = 999\n\n',
+      },
+      architecture: {
+        input_modalities: ['text'],
+        output_modalities: ['text'],
+      },
+      source: 'cache',
+      can_remove: true,
+    },
+    {
+      id: 'bonsai-27b-q1',
+      aliases: [],
+      tags: [],
+      object: 'model',
+      owned_by: 'llamacpp',
+      created: 1784820254,
+      status: {
+        value: 'unloaded',
+        args: [
+          '/redacted/bin/llama-server',
+          '--redacted-flag',
+          'redacted-host',
+          '--jinja',
+          '--port',
+          '46313',
+          '--alias',
+          'bonsai-27b-q1',
+          '--ctx-size',
+          '8192',
+          '--flash-attn',
+          'auto',
+          '--model',
+          '/redacted/Bonsai-27B-gguf/Bonsai-27B-Q1_0.gguf',
+          '--n-gpu-layers',
+          '999',
+        ],
+        preset:
+          '[bonsai-27b-q1]\njinja = true\nctx-size = 8192\nflash-attn = auto\nmodel = /redacted/Bonsai-27B-gguf/Bonsai-27B-Q1_0.gguf\nn-gpu-layers = 999\n\n',
+      },
+      architecture: {
+        input_modalities: ['text'],
+        output_modalities: ['text'],
+      },
+      source: 'preset',
+      can_remove: false,
+    },
+  ],
+  object: 'list',
+};
+
+/** A single-model child of that router, reached directly. Multimodal. */
+export const directVisionModelsBody = {
+  models: [
+    {
+      name: 'gemma-4-e2b',
+      model: 'gemma-4-e2b',
+      modified_at: '',
+      size: '',
+      digest: '',
+      type: 'model',
+      description: '',
+      tags: [''],
+      capabilities: ['completion', 'multimodal'],
+      parameters: '',
+      details: {
+        parent_model: '',
+        format: 'gguf',
+        family: '',
+        families: [''],
+        parameter_size: '',
+        quantization_level: '',
+      },
+    },
+  ],
+  object: 'list',
+  data: [
+    {
+      id: 'gemma-4-e2b',
+      aliases: ['gemma-4-e2b'],
+      tags: [],
+      object: 'model',
+      created: 1784820235,
+      owned_by: 'llamacpp',
+      meta: {
+        vocab_type: 2,
+        n_vocab: 262144,
+        n_ctx: 8192,
+        n_ctx_train: 131072,
+        n_embd: 1536,
+        n_params: 4647450147,
+        size: 3412060300,
+        ftype: 'Q4_K - Medium',
+      },
+    },
+  ],
+};
+
+/** The same, for a text-only child: `capabilities` without `multimodal`. */
+export const directTextModelsBody = {
+  models: [
+    {
+      name: 'gemma-3-4b',
+      model: 'gemma-3-4b',
+      modified_at: '',
+      size: '',
+      digest: '',
+      type: 'model',
+      description: '',
+      tags: [''],
+      capabilities: ['completion'],
+      parameters: '',
+      details: {
+        parent_model: '',
+        format: 'gguf',
+        family: '',
+        families: [''],
+        parameter_size: '',
+        quantization_level: '',
+      },
+    },
+  ],
+  object: 'list',
+  data: [
+    {
+      id: 'gemma-3-4b',
+      aliases: ['gemma-3-4b'],
+      tags: [],
+      object: 'model',
+      created: 1784820255,
+      owned_by: 'llamacpp',
+      meta: {
+        vocab_type: 1,
+        n_vocab: 262144,
+        n_ctx: 8192,
+        n_ctx_train: 131072,
+        n_embd: 2560,
+        n_params: 3880099328,
+        size: 2483218432,
+        ftype: 'Q4_K - Medium',
+      },
+    },
+  ],
+};

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -445,6 +445,152 @@ describe('fetchServerProps', () => {
       {},
     );
   });
+
+  it('scopes the request to a model id when one is supplied', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          model_path: '/models/gemma-4-e2b.gguf',
+          default_generation_settings: {n_ctx: 8192},
+          modalities: {vision: true, video: true, audio: true},
+        }),
+    });
+
+    const props = await fetchServerProps(
+      'http://localhost:8080',
+      undefined,
+      undefined,
+      'gemma-4-e2b',
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/props?model=gemma-4-e2b',
+      expect.objectContaining({method: 'GET'}),
+    );
+    expect(props).toEqual({contextLength: 8192, supportsVision: true});
+  });
+
+  it('url-encodes a model id containing a slash', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({n_ctx: 4096}),
+    });
+
+    await fetchServerProps(
+      'http://localhost:8080',
+      undefined,
+      undefined,
+      'unsloth/gemma-3-4b',
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/props?model=unsloth%2Fgemma-3-4b',
+      expect.objectContaining({method: 'GET'}),
+    );
+  });
+
+  it('returns empty caps for a router placeholder body', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          role: 'router',
+          model_path: 'none',
+          default_generation_settings: {n_ctx: 0},
+          modalities: null,
+        }),
+    });
+
+    const props = await fetchServerProps('http://localhost:8080');
+
+    // n_ctx 0 is "unknown", not a window, and vision is undecidable on a body
+    // that describes no model — both fields stay absent.
+    expect(props).toEqual({});
+  });
+
+  it('omits contextLength when n_ctx is zero, negative, or not a number', async () => {
+    for (const n_ctx of [0, -1, NaN, '4096']) {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            model_path: '/models/m.gguf',
+            n_ctx,
+            modalities: {},
+          }),
+      });
+
+      const props = await fetchServerProps('http://localhost:8080');
+      expect(props.contextLength).toBeUndefined();
+    }
+  });
+
+  it('reports vision false when a real model body carries no modalities key', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          model_path: '/models/old-build.gguf',
+          default_generation_settings: {n_ctx: 2048},
+        }),
+    });
+
+    const props = await fetchServerProps('http://localhost:8080');
+    expect(props).toEqual({contextLength: 2048, supportsVision: false});
+  });
+
+  it('decides vision from model_path alone when no window is reported', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          model_path: '/models/m.gguf',
+          n_ctx: 0,
+          modalities: {vision: true},
+        }),
+    });
+
+    const props = await fetchServerProps('http://localhost:8080');
+    expect(props).toEqual({supportsVision: true});
+  });
+
+  it('bounds an omitted timeout at the props default, not the connection default', async () => {
+    jest.useFakeTimers();
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+
+    await fetchServerProps('http://localhost:8080');
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+    setTimeoutSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('falls back to the props default when the server timeout is unusable', async () => {
+    jest.useFakeTimers();
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+
+    for (const timeout of [0, -1, NaN]) {
+      setTimeoutSpy.mockClear();
+      await fetchServerProps('http://localhost:8080', undefined, timeout);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+    }
+
+    setTimeoutSpy.mockClear();
+    await fetchServerProps('http://localhost:8080', undefined, 20000);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 20000);
+
+    setTimeoutSpy.mockRestore();
+    jest.useRealTimers();
+  });
 });
 
 // Mock XMLHttpRequest for streaming tests

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -271,6 +271,23 @@ describe('fetchModelsWithHeaders', () => {
       expect(models[0].capabilities).toEqual(['completion']);
     });
 
+    it('never pairs an id-less row with a nameless entry', async () => {
+      serve({
+        data: [
+          {object: 'model', owned_by: 'x'},
+          {id: 'b', object: 'model', owned_by: 'x'},
+        ],
+        models: [
+          {capabilities: ['multimodal']},
+          {name: 'other', capabilities: ['completion']},
+        ],
+      });
+
+      const {models} = await fetchModelsWithHeaders('http://localhost:8080');
+
+      expect(models.some(m => 'capabilities' in m)).toBe(false);
+    });
+
     it('ignores a models field that is not an array', async () => {
       serve({
         data: [{id: 'a', object: 'model', owned_by: 'x'}],

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -8,6 +8,11 @@ import {
   buildReasoningPayload,
   __clearRemoteImageCache,
 } from '../openai';
+import {
+  directTextModelsBody,
+  directVisionModelsBody,
+  routerModelsBody,
+} from '../../../jest/fixtures/remoteModelList';
 
 /** Build a minimal Headers-like object for fetch mocks. */
 function mockHeaders(entries: Record<string, string> = {}) {
@@ -202,6 +207,80 @@ describe('fetchModelsWithHeaders', () => {
     expect(abortSpy).toHaveBeenCalled();
     abortSpy.mockRestore();
     jest.useRealTimers();
+  });
+
+  describe('models[] capabilities', () => {
+    const serve = (body: unknown) => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        headers: mockHeaders({server: 'llama.cpp'}),
+        json: () => Promise.resolve(body),
+      });
+    };
+
+    it('carries a direct server capabilities onto its data row', async () => {
+      serve(directVisionModelsBody);
+
+      const {models} = await fetchModelsWithHeaders('http://localhost:8080');
+
+      expect(models).toHaveLength(1);
+      expect(models[0].id).toBe('gemma-4-e2b');
+      expect(models[0].capabilities).toEqual(['completion', 'multimodal']);
+      expect(models[0].meta?.n_ctx).toBe(8192);
+    });
+
+    it('distinguishes a text-only direct server by the same field', async () => {
+      serve(directTextModelsBody);
+
+      const {models} = await fetchModelsWithHeaders('http://localhost:8080');
+
+      expect(models[0].capabilities).toEqual(['completion']);
+    });
+
+    it('returns a router body untouched, models[] being absent there', async () => {
+      serve(routerModelsBody);
+
+      const {models} = await fetchModelsWithHeaders('http://localhost:8080');
+
+      expect(models).toEqual(routerModelsBody.data);
+      expect(models.some(m => 'capabilities' in m)).toBe(false);
+    });
+
+    it('leaves rows alone when no entry names them', async () => {
+      serve({
+        data: [
+          {id: 'a', object: 'model', owned_by: 'x'},
+          {id: 'b', object: 'model', owned_by: 'x'},
+        ],
+        models: [{name: 'c', model: 'c', capabilities: ['completion']}],
+      });
+
+      const {models} = await fetchModelsWithHeaders('http://localhost:8080');
+
+      expect(models.some(m => 'capabilities' in m)).toBe(false);
+    });
+
+    it('pairs a lone row with a lone entry whatever the entry calls itself', async () => {
+      serve({
+        data: [{id: 'a', object: 'model', owned_by: 'x'}],
+        models: [{name: 'something-else', capabilities: ['completion']}],
+      });
+
+      const {models} = await fetchModelsWithHeaders('http://localhost:8080');
+
+      expect(models[0].capabilities).toEqual(['completion']);
+    });
+
+    it('ignores a models field that is not an array', async () => {
+      serve({
+        data: [{id: 'a', object: 'model', owned_by: 'x'}],
+        models: {name: 'a', capabilities: ['completion']},
+      });
+
+      const {models} = await fetchModelsWithHeaders('http://localhost:8080');
+
+      expect(models[0].capabilities).toBeUndefined();
+    });
   });
 });
 

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -367,9 +367,11 @@ export async function testConnection(
 
 const DETECT_TIMEOUT_MS = 5000;
 
-// Default bound for the detached /props capability probe, applied inside
-// fetchServerProps whenever the server sets no usable requestTimeoutMs. A
-// fire-and-forget probe must not inherit the 30 s connection default.
+// Bound for the detached /props capability probe: the fallback applied inside
+// fetchServerProps whenever the server sets no usable requestTimeoutMs, and
+// the ceiling ServerStore clamps a server-set value to. A fire-and-forget
+// probe must neither inherit the 30 s connection default nor an arbitrarily
+// large user-set timeout.
 export const PROPS_TIMEOUT_MS = 5000;
 
 /**

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -9,11 +9,19 @@ import {
 } from '../utils/completionTypes';
 import {RemoteModelCaps} from '../utils/types';
 
-/** Raw API response shape from OpenAI /v1/models */
+/**
+ * Raw API response shape from OpenAI /v1/models. The optional fields are what
+ * a llama.cpp server adds: the first three arrive on the row itself, the last
+ * is lifted from the sibling `models[]` array a single-model server emits.
+ */
 export interface RemoteModelInfo {
   id: string;
   object: string;
   owned_by: string;
+  status?: {value?: string; args?: string[]};
+  architecture?: {input_modalities?: string[]; output_modalities?: string[]};
+  meta?: {n_ctx?: number; n_ctx_train?: number; [key: string]: unknown};
+  capabilities?: string[];
 }
 
 /** Chat message type compatible with OpenAI API format */
@@ -213,6 +221,31 @@ export interface FetchModelsResult {
 }
 
 /**
+ * A single-model llama.cpp server describes its model twice: once in `data[]`
+ * and once in a sibling `models[]` array, which is the only one carrying
+ * `capabilities`. Joining them here keeps the two halves of one row together
+ * for every caller. Servers that emit no `models[]` are unaffected.
+ */
+function liftModelEntryCapabilities(
+  rows: RemoteModelInfo[],
+  entries: unknown,
+): RemoteModelInfo[] {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return rows;
+  }
+  return rows.map(row => {
+    const entry =
+      entries.find(e => (e?.name ?? e?.model) === row.id) ??
+      // One row and one entry can only describe each other, whatever the
+      // entry happens to call itself.
+      (rows.length === 1 && entries.length === 1 ? entries[0] : undefined);
+    return entry?.capabilities
+      ? {...row, capabilities: entry.capabilities}
+      : row;
+  });
+}
+
+/**
  * Fetch available models and response headers from an OpenAI-compatible server.
  * GET /v1/models
  */
@@ -251,7 +284,10 @@ export async function fetchModelsWithHeaders(
 
     const data = await response.json();
     return {
-      models: (data.data || []) as RemoteModelInfo[],
+      models: liftModelEntryCapabilities(
+        (data.data || []) as RemoteModelInfo[],
+        data.models,
+      ),
       headers: responseHeaders,
     };
   } catch (error: any) {

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -7,7 +7,7 @@ import {
   ReasoningIntent,
   ToolCall,
 } from '../utils/completionTypes';
-import {ServerConfig} from '../utils/types';
+import {RemoteModelCaps} from '../utils/types';
 
 /** Raw API response shape from OpenAI /v1/models */
 export interface RemoteModelInfo {
@@ -278,36 +278,35 @@ export async function fetchModels(
 }
 
 /**
- * Server capabilities discovered from llama.cpp GET /props. Coupled to
- * ServerConfig so a field rename breaks compile instead of silently
- * no-opping the ServerStore write.
- */
-export type ServerProps = Pick<
-  ServerConfig,
-  'contextLength' | 'supportsVision'
->;
-
-/**
- * Fetch server capabilities from a llama.cpp server's GET /props endpoint.
+ * Fetch model capabilities from a llama.cpp server's GET /props endpoint.
  * Pure: parses the response into caps and never throws — a timeout, non-2xx,
  * or malformed body resolves to `{}` so the caller's models path and
  * connection are never affected. `/props` is llama.cpp-specific; callers gate
  * on serverType before invoking.
  *
- * Key names verified against a live llama.cpp build (b9910): context window is
- * `default_generation_settings.n_ctx` (top-level `n_ctx` is an older-build
- * fallback); vision is `modalities.vision`.
+ * `modelId` scopes the request (`?model=<id>`). A multi-model router answers
+ * the bare form with a placeholder (`model_path: 'none'`, `n_ctx: 0`,
+ * `modalities` absent) that describes no model, so a field is only ever
+ * returned when the body describes an actually loaded model. Absent field =
+ * unknown; the caller merges field-wise and never blanks a known value.
+ *
+ * Key names verified against live llama.cpp builds (b9910, b9976): context
+ * window is `default_generation_settings.n_ctx` (top-level `n_ctx` is an
+ * older-build fallback); vision is `modalities.vision`.
  */
 export async function fetchServerProps(
   serverUrl: string,
   apiKey?: string,
   timeoutMs?: number,
-): Promise<ServerProps> {
-  const url = `${normalizeUrl(serverUrl)}/props`;
+  modelId?: string,
+): Promise<RemoteModelCaps> {
+  const url =
+    `${normalizeUrl(serverUrl)}/props` +
+    (modelId ? `?model=${encodeURIComponent(modelId)}` : '');
   const controller = new AbortController();
   const timeout = setTimeout(
     () => controller.abort(),
-    resolveTimeout(timeoutMs, CONNECTION_TIMEOUT_MS),
+    resolveTimeout(timeoutMs, PROPS_TIMEOUT_MS),
   );
 
   try {
@@ -320,18 +319,28 @@ export async function fetchServerProps(
       return {};
     }
     const data = await response.json();
-    const contextLength: unknown =
+    const caps: RemoteModelCaps = {};
+
+    const nCtx: unknown =
       data?.default_generation_settings?.n_ctx ?? data?.n_ctx;
-    // supportsVision is always defined (true or false) on a 2xx probe so a
-    // model swap that drops vision overwrites a stale true; a failed probe
-    // returns {} below and leaves caps untouched.
-    const props: ServerProps = {
-      supportsVision: data?.modalities?.vision === true,
-    };
-    if (typeof contextLength === 'number') {
-      props.contextLength = contextLength;
+    if (typeof nCtx === 'number' && Number.isFinite(nCtx) && nCtx > 0) {
+      caps.contextLength = nCtx;
     }
-    return props;
+
+    // A router placeholder reports model_path 'none' and no window. Anything
+    // else names a loaded model, and there a missing `modalities` key means
+    // the build has no vision — a definite false, not unknown.
+    const modelPath: unknown = data?.model_path;
+    const describesModel =
+      (typeof modelPath === 'string' &&
+        modelPath !== '' &&
+        modelPath !== 'none') ||
+      caps.contextLength !== undefined;
+    if (describesModel) {
+      caps.supportsVision = data?.modalities?.vision === true;
+    }
+
+    return caps;
   } catch {
     return {};
   } finally {
@@ -358,10 +367,9 @@ export async function testConnection(
 
 const DETECT_TIMEOUT_MS = 5000;
 
-// Bound the detached /props capability probe. /props is a tiny local JSON that
-// llama.cpp serves instantly, so 5 s is generous; it mirrors the server-type
-// detect probe. Passed explicitly rather than omitted — omitting resolves to
-// CONNECTION_TIMEOUT_MS (30 s), which would not bound a fire-and-forget probe.
+// Default bound for the detached /props capability probe, applied inside
+// fetchServerProps whenever the server sets no usable requestTimeoutMs. A
+// fire-and-forget probe must not inherit the 30 s connection default.
 export const PROPS_TIMEOUT_MS = 5000;
 
 /**

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -235,7 +235,9 @@ function liftModelEntryCapabilities(
   }
   return rows.map(row => {
     const entry =
-      entries.find(e => (e?.name ?? e?.model) === row.id) ??
+      (row.id
+        ? entries.find(e => (e?.name ?? e?.model) === row.id)
+        : undefined) ??
       // One row and one entry can only describe each other, whatever the
       // entry happens to call itself.
       (rows.length === 1 && entries.length === 1 ? entries[0] : undefined);

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -238,8 +238,6 @@ function liftModelEntryCapabilities(
       (row.id
         ? entries.find(e => (e?.name ?? e?.model) === row.id)
         : undefined) ??
-      // One row and one entry can only describe each other, whatever the
-      // entry happens to call itself.
       (rows.length === 1 && entries.length === 1 ? entries[0] : undefined);
     return entry?.capabilities
       ? {...row, capabilities: entry.capabilities}
@@ -365,9 +363,6 @@ export async function fetchServerProps(
       caps.contextLength = nCtx;
     }
 
-    // A router placeholder reports model_path 'none' and no window. Anything
-    // else names a loaded model, and there a missing `modalities` key means
-    // the build has no vision — a definite false, not unknown.
     const modelPath: unknown = data?.model_path;
     const describesModel =
       (typeof modelPath === 'string' &&
@@ -405,11 +400,8 @@ export async function testConnection(
 
 const DETECT_TIMEOUT_MS = 5000;
 
-// Bound for the detached /props capability probe: the fallback applied inside
-// fetchServerProps whenever the server sets no usable requestTimeoutMs, and
-// the ceiling ServerStore clamps a server-set value to. A fire-and-forget
-// probe must neither inherit the 30 s connection default nor an arbitrarily
-// large user-set timeout.
+// A fire-and-forget probe must neither inherit the 30 s connection default nor
+// an arbitrarily large user-set timeout.
 export const PROPS_TIMEOUT_MS = 5000;
 
 /**

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -12,6 +12,7 @@ import {chatSessionStore, modelStore, serverStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {MessageType, ModelOrigin} from '../../utils/types';
 import {resolveBannerVariant} from '../../utils/bannerVariantResolver';
+import {resolveRemoteCaps} from '../../utils/remoteCaps';
 import {talentRegistry} from '../../services/talents';
 import {t} from '../../locales';
 
@@ -104,15 +105,19 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
     const isRemote = activeModel?.origin === ModelOrigin.REMOTE;
 
     // activeContextSettings.n_ctx is local-only (set by a LlamaContext). For a
-    // remote model fall back to the server's /props-reported contextLength so
-    // the context banners can measure against a real window.
+    // remote model fall back to the /props-reported window for that model so
+    // the context banners can measure against a real one. A window of 0 is
+    // unknown, not full — leave it undefined so no banner is triggered.
     const localNCtx = modelStore.activeContextSettings?.n_ctx;
-    const effectiveNCtx =
+    const resolvedNCtx =
       localNCtx ??
-      (isRemote
-        ? serverStore.servers.find(s => s.id === activeModel?.serverId)
-            ?.contextLength
-        : undefined);
+      resolveRemoteCaps(
+        activeModel,
+        serverStore.remoteCaps,
+        serverStore.servers,
+      ).contextLength;
+    const effectiveNCtx =
+      resolvedNCtx !== undefined && resolvedNCtx > 0 ? resolvedNCtx : undefined;
 
     const {variant, heavyTalentName, ratio} = resolveBannerVariant(
       chatSessionStore.lastCompletionResult,

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -106,8 +106,12 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
 
     // activeContextSettings.n_ctx is local-only (set by a LlamaContext). For a
     // remote model fall back to the /props-reported window for that model so
-    // the context banners can measure against a real one. A window of 0 is
-    // unknown, not full — leave it undefined so no banner is triggered.
+    // the context banners can measure against a real one.
+    //
+    // The `> 0` filter is defence in depth: both writers (openai.ts parse,
+    // resolveRemoteCaps legacy fallback) already drop a non-positive window,
+    // and 0 means unknown, not exhausted — a banner measured against it would
+    // read every turn as context-full.
     const localNCtx = modelStore.activeContextSettings?.n_ctx;
     const resolvedNCtx =
       localNCtx ??

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -108,17 +108,16 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
     // remote model fall back to the /props-reported window for that model so
     // the context banners can measure against a real one.
     //
-    // The `> 0` filter is defence in depth: both writers (openai.ts parse,
-    // resolveRemoteCaps legacy fallback) already drop a non-positive window,
-    // and 0 means unknown, not exhausted — a banner measured against it would
-    // read every turn as context-full.
+    // The `> 0` filter is defence in depth: the openai.ts parse already drops
+    // a non-positive window, and 0 means unknown, not exhausted — a banner
+    // measured against it would read every turn as context-full.
     const localNCtx = modelStore.activeContextSettings?.n_ctx;
     const resolvedNCtx =
       localNCtx ??
       resolveRemoteCaps(
         activeModel,
         serverStore.remoteCaps,
-        serverStore.servers,
+        modelStore.activeRemoteBinding,
       ).contextLength;
     const effectiveNCtx =
       resolvedNCtx !== undefined && resolvedNCtx > 0 ? resolvedNCtx : undefined;

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -102,9 +102,6 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
 
     const isRemote = modelStore.activeModel?.origin === ModelOrigin.REMOTE;
 
-    // The window the live session measures against — local `n_ctx` or the
-    // /props-reported one, picked by the resolver. Already `> 0` or absent, so
-    // 0 (unknown, not exhausted) can never read as context-full here.
     const effectiveNCtx = modelStore.activeModelCaps.effectiveContextLength;
 
     const {variant, heavyTalentName, ratio} = resolveBannerVariant(

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -8,11 +8,10 @@ import {createStyles} from './styles';
 
 import {AlertIcon} from '../../assets/icons';
 import {useTheme} from '../../hooks';
-import {chatSessionStore, modelStore, serverStore} from '../../store';
+import {chatSessionStore, modelStore} from '../../store';
 import {L10nContext} from '../../utils';
 import {MessageType, ModelOrigin} from '../../utils/types';
 import {resolveBannerVariant} from '../../utils/bannerVariantResolver';
-import {resolveRemoteCaps} from '../../utils/remoteCaps';
 import {talentRegistry} from '../../services/talents';
 import {t} from '../../locales';
 
@@ -101,26 +100,12 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
       },
     };
 
-    const activeModel = modelStore.activeModel;
-    const isRemote = activeModel?.origin === ModelOrigin.REMOTE;
+    const isRemote = modelStore.activeModel?.origin === ModelOrigin.REMOTE;
 
-    // activeContextSettings.n_ctx is local-only (set by a LlamaContext). For a
-    // remote model fall back to the /props-reported window for that model so
-    // the context banners can measure against a real one.
-    //
-    // The `> 0` filter is defence in depth: the openai.ts parse already drops
-    // a non-positive window, and 0 means unknown, not exhausted — a banner
-    // measured against it would read every turn as context-full.
-    const localNCtx = modelStore.activeContextSettings?.n_ctx;
-    const resolvedNCtx =
-      localNCtx ??
-      resolveRemoteCaps(
-        activeModel,
-        serverStore.remoteCaps,
-        modelStore.activeRemoteBinding,
-      ).contextLength;
-    const effectiveNCtx =
-      resolvedNCtx !== undefined && resolvedNCtx > 0 ? resolvedNCtx : undefined;
+    // The window the live session measures against — local `n_ctx` or the
+    // /props-reported one, picked by the resolver. Already `> 0` or absent, so
+    // 0 (unknown, not exhausted) can never read as context-full here.
+    const effectiveNCtx = modelStore.activeModelCaps.effectiveContextLength;
 
     const {variant, heavyTalentName, ratio} = resolveBannerVariant(
       chatSessionStore.lastCompletionResult,

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -190,9 +190,9 @@ describe('BannerRow', () => {
           name: 'llama',
           url: 'http://localhost:8080',
           serverType: 'llama.cpp',
-          contextLength: 4096,
         } as any,
       ];
+      serverStore.remoteCaps = {'remote-1': {contextLength: 4096}};
       // A remote session can reach >=2 consecutive full turns (the counter is
       // remote-agnostic), but must not re-surface the escalated increase advice.
       chatSessionStore.consecutiveFullFailures = 2;
@@ -210,6 +210,7 @@ describe('BannerRow', () => {
     runInAction(() => {
       modelStore.models = [];
       serverStore.servers = [];
+      serverStore.remoteCaps = {};
     });
   });
 
@@ -274,9 +275,9 @@ describe('BannerRow', () => {
           name: 'llama',
           url: 'http://localhost:8080',
           serverType: 'llama.cpp',
-          contextLength: 4096,
         } as any,
       ];
+      serverStore.remoteCaps = {'remote-1': {contextLength: 4096}};
       chatSessionStore.lastCompletionResult = {
         used: 4096,
         contextFull: true,
@@ -295,33 +296,35 @@ describe('BannerRow', () => {
     runInAction(() => {
       modelStore.models = [];
       serverStore.servers = [];
+      serverStore.remoteCaps = {};
     });
   });
 
-  it('prefers the per-model window over the per-server one', () => {
+  it('ignores a window probed against another backend', () => {
     runInAction(() => {
-      modelStore.activeModelId = 'srv-1/gemma-4-e2b';
+      modelStore.activeModelId = 'remote-1';
       modelStore.models = [
-        {
-          id: 'srv-1/gemma-4-e2b',
-          origin: ModelOrigin.REMOTE,
-          serverId: 'srv-1',
-        } as any,
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
       ];
       (modelStore as any).activeContextSettings = undefined;
       serverStore.servers = [
         {
           id: 'srv-1',
           name: 'llama',
-          url: 'http://localhost:8080',
-          serverType: 'llama.cpp',
-          contextLength: 4096,
+          url: 'http://localhost:9090',
         } as any,
       ];
-      serverStore.remoteCaps = {
-        'srv-1/gemma-4-e2b': {contextLength: 8192, supportsVision: true},
+      // The session is still on :8080; the entry describes :9090, so there is
+      // no window to measure against and the banners stay silent.
+      modelStore.activeRemoteBinding = {
+        modelId: 'remote-1',
+        serverId: 'srv-1',
+        remoteModelId: 'remote-1',
+        url: 'http://localhost:8080',
       };
-      // Half of the per-model window, but full against the per-server one.
+      serverStore.remoteCaps = {
+        'remote-1': {contextLength: 4096, probedUrl: 'http://localhost:9090'},
+      };
       chatSessionStore.lastCompletionResult = {
         used: 4096,
         contextFull: false,
@@ -334,42 +337,9 @@ describe('BannerRow', () => {
 
     runInAction(() => {
       modelStore.models = [];
+      modelStore.activeRemoteBinding = undefined;
       serverStore.servers = [];
       serverStore.remoteCaps = {};
-    });
-  });
-
-  it('does not treat a legacy per-server window of 0 as a full context', () => {
-    runInAction(() => {
-      modelStore.activeModelId = 'remote-1';
-      modelStore.models = [
-        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
-      ];
-      (modelStore as any).activeContextSettings = undefined;
-      // A router placeholder persisted 0 before capabilities went per model.
-      // 0 is an unknown window, not an exhausted one.
-      serverStore.servers = [
-        {
-          id: 'srv-1',
-          name: 'llama',
-          url: 'http://localhost:8080',
-          serverType: 'llama.cpp',
-          contextLength: 0,
-        } as any,
-      ];
-      chatSessionStore.lastCompletionResult = {
-        used: 120,
-        contextFull: false,
-        isRemote: true,
-      };
-    });
-    const {queryByTestId} = renderBanner();
-    expect(queryByTestId('context-full-banner')).toBeNull();
-    expect(queryByTestId('context-warning-banner')).toBeNull();
-
-    runInAction(() => {
-      modelStore.models = [];
-      serverStore.servers = [];
     });
   });
 
@@ -420,9 +390,9 @@ describe('BannerRow', () => {
           name: 'llama',
           url: 'http://localhost:8080',
           serverType: 'llama.cpp',
-          contextLength: 4096,
         } as any,
       ];
+      serverStore.remoteCaps = {'remote-1': {contextLength: 4096}};
       chatSessionStore.lastCompletionResult = {
         used: 4096,
         contextFull: true,
@@ -439,6 +409,7 @@ describe('BannerRow', () => {
     runInAction(() => {
       modelStore.models = [];
       serverStore.servers = [];
+      serverStore.remoteCaps = {};
     });
   });
 
@@ -468,9 +439,9 @@ describe('BannerRow', () => {
           name: 'llama',
           url: 'http://localhost:8080',
           serverType: 'llama.cpp',
-          contextLength: 4096,
         } as any,
       ];
+      serverStore.remoteCaps = {'remote-1': {contextLength: 4096}};
       chatSessionStore.lastCompletionResult = {
         used: 3300,
         contextFull: false,
@@ -486,6 +457,7 @@ describe('BannerRow', () => {
     runInAction(() => {
       modelStore.models = [];
       serverStore.servers = [];
+      serverStore.remoteCaps = {};
     });
   });
 

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {runInAction} from 'mobx';
 
 import {fireEvent, render} from '../../../../jest/test-utils';
+import {modelsList} from '../../../../jest/fixtures/models';
 
 import {L10nContext} from '../../../utils';
 import {ModelOrigin} from '../../../utils/types';
@@ -30,6 +31,9 @@ describe('BannerRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     runInAction(() => {
+      // Cases that swap in a remote model leave the list empty, so restore it:
+      // the local window resolves against the active model, not the id alone.
+      modelStore.models = modelsList;
       modelStore.activeModelId = 'model-1';
       (modelStore as any).activeContextSettings = {n_ctx: 4096};
       modelStore.availableMemoryCeiling = 5 * 1e9;
@@ -424,6 +428,29 @@ describe('BannerRow', () => {
     const {getByText, queryByText} = renderBanner({canIncrease: true});
     expect(getByText(l10n.en.chat.contextFull)).toBeTruthy();
     expect(queryByText(l10n.en.chat.contextFullRemote)).toBeNull();
+  });
+
+  it('measures against the session window, not the window the model declares', () => {
+    runInAction(() => {
+      modelStore.models = [
+        {
+          id: 'model-1',
+          origin: ModelOrigin.PRESET,
+          ggufMetadata: {context_length: 32768},
+        } as any,
+      ];
+      (modelStore as any).activeContextSettings = {n_ctx: 4096};
+      chatSessionStore.lastCompletionResult = {
+        used: 3300,
+        contextFull: false,
+        isRemote: false,
+      };
+    });
+    const {getByTestId} = renderBanner();
+    // 3300 / 4096 ≈ 81%; against the declared 32768 it would be 10% and no
+    // banner would render at all.
+    expect(getByTestId('context-warning-banner')).toBeTruthy();
+    expect(getByTestId('banner-percent')).toHaveTextContent('81%');
   });
 
   it('resolves the near-limit warning + meter percent for a remote model', () => {

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -339,7 +339,7 @@ describe('BannerRow', () => {
     });
   });
 
-  it('does not treat a reported window of 0 as a full context', () => {
+  it('does not treat a legacy per-server window of 0 as a full context', () => {
     runInAction(() => {
       modelStore.activeModelId = 'remote-1';
       modelStore.models = [
@@ -370,6 +370,40 @@ describe('BannerRow', () => {
     runInAction(() => {
       modelStore.models = [];
       serverStore.servers = [];
+    });
+  });
+
+  it('does not treat a per-model window of 0 as a full context', () => {
+    runInAction(() => {
+      modelStore.activeModelId = 'remote-1';
+      modelStore.models = [
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
+      ];
+      (modelStore as any).activeContextSettings = undefined;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+        } as any,
+      ];
+      // No writer produces this today; the gate is what keeps it that way.
+      serverStore.remoteCaps = {'remote-1': {contextLength: 0}};
+      chatSessionStore.lastCompletionResult = {
+        used: 120,
+        contextFull: false,
+        isRemote: true,
+      };
+    });
+    const {queryByTestId} = renderBanner();
+    expect(queryByTestId('context-full-banner')).toBeNull();
+    expect(queryByTestId('context-warning-banner')).toBeNull();
+
+    runInAction(() => {
+      modelStore.models = [];
+      serverStore.servers = [];
+      serverStore.remoteCaps = {};
     });
   });
 

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -298,6 +298,81 @@ describe('BannerRow', () => {
     });
   });
 
+  it('prefers the per-model window over the per-server one', () => {
+    runInAction(() => {
+      modelStore.activeModelId = 'srv-1/gemma-4-e2b';
+      modelStore.models = [
+        {
+          id: 'srv-1/gemma-4-e2b',
+          origin: ModelOrigin.REMOTE,
+          serverId: 'srv-1',
+        } as any,
+      ];
+      (modelStore as any).activeContextSettings = undefined;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+          contextLength: 4096,
+        } as any,
+      ];
+      serverStore.remoteCaps = {
+        'srv-1/gemma-4-e2b': {contextLength: 8192, supportsVision: true},
+      };
+      // Half of the per-model window, but full against the per-server one.
+      chatSessionStore.lastCompletionResult = {
+        used: 4096,
+        contextFull: false,
+        isRemote: true,
+      };
+    });
+    const {queryByTestId} = renderBanner();
+    expect(queryByTestId('context-full-banner')).toBeNull();
+    expect(queryByTestId('context-warning-banner')).toBeNull();
+
+    runInAction(() => {
+      modelStore.models = [];
+      serverStore.servers = [];
+      serverStore.remoteCaps = {};
+    });
+  });
+
+  it('does not treat a reported window of 0 as a full context', () => {
+    runInAction(() => {
+      modelStore.activeModelId = 'remote-1';
+      modelStore.models = [
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
+      ];
+      (modelStore as any).activeContextSettings = undefined;
+      // A router placeholder persisted 0 before capabilities went per model.
+      // 0 is an unknown window, not an exhausted one.
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+          contextLength: 0,
+        } as any,
+      ];
+      chatSessionStore.lastCompletionResult = {
+        used: 120,
+        contextFull: false,
+        isRemote: true,
+      };
+    });
+    const {queryByTestId} = renderBanner();
+    expect(queryByTestId('context-full-banner')).toBeNull();
+    expect(queryByTestId('context-warning-banner')).toBeNull();
+
+    runInAction(() => {
+      modelStore.models = [];
+      serverStore.servers = [];
+    });
+  });
+
   it('uses the remote context-full copy (no increase clause) for a remote model', () => {
     runInAction(() => {
       modelStore.activeModelId = 'remote-1';

--- a/src/components/RemoteModelSheet/RemoteModelSheet.tsx
+++ b/src/components/RemoteModelSheet/RemoteModelSheet.tsx
@@ -612,6 +612,11 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                       uncheckedColor={theme.colors.onSurfaceVariant}
                     />
                     <Text style={styles.modelName}>{model.id}</Text>
+                    {alreadyAdded && (
+                      <Text style={styles.alreadyAddedText}>
+                        {l10n.settings.alreadyAdded}
+                      </Text>
+                    )}
                     {serverTypeInEffect === 'llama.cpp' && (
                       <View
                         style={styles.modelVisionSlot}
@@ -642,11 +647,6 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                           <Text style={styles.modelVisionUnknown}>—</Text>
                         )}
                       </View>
-                    )}
-                    {alreadyAdded && (
-                      <Text style={styles.alreadyAddedText}>
-                        {l10n.settings.alreadyAdded}
-                      </Text>
                     )}
                   </TouchableOpacity>
                 );

--- a/src/components/RemoteModelSheet/RemoteModelSheet.tsx
+++ b/src/components/RemoteModelSheet/RemoteModelSheet.tsx
@@ -622,7 +622,7 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                             ? l10n.models.modelCard.labels.visionSupported
                             : listCaps.supportsVision === false
                               ? l10n.models.modelCard.labels.visionNotSupported
-                              : l10n.models.modelCard.labels.capabilityUnknown
+                              : l10n.models.modelCard.labels.visionUnknown
                         }`}>
                         {listCaps.supportsVision === true ? (
                           <EyeIcon
@@ -637,10 +637,8 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                             stroke={theme.colors.iconModelTypeText}
                           />
                         ) : (
-                          // Three states, not two: "no vision" and "this build
-                          // does not say" land on 42 rows and one row
-                          // respectively, and absence alone cannot tell them
-                          // apart — a screen reader would hear nothing at all.
+                          // Without a visible placeholder a screen reader
+                          // would hear nothing at all here.
                           <Text style={styles.modelVisionUnknown}>—</Text>
                         )}
                       </View>

--- a/src/components/RemoteModelSheet/RemoteModelSheet.tsx
+++ b/src/components/RemoteModelSheet/RemoteModelSheet.tsx
@@ -38,10 +38,11 @@ import {
   fetchModelsWithHeaders,
   detectServerType,
 } from '../../api/openai';
+import {deriveListCaps} from '../../utils/listCaps';
 import {t} from '../../locales';
 
 import {createStyles} from './styles';
-import {EyeIcon, EyeOffIcon} from '../../assets/icons';
+import {ChatIcon, EyeIcon, EyeOffIcon} from '../../assets/icons';
 
 interface RemoteModelSheetProps {
   isVisible: boolean;
@@ -304,6 +305,11 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
     const selectedServer = selectedServerId
       ? serverStore.servers.find(s => s.id === selectedServerId)
       : null;
+
+    // The type in effect, which is not always the type this sheet detected:
+    // pressing a known-server chip never calls setServerType, so on the very
+    // routers this exists for the local state is still 'unknown'.
+    const serverTypeInEffect = selectedServer?.serverType ?? serverType;
 
     const showPostConnection = probeResult?.ok === true;
     // Show API key + server name fields when probe attempted (success OR auth failure)
@@ -574,6 +580,7 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                 const servId = selectedServerId || '';
                 const alreadyAdded =
                   !!selectedServerId && isModelAlreadyAdded(servId, model.id);
+                const listCaps = deriveListCaps(model, serverTypeInEffect);
                 return (
                   <TouchableOpacity
                     key={model.id}
@@ -605,6 +612,39 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                       uncheckedColor={theme.colors.onSurfaceVariant}
                     />
                     <Text style={styles.modelName}>{model.id}</Text>
+                    {serverTypeInEffect === 'llama.cpp' && (
+                      <View
+                        style={styles.modelVisionSlot}
+                        testID={`remote-model-row-vision-${model.id}`}
+                        accessible={true}
+                        accessibilityLabel={`${l10n.models.modelCard.labels.vision}: ${
+                          listCaps.supportsVision === true
+                            ? l10n.models.modelCard.labels.visionSupported
+                            : listCaps.supportsVision === false
+                              ? l10n.models.modelCard.labels.visionNotSupported
+                              : l10n.models.modelCard.labels.capabilityUnknown
+                        }`}>
+                        {listCaps.supportsVision === true ? (
+                          <EyeIcon
+                            width={16}
+                            height={16}
+                            stroke={theme.colors.iconModelTypeVision}
+                          />
+                        ) : listCaps.supportsVision === false ? (
+                          <ChatIcon
+                            width={16}
+                            height={16}
+                            stroke={theme.colors.iconModelTypeText}
+                          />
+                        ) : (
+                          // Three states, not two: "no vision" and "this build
+                          // does not say" land on 42 rows and one row
+                          // respectively, and absence alone cannot tell them
+                          // apart — a screen reader would hear nothing at all.
+                          <Text style={styles.modelVisionUnknown}>—</Text>
+                        )}
+                      </View>
+                    )}
                     {alreadyAdded && (
                       <Text style={styles.alreadyAddedText}>
                         {l10n.settings.alreadyAdded}

--- a/src/components/RemoteModelSheet/RemoteModelSheet.tsx
+++ b/src/components/RemoteModelSheet/RemoteModelSheet.tsx
@@ -642,8 +642,6 @@ export const RemoteModelSheet: React.FC<RemoteModelSheetProps> = observer(
                             stroke={theme.colors.iconModelTypeText}
                           />
                         ) : (
-                          // Without a visible placeholder a screen reader
-                          // would hear nothing at all here.
                           <Text style={styles.modelVisionUnknown}>—</Text>
                         )}
                       </View>

--- a/src/components/RemoteModelSheet/__tests__/RemoteModelSheet.test.tsx
+++ b/src/components/RemoteModelSheet/__tests__/RemoteModelSheet.test.tsx
@@ -2,10 +2,16 @@ import React from 'react';
 import {render, fireEvent, waitFor} from '../../../../jest/test-utils';
 import {RemoteModelSheet} from '../RemoteModelSheet';
 import {serverStore} from '../../../store';
-import {fetchModels, fetchModelsWithHeaders} from '../../../api/openai';
+import {
+  detectServerType,
+  fetchModels,
+  fetchModelsWithHeaders,
+} from '../../../api/openai';
+import {routerModelsBody} from '../../../../jest/fixtures/remoteModelList';
 
 const mockedFetchModels = fetchModels as jest.Mock;
 const mockedFetchModelsWithHeaders = fetchModelsWithHeaders as jest.Mock;
+const mockedDetectServerType = detectServerType as jest.Mock;
 
 // Mock the Sheet component following HFTokenSheet test pattern
 jest.mock('../../Sheet', () => {
@@ -362,6 +368,93 @@ describe('RemoteModelSheet', () => {
           undefined,
         );
       });
+    });
+  });
+  describe('the row vision slot', () => {
+    const ROUTER_ROWS = routerModelsBody.data as any[];
+    const VISION = 'gemma-4-e2b';
+    const TEXT = 'gemma-3-4b';
+
+    const openViaChip = async (
+      serverType: string | undefined,
+      rows: any[] = ROUTER_ROWS,
+    ) => {
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'router',
+          url: 'http://localhost:8080',
+          serverType,
+        },
+      ];
+      (serverStore.getApiKey as jest.Mock).mockResolvedValue(undefined);
+      mockedFetchModels.mockResolvedValueOnce(rows);
+
+      const view = render(
+        <RemoteModelSheet isVisible={true} onDismiss={jest.fn()} />,
+      );
+      fireEvent.press(view.getByTestId('server-chip-srv-1'));
+      await waitFor(() => {
+        expect(view.queryByText(VISION)).toBeTruthy();
+      });
+      return view;
+    };
+
+    const slot = (id: string) => `remote-model-row-vision-${id}`;
+
+    it('tells the three states apart in one list', async () => {
+      // The row the router build cannot describe has to read differently from
+      // the row it describes as text-only, or 42 rows collapse into one state.
+      const unknownRow = {...ROUTER_ROWS[0], id: 'mystery-model'};
+      delete unknownRow.architecture;
+      const {getByTestId} = await openViaChip('llama.cpp', [
+        ...ROUTER_ROWS,
+        unknownRow,
+      ]);
+
+      const labels = [VISION, TEXT, 'mystery-model'].map(
+        id => getByTestId(slot(id)).props.accessibilityLabel,
+      );
+
+      expect(labels).toEqual([
+        'Vision: Supported',
+        'Vision: Not supported',
+        'Vision: Unknown',
+      ]);
+      expect(new Set(labels).size).toBe(3);
+    });
+
+    it('reads the persisted server type, not the type this sheet detected', async () => {
+      const {getByTestId} = await openViaChip('llama.cpp');
+
+      // The chip path never detects a type, so the sheet own serverType state
+      // is still its initial 'unknown'. The slot renders anyway, which is the
+      // whole point: gating on that state would suppress it on exactly the
+      // routers this exists for.
+      expect(mockedDetectServerType).not.toHaveBeenCalled();
+      expect(getByTestId(slot(VISION))).toBeTruthy();
+    });
+
+    it('renders no slot at all on a server of another type', async () => {
+      const {queryByTestId} = await openViaChip('Ollama');
+
+      expect(queryByTestId(slot(VISION))).toBeNull();
+      expect(queryByTestId(slot(TEXT))).toBeNull();
+    });
+
+    it('renders no slot for a server whose type is unknown', async () => {
+      const {queryByTestId} = await openViaChip(undefined);
+
+      expect(queryByTestId(slot(VISION))).toBeNull();
+    });
+
+    it('issues no request of its own to answer', async () => {
+      await openViaChip('llama.cpp');
+
+      // One models fetch for the chip press, and nothing else: the slot reads
+      // a body the sheet already had.
+      expect(mockedFetchModels).toHaveBeenCalledTimes(1);
+      expect(mockedFetchModelsWithHeaders).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/RemoteModelSheet/__tests__/RemoteModelSheet.test.tsx
+++ b/src/components/RemoteModelSheet/__tests__/RemoteModelSheet.test.tsx
@@ -427,10 +427,8 @@ describe('RemoteModelSheet', () => {
     it('reads the persisted server type, not the type this sheet detected', async () => {
       const {getByTestId} = await openViaChip('llama.cpp');
 
-      // The chip path never detects a type, so the sheet own serverType state
-      // is still its initial 'unknown'. The slot renders anyway, which is the
-      // whole point: gating on that state would suppress it on exactly the
-      // routers this exists for.
+      // The chip path never detects a type, so the sheet's own serverType
+      // state is still its initial 'unknown'.
       expect(mockedDetectServerType).not.toHaveBeenCalled();
       expect(getByTestId(slot(VISION))).toBeTruthy();
     });
@@ -451,8 +449,6 @@ describe('RemoteModelSheet', () => {
     it('issues no request of its own to answer', async () => {
       await openViaChip('llama.cpp');
 
-      // One models fetch for the chip press, and nothing else: the slot reads
-      // a body the sheet already had.
       expect(mockedFetchModels).toHaveBeenCalledTimes(1);
       expect(mockedFetchModelsWithHeaders).not.toHaveBeenCalled();
     });

--- a/src/components/RemoteModelSheet/styles.ts
+++ b/src/components/RemoteModelSheet/styles.ts
@@ -114,6 +114,15 @@ export const createStyles = (theme: Theme) => {
       color: theme.colors.onSurface,
       marginLeft: 8,
     },
+    modelVisionSlot: {
+      marginLeft: 4,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    modelVisionUnknown: {
+      fontSize: 14,
+      color: theme.colors.onSurfaceVariant,
+    },
     alreadyAddedText: {
       fontSize: 12,
       color: theme.colors.onSurfaceVariant,

--- a/src/components/RemoteModelSheet/styles.ts
+++ b/src/components/RemoteModelSheet/styles.ts
@@ -115,7 +115,7 @@ export const createStyles = (theme: Theme) => {
       marginLeft: 8,
     },
     modelVisionSlot: {
-      marginLeft: 4,
+      marginStart: 4,
       alignItems: 'center',
       justifyContent: 'center',
     },

--- a/src/components/RemoteModelSheet/styles.ts
+++ b/src/components/RemoteModelSheet/styles.ts
@@ -115,7 +115,8 @@ export const createStyles = (theme: Theme) => {
       marginLeft: 8,
     },
     modelVisionSlot: {
-      marginStart: 4,
+      width: 20,
+      marginStart: 12,
       alignItems: 'center',
       justifyContent: 'center',
     },
@@ -127,7 +128,7 @@ export const createStyles = (theme: Theme) => {
       fontSize: 12,
       color: theme.colors.onSurfaceVariant,
       fontStyle: 'italic',
-      marginLeft: 4,
+      marginStart: 4,
     },
     noModelsText: {
       fontSize: 14,

--- a/src/hooks/__tests__/useChatSession.test.ts
+++ b/src/hooks/__tests__/useChatSession.test.ts
@@ -333,9 +333,8 @@ describe('useChatSession', () => {
   });
 
   it('emits multimodal warning when user sends an image but multimodal is disabled', async () => {
-    // modelStore.isMultimodalEnabled is mocked to return false by default
-    // (see __mocks__/stores/modelStore.ts). The hook should call
-    // uiStore.setChatWarning with the multimodal-not-enabled message.
+    // No model is vision-active, so the hook should call uiStore.setChatWarning
+    // with the multimodal-not-enabled message.
     if (modelStore.context) {
       modelStore.context.completion = jest
         .fn()

--- a/src/hooks/__tests__/useChatSession.test.ts
+++ b/src/hooks/__tests__/useChatSession.test.ts
@@ -1,5 +1,6 @@
 import {LlamaContext} from 'llama.rn';
 import {renderHook, act, waitFor} from '@testing-library/react-native';
+import {runInAction} from 'mobx';
 
 import {textMessage} from '../../../jest/fixtures';
 import {sessionFixtures} from '../../../jest/fixtures/chatSessions';
@@ -17,12 +18,14 @@ import {
   chatSessionStore,
   modelStore,
   palStore,
+  serverStore,
   ttsStore,
   uiStore,
 } from '../../store';
 
 import {l10n} from '../../locales';
 import {assistant} from '../../utils/chat';
+import {ModelOrigin} from '../../utils/types';
 
 const mockAssistant = {
   id: 'h3o3lc5xj',
@@ -354,6 +357,51 @@ describe('useChatSession', () => {
     const arg = (uiStore.setChatWarning as jest.Mock).mock.calls[0][0];
     // The warning carries the multimodalNotEnabled message text.
     expect(JSON.stringify(arg)).toContain(l10n.en.chat.multimodalNotEnabled);
+  });
+
+  it('sends an image on a remote model whose probe reported vision', async () => {
+    runInAction(() => {
+      modelStore.models = [
+        {
+          id: 'srv-1/gemma-4-e2b',
+          origin: ModelOrigin.REMOTE,
+          serverId: 'srv-1',
+          remoteModelId: 'gemma-4-e2b',
+        } as any,
+      ];
+      modelStore.activeModelId = 'srv-1/gemma-4-e2b';
+      serverStore.remoteCaps = {'srv-1/gemma-4-e2b': {supportsVision: true}};
+    });
+    if (modelStore.context) {
+      modelStore.context.completion = jest
+        .fn()
+        .mockResolvedValue({text: 'ok', content: 'ok', timings: {}});
+    }
+
+    const {result} = renderHook(() =>
+      useChatSession({current: null}, textMessage.author, mockAssistant),
+    );
+    await act(async () => {
+      await result.current.handleSendPress({
+        text: 'look at this',
+        type: 'text',
+        imageUris: ['file:///photo.jpg'],
+      });
+    });
+
+    // The attach affordance and the send gate read the same field of the same
+    // call, so a capability good enough to enable attach also delivers.
+    const warnings = (uiStore.setChatWarning as jest.Mock).mock.calls;
+    expect(
+      warnings.some(call =>
+        JSON.stringify(call[0]).includes(l10n.en.chat.multimodalNotEnabled),
+      ),
+    ).toBe(false);
+
+    runInAction(() => {
+      serverStore.remoteCaps = {};
+      modelStore.activeModelId = undefined;
+    });
   });
 
   it('should use system prompt as-is when pal has no parameters', async () => {

--- a/src/hooks/__tests__/useChatSession.test.ts
+++ b/src/hooks/__tests__/useChatSession.test.ts
@@ -389,8 +389,15 @@ describe('useChatSession', () => {
       });
     });
 
-    // The attach affordance and the send gate read the same field of the same
-    // call, so a capability good enough to enable attach also delivers.
+    const sent = (modelStore.engine!.completion as jest.Mock).mock
+      .calls[0][0] as {messages: Array<{role: string; content: any}>};
+    const lastUser = [...sent.messages].reverse().find(m => m.role === 'user')!;
+    expect(lastUser.content).toEqual(
+      expect.arrayContaining([
+        {type: 'image_url', image_url: {url: 'file:///photo.jpg'}},
+      ]),
+    );
+
     const warnings = (uiStore.setChatWarning as jest.Mock).mock.calls;
     expect(
       warnings.some(call =>

--- a/src/hooks/__tests__/useChatSession.test.ts
+++ b/src/hooks/__tests__/useChatSession.test.ts
@@ -336,8 +336,6 @@ describe('useChatSession', () => {
   });
 
   it('emits multimodal warning when user sends an image but multimodal is disabled', async () => {
-    // No model is vision-active, so the hook should call uiStore.setChatWarning
-    // with the multimodal-not-enabled message.
     if (modelStore.context) {
       modelStore.context.completion = jest
         .fn()

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -520,7 +520,7 @@ export const useChatSession = (
     const imageUris = message.imageUris;
     const hasImages = !!(imageUris && imageUris.length > 0);
 
-    const isMultimodalEnabled = await modelStore.isMultimodalEnabled();
+    const isMultimodalEnabled = modelStore.activeModelCaps.visionActive;
 
     const currentMessages = toJS(chatSessionStore.currentSessionMessages);
 
@@ -920,6 +920,5 @@ export const useChatSession = (
     handleSendPress,
     handleResetConversation,
     handleStopPress,
-    isMultimodalEnabled: async () => await modelStore.isMultimodalEnabled(),
   };
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -377,6 +377,9 @@
       "labels": {
         "skills": "Skills: ",
         "vision": "Vision",
+        "visionSupported": "Supported",
+        "visionNotSupported": "Not supported",
+        "capabilityUnknown": "Unknown",
         "capabilities": "capabilities.",
         "modelName": "Model Name",
         "contextLength": "Context Length",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -379,7 +379,7 @@
         "vision": "Vision",
         "visionSupported": "Supported",
         "visionNotSupported": "Not supported",
-        "capabilityUnknown": "Unknown",
+        "visionUnknown": "Unknown",
         "capabilities": "capabilities.",
         "modelName": "Model Name",
         "contextLength": "Context Length",

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -26,8 +26,7 @@ import {hasVideoCapability} from '../../utils/pal-capabilities';
 
 import {L10nContext} from '../../utils';
 import {resolveReasoningCapability} from '../../utils/reasoningCapability';
-import {resolveRemoteCaps} from '../../utils/remoteCaps';
-import {MessageType, ModelOrigin} from '../../utils/types';
+import {MessageType} from '../../utils/types';
 import {ErrorState} from '../../utils/errors';
 import {user, assistant} from '../../utils/chat';
 
@@ -73,8 +72,11 @@ export const ChatScreen: React.FC = observer(() => {
   const [isErrorReportVisible, setIsErrorReportVisible] = useState(false);
   const [errorToReport, setErrorToReport] = useState<ErrorState | null>(null);
 
-  const {handleSendPress, handleStopPress, isMultimodalEnabled} =
-    useChatSession(currentMessageInfo, user, assistant);
+  const {handleSendPress, handleStopPress} = useChatSession(
+    currentMessageInfo,
+    user,
+    assistant,
+  );
 
   // Handle deep linking for message prefill
   const {pendingMessage, clearPendingMessage} = usePendingMessage();
@@ -102,30 +104,10 @@ export const ChatScreen: React.FC = observer(() => {
     setErrorToReport(null);
   }, []);
 
-  // Local vision needs the loaded context, so it is resolved asynchronously.
-  const [multimodalEnabled, setMultimodalEnabled] = React.useState(false);
-
-  React.useEffect(() => {
-    const checkMultimodal = async () => {
-      const enabled = await isMultimodalEnabled();
-      setMultimodalEnabled(enabled);
-    };
-
-    checkMultimodal();
-  }, [isMultimodalEnabled]);
-
-  // Remote vision is resolved here in the render body, not in the effect above:
-  // caps land from a detached probe, and only a tracked read re-renders the
+  // Resolved in the render body, not an effect: capabilities land from a
+  // detached probe or a model load, and only a tracked read re-renders the
   // attach affordance when they do. Unknown stays disabled.
-  const activeModel = modelStore.activeModel;
-  const isRemoteModel = activeModel?.origin === ModelOrigin.REMOTE;
-  const visionEnabled = isRemoteModel
-    ? resolveRemoteCaps(
-        activeModel,
-        serverStore.remoteCaps,
-        modelStore.activeRemoteBinding,
-      ).supportsVision === true
-    : multimodalEnabled;
+  const visionEnabled = modelStore.activeModelCaps.visionActive;
 
   // Resolver is the single source of truth for reasoning capability.
   // Pill is reachable whenever the model is not known to be non-reasoning

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -26,7 +26,8 @@ import {hasVideoCapability} from '../../utils/pal-capabilities';
 
 import {L10nContext} from '../../utils';
 import {resolveReasoningCapability} from '../../utils/reasoningCapability';
-import {MessageType} from '../../utils/types';
+import {resolveRemoteCaps} from '../../utils/remoteCaps';
+import {MessageType, ModelOrigin} from '../../utils/types';
 import {ErrorState} from '../../utils/errors';
 import {user, assistant} from '../../utils/chat';
 
@@ -101,7 +102,7 @@ export const ChatScreen: React.FC = observer(() => {
     setErrorToReport(null);
   }, []);
 
-  // Check if multimodal is enabled
+  // Local vision needs the loaded context, so it is resolved asynchronously.
   const [multimodalEnabled, setMultimodalEnabled] = React.useState(false);
 
   React.useEffect(() => {
@@ -112,6 +113,19 @@ export const ChatScreen: React.FC = observer(() => {
 
     checkMultimodal();
   }, [isMultimodalEnabled]);
+
+  // Remote vision is resolved here in the render body, not in the effect above:
+  // caps land from a detached probe, and only a tracked read re-renders the
+  // attach affordance when they do. Unknown stays disabled.
+  const activeModel = modelStore.activeModel;
+  const isRemoteModel = activeModel?.origin === ModelOrigin.REMOTE;
+  const visionEnabled = isRemoteModel
+    ? resolveRemoteCaps(
+        activeModel,
+        serverStore.remoteCaps,
+        serverStore.servers,
+      ).supportsVision === true
+    : multimodalEnabled;
 
   // Resolver is the single source of truth for reasoning capability.
   // Pill is reachable whenever the model is not known to be non-reasoning
@@ -275,7 +289,7 @@ export const ChatScreen: React.FC = observer(() => {
         isStreaming={modelStore.isStreaming}
         sendButtonVisibilityMode="always"
         showImageUpload={true}
-        isVisionEnabled={multimodalEnabled}
+        isVisionEnabled={visionEnabled}
         initialInputText={pendingMessage || undefined}
         onInitialTextConsumed={clearPendingMessage}
         inputProps={{

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -104,9 +104,6 @@ export const ChatScreen: React.FC = observer(() => {
     setErrorToReport(null);
   }, []);
 
-  // Resolved in the render body, not an effect: capabilities land from a
-  // detached probe or a model load, and only a tracked read re-renders the
-  // attach affordance when they do. Unknown stays disabled.
   const visionEnabled = modelStore.activeModelCaps.visionActive;
 
   // Resolver is the single source of truth for reasoning capability.

--- a/src/screens/ChatScreen/ChatScreen.tsx
+++ b/src/screens/ChatScreen/ChatScreen.tsx
@@ -123,7 +123,7 @@ export const ChatScreen: React.FC = observer(() => {
     ? resolveRemoteCaps(
         activeModel,
         serverStore.remoteCaps,
-        serverStore.servers,
+        modelStore.activeRemoteBinding,
       ).supportsVision === true
     : multimodalEnabled;
 

--- a/src/screens/ChatScreen/VideoPalScreen.tsx
+++ b/src/screens/ChatScreen/VideoPalScreen.tsx
@@ -119,8 +119,7 @@ export const VideoPalScreen = observer(({activePal}: VideoPalScreenProps) => {
 
     // Check if multimodal is enabled
     try {
-      const isEnabled = await modelStore.isMultimodalEnabled();
-      if (!isEnabled) {
+      if (!modelStore.activeModelCaps.visionActive) {
         safeAlert(
           'Multimodal Not Enabled',
           'This model does not support image analysis. Please load a multimodal model.',

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -858,3 +858,88 @@ describe('ChatScreen on/off toggle → reasoning carrier (remote)', () => {
     });
   });
 });
+
+// The image-attach affordance must reflect a capability that lands after the
+// screen is already on screen: the probe is detached and a lazily-started
+// server can take seconds to answer. This only holds while the flag is derived
+// in the render body — resolving it in an effect or a promise body would leave
+// the button stuck disabled, which is the whole defect.
+describe('ChatScreen remote vision reactivity', () => {
+  const modelId = 'srv-1/gemma-4-e2b';
+  let savedModels: any[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    savedModels = modelStore.models;
+    modelStore.models = [
+      ...savedModels,
+      {
+        ...savedModels[0],
+        id: modelId,
+        origin: ModelOrigin.REMOTE,
+        serverId: 'srv-1',
+        remoteModelId: 'gemma-4-e2b',
+      },
+    ];
+    runInAction(() => {
+      modelStore.context = undefined;
+      modelStore.activeModelId = modelId;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+        } as any,
+      ];
+      serverStore.remoteCaps = {};
+    });
+    modelStore.engine = {
+      completion: jest.fn(),
+      stopCompletion: jest.fn(),
+    } as any;
+  });
+
+  afterEach(() => {
+    modelStore.models = savedModels;
+    runInAction(() => {
+      modelStore.activeModelId = undefined;
+      serverStore.servers = [];
+      serverStore.remoteCaps = {};
+    });
+  });
+
+  it('enables attach when capabilities land, with no further user action', () => {
+    const {getByLabelText} = render(<ChatScreen />, {withNavigation: true});
+
+    // Unknown capabilities fail closed.
+    expect(getByLabelText('Add image').props.accessibilityState.disabled).toBe(
+      true,
+    );
+
+    act(() => {
+      runInAction(() => {
+        serverStore.remoteCaps[modelId] = {supportsVision: true};
+      });
+    });
+
+    // No navigation, no press, no prop change in between.
+    expect(getByLabelText('Add image').props.accessibilityState.disabled).toBe(
+      false,
+    );
+  });
+
+  it('keeps attach disabled for a sibling model that reports no vision', () => {
+    act(() => {
+      runInAction(() => {
+        serverStore.remoteCaps['srv-1/gemma-3-4b'] = {supportsVision: true};
+      });
+    });
+
+    const {getByLabelText} = render(<ChatScreen />, {withNavigation: true});
+
+    expect(getByLabelText('Add image').props.accessibilityState.disabled).toBe(
+      true,
+    );
+  });
+});

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -861,9 +861,7 @@ describe('ChatScreen on/off toggle → reasoning carrier (remote)', () => {
 
 // The image-attach affordance must reflect a capability that lands after the
 // screen is already on screen: the probe is detached and a lazily-started
-// server can take seconds to answer. This only holds while the flag is derived
-// in the render body — resolving it in an effect or a promise body would leave
-// the button stuck disabled, which is the whole defect.
+// server can take seconds to answer.
 describe('ChatScreen remote vision reactivity', () => {
   const modelId = 'srv-1/gemma-4-e2b';
   let savedModels: any[];
@@ -912,7 +910,6 @@ describe('ChatScreen remote vision reactivity', () => {
   it('enables attach when capabilities land, with no further user action', () => {
     const {getByLabelText} = render(<ChatScreen />, {withNavigation: true});
 
-    // Unknown capabilities fail closed.
     expect(getByLabelText('Add image').props.accessibilityState.disabled).toBe(
       true,
     );
@@ -923,7 +920,6 @@ describe('ChatScreen remote vision reactivity', () => {
       });
     });
 
-    // No navigation, no press, no prop change in between.
     expect(getByLabelText('Add image').props.accessibilityState.disabled).toBe(
       false,
     );

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -929,7 +929,7 @@ describe('ChatScreen remote vision reactivity', () => {
     );
   });
 
-  it('keeps attach disabled for a sibling model that reports no vision', () => {
+  it('does not let the active model inherit a sibling model vision flag', () => {
     act(() => {
       runInAction(() => {
         serverStore.remoteCaps['srv-1/gemma-3-4b'] = {supportsVision: true};

--- a/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/ChatScreen.test.tsx
@@ -929,6 +929,44 @@ describe('ChatScreen remote vision reactivity', () => {
     );
   });
 
+  it('enables attach when a local model finishes loading its projection', () => {
+    const localId = 'local-mm-1';
+    runInAction(() => {
+      modelStore.models = [
+        ...savedModels,
+        {
+          ...savedModels[0],
+          id: localId,
+          origin: ModelOrigin.PRESET,
+          supportsMultimodal: true,
+        },
+      ];
+      modelStore.activeModelId = localId;
+      modelStore.isMultimodalActive = false;
+    });
+
+    const {getByLabelText} = render(<ChatScreen />, {withNavigation: true});
+
+    expect(getByLabelText('Add image').props.accessibilityState.disabled).toBe(
+      true,
+    );
+
+    // What `proceedWithInitialization` writes once the native init verifies.
+    act(() => {
+      runInAction(() => {
+        modelStore.isMultimodalActive = true;
+      });
+    });
+
+    expect(getByLabelText('Add image').props.accessibilityState.disabled).toBe(
+      false,
+    );
+
+    runInAction(() => {
+      modelStore.isMultimodalActive = false;
+    });
+  });
+
   it('does not let the active model inherit a sibling model vision flag', () => {
     act(() => {
       runInAction(() => {

--- a/src/screens/ChatScreen/__tests__/VideoPalScreen.test.tsx
+++ b/src/screens/ChatScreen/__tests__/VideoPalScreen.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Alert} from 'react-native';
 
+import {runInAction} from 'mobx';
+
 import {
   render as baseRender,
   fireEvent,
@@ -11,6 +13,7 @@ import {VideoPalScreen} from '../VideoPalScreen';
 import {palStore, chatSessionStore, modelStore} from '../../../store';
 import type {Pal} from '../../../types/pal';
 import {LlamaContext} from 'llama.rn';
+import {ModelOrigin} from '../../../utils/types';
 import {mockLlamaContextParams} from '../../../../jest/fixtures/models';
 
 const render = (ui: React.ReactElement, options: any = {}) =>
@@ -53,6 +56,11 @@ describe('VideoPalScreen', () => {
   });
 
   afterEach(() => {
+    runInAction(() => {
+      modelStore.isMultimodalActive = false;
+      modelStore.activeModelId = undefined;
+      modelStore.models = [];
+    });
     // Restore original activePalId getter if it existed
     if (originalActivePalId) {
       Object.defineProperty(
@@ -116,8 +124,10 @@ describe('VideoPalScreen', () => {
     // Provide a context so we pass the first guard
     modelStore.context = new LlamaContext(mockLlamaContextParams);
 
-    // Ensure multimodal check resolves to false
-    jest.spyOn(modelStore, 'isMultimodalEnabled').mockResolvedValue(false);
+    // Multimodal is not active on the loaded model
+    runInAction(() => {
+      modelStore.isMultimodalActive = false;
+    });
 
     const alertSpy = jest.spyOn(Alert, 'alert');
 
@@ -150,7 +160,13 @@ describe('VideoPalScreen', () => {
     modelStore.context = new LlamaContext(mockLlamaContextParams);
 
     // Allow multimodal
-    jest.spyOn(modelStore, 'isMultimodalEnabled').mockResolvedValue(true);
+    runInAction(() => {
+      modelStore.models = [
+        {id: 'model-1', origin: ModelOrigin.PRESET, supportsMultimodal: true},
+      ] as any;
+      modelStore.activeModelId = 'model-1';
+      modelStore.isMultimodalActive = true;
+    });
 
     const {getByLabelText, getByTestId, queryByTestId} = render(
       <VideoPalScreen activePal={videoPal} />,

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -132,7 +132,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
         ? l10n.models.modelCard.labels.visionSupported
         : modelCaps.vision === 'no'
           ? l10n.models.modelCard.labels.visionNotSupported
-          : l10n.models.modelCard.labels.capabilityUnknown;
+          : l10n.models.modelCard.labels.visionUnknown;
 
     // Check projection model status for downloaded vision models
     const projectionModelStatus = modelStore.getProjectionModelStatus(model);

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -124,6 +124,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
     const isDownloading = modelStore.isDownloading(model.id);
     const isHfModel = model.origin === ModelOrigin.HF;
     const isRemoteModel = model.origin === ModelOrigin.REMOTE;
+    const cardId = model.filename || model.id;
 
     const modelCaps = modelStore.capsFor(model);
     const visionLabel =
@@ -286,7 +287,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
 
     // Helper function to get model type icon - updated sizes
     const getModelTypeIcon = () => {
-      if (model.supportsMultimodal) {
+      if (modelCaps.vision === 'yes') {
         return (
           <EyeIcon
             width={16}
@@ -662,15 +663,20 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
 
     return (
       <>
-        <Card
-          elevation={0}
-          style={styles.card}
-          testID={`model-card-${model.filename || model.id}`}>
+        <Card elevation={0} style={styles.card} testID={`model-card-${cardId}`}>
           {/* Compact Header */}
           <View style={styles.compactHeader}>
             <View style={styles.headerContent}>
               <View style={styles.headerLeft}>
-                <View style={styles.modelTypeIcon}>{getModelTypeIcon()}</View>
+                <View
+                  style={styles.modelTypeIcon}
+                  {...(isRemoteModel && {
+                    accessible: true,
+                    accessibilityLabel: `${l10n.models.modelCard.labels.vision}: ${visionLabel}`,
+                    testID: `model-card-vision-${cardId}`,
+                  })}>
+                  {getModelTypeIcon()}
+                </View>
                 <Text
                   variant="titleSmall"
                   style={styles.compactModelName}
@@ -897,7 +903,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                   {modelCaps.contextLength && (
                     <View
                       style={styles.technicalDetailCard}
-                      testID="model-card-context-length">
+                      testID={`model-card-context-length-${cardId}`}>
                       <Text style={styles.technicalDetailLabel}>
                         {l10n.models.modelCard.labels.contextLength}
                       </Text>
@@ -938,7 +944,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                   {isRemoteModel && (
                     <View
                       style={styles.technicalDetailCard}
-                      testID="model-card-vision-capability"
+                      testID={`model-card-vision-capability-${cardId}`}
                       accessible={true}
                       accessibilityLabel={`${l10n.models.modelCard.labels.vision}: ${visionLabel}`}>
                       <Text style={styles.technicalDetailLabel}>

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -125,6 +125,14 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
     const isHfModel = model.origin === ModelOrigin.HF;
     const isRemoteModel = model.origin === ModelOrigin.REMOTE;
 
+    const modelCaps = modelStore.capsFor(model);
+    const visionLabel =
+      modelCaps.vision === 'yes'
+        ? l10n.models.modelCard.labels.visionSupported
+        : modelCaps.vision === 'no'
+          ? l10n.models.modelCard.labels.visionNotSupported
+          : l10n.models.modelCard.labels.capabilityUnknown;
+
     // Check projection model status for downloaded vision models
     const projectionModelStatus = modelStore.getProjectionModelStatus(model);
     const hasProjectionModelWarning =
@@ -389,6 +397,30 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
               accessibilityLabel={l10n.common.delete}>
               <TrashIcon width={16} height={16} stroke={theme.colors.error} />
             </TouchableOpacity>
+            <TouchableOpacity
+              testID="expand-details-button"
+              onPress={toggleExpanded}
+              style={styles.iconButton}
+              accessibilityRole="button"
+              accessibilityLabel={
+                isExpanded
+                  ? l10n.models.modelCard.accessibility.collapseDetails
+                  : l10n.models.modelCard.accessibility.expandDetails
+              }>
+              {isExpanded ? (
+                <ChevronSelectorExpandedVerticalIcon
+                  width={16}
+                  height={16}
+                  stroke={theme.colors.onSurfaceVariant}
+                />
+              ) : (
+                <ChevronSelectorVerticalIcon
+                  width={16}
+                  height={16}
+                  stroke={theme.colors.onSurfaceVariant}
+                />
+              )}
+            </TouchableOpacity>
           </View>
         );
       }
@@ -633,7 +665,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
         <Card
           elevation={0}
           style={styles.card}
-          testID={`model-card-${model.filename}`}>
+          testID={`model-card-${model.filename || model.id}`}>
           {/* Compact Header */}
           <View style={styles.compactHeader}>
             <View style={styles.headerContent}>
@@ -770,7 +802,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                 </View>
 
                 {/* Memory Requirement */}
-                {model.isDownloaded && (
+                {model.isDownloaded && !isRemoteModel && (
                   <MemoryRequirement
                     model={model}
                     projectionModel={projectionModelForCheck}
@@ -862,17 +894,15 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                   )}
 
                   {/* Context Length */}
-                  {(model.hfModel?.specs?.gguf?.context_length ||
-                    model.ggufMetadata?.context_length) && (
-                    <View style={styles.technicalDetailCard}>
+                  {modelCaps.contextLength && (
+                    <View
+                      style={styles.technicalDetailCard}
+                      testID="model-card-context-length">
                       <Text style={styles.technicalDetailLabel}>
                         {l10n.models.modelCard.labels.contextLength}
                       </Text>
                       <Text style={styles.technicalDetailValue}>
-                        {(
-                          model.hfModel?.specs?.gguf?.context_length ||
-                          model.ggufMetadata?.context_length
-                        )?.toLocaleString()}
+                        {modelCaps.contextLength.toLocaleString()}
                       </Text>
                     </View>
                   )}
@@ -892,13 +922,30 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                   )}
 
                   {/* Author */}
-                  {model.author && (
+                  {model.author && !isRemoteModel && (
                     <View style={styles.technicalDetailCard}>
                       <Text style={styles.technicalDetailLabel}>
                         {l10n.models.modelCard.labels.author}
                       </Text>
                       <Text style={styles.technicalDetailValue}>
                         {model.author}
+                      </Text>
+                    </View>
+                  )}
+
+                  {/* Vision — remote only; local models have the toggle above,
+                      which shows the same state and lets the user change it. */}
+                  {isRemoteModel && (
+                    <View
+                      style={styles.technicalDetailCard}
+                      testID="model-card-vision-capability"
+                      accessible={true}
+                      accessibilityLabel={`${l10n.models.modelCard.labels.vision}: ${visionLabel}`}>
+                      <Text style={styles.technicalDetailLabel}>
+                        {l10n.models.modelCard.labels.vision}
+                      </Text>
+                      <Text style={styles.technicalDetailValue}>
+                        {visionLabel}
                       </Text>
                     </View>
                   )}

--- a/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
+++ b/src/screens/ModelsScreen/ModelCard/ModelCard.tsx
@@ -939,8 +939,7 @@ export const ModelCard: React.FC<ModelCardProps> = observer(
                     </View>
                   )}
 
-                  {/* Vision — remote only; local models have the toggle above,
-                      which shows the same state and lets the user change it. */}
+                  {/* Vision */}
                   {isRemoteModel && (
                     <View
                       style={styles.technicalDetailCard}

--- a/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
+++ b/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
@@ -12,6 +12,7 @@ import {
   remoteModel,
   remoteModelSibling,
 } from '../../../../../jest/fixtures/models';
+import {themeFixtures} from '../../../../../jest/fixtures/theme';
 
 // Unmock useMemoryCheck for memory warning tests
 jest.unmock('../../../../hooks/useMemoryCheck');
@@ -41,6 +42,13 @@ jest.mock('@react-navigation/native', () => ({
 
 const customRender = (ui: React.ReactElement, options: any = {}) =>
   render(ui, {withBottomSheetProvider: true, withNavigation: true, ...options});
+
+/**
+ * Every `.svg` resolves to the same mock component, so the two header glyphs
+ * are told apart by the stroke they are given, not by their type.
+ */
+const glyphStroke = (glyphWrapper: any): string =>
+  glyphWrapper.props.children.props.stroke;
 
 describe('ModelCard', () => {
   beforeEach(() => {
@@ -638,6 +646,10 @@ describe('ModelCard', () => {
   });
 
   describe('Remote model capabilities', () => {
+    const visionCell = `model-card-vision-capability-${remoteModel.id}`;
+    const contextCell = `model-card-context-length-${remoteModel.id}`;
+    const headerGlyph = `model-card-vision-${remoteModel.id}`;
+
     const expand = (getByTestId: any) => {
       act(() => {
         fireEvent.press(getByTestId('expand-details-button'));
@@ -657,7 +669,7 @@ describe('ModelCard', () => {
       expand(getByTestId);
 
       await waitFor(() => {
-        expect(getByTestId('model-card-vision-capability')).toBeTruthy();
+        expect(getByTestId(visionCell)).toBeTruthy();
       });
     });
 
@@ -673,7 +685,7 @@ describe('ModelCard', () => {
       expand(getByTestId);
 
       await waitFor(() => {
-        expect(getByTestId('model-card-vision-capability')).toBeTruthy();
+        expect(getByTestId(visionCell)).toBeTruthy();
       });
 
       // The estimator has no local file to measure, so this row would read
@@ -691,7 +703,7 @@ describe('ModelCard', () => {
       expect(queryByTestId('vision-skill-touchable')).toBeNull();
 
       // What does render: the server-reported facts.
-      expect(getByTestId('model-card-context-length')).toBeTruthy();
+      expect(getByTestId(contextCell)).toBeTruthy();
       expect(
         queryByText(l10n.en.models.modelCard.labels.visionSupported),
       ).toBeTruthy();
@@ -704,7 +716,7 @@ describe('ModelCard', () => {
       expand(getByTestId);
 
       await waitFor(() => {
-        expect(getByTestId('model-card-vision-capability')).toBeTruthy();
+        expect(getByTestId(visionCell)).toBeTruthy();
       });
 
       expect(
@@ -713,7 +725,7 @@ describe('ModelCard', () => {
       expect(
         queryByText(l10n.en.models.modelCard.labels.visionNotSupported),
       ).toBeNull();
-      expect(queryByTestId('model-card-context-length')).toBeNull();
+      expect(queryByTestId(contextCell)).toBeNull();
     });
 
     it('reflects capabilities that land while the card is already open', async () => {
@@ -727,7 +739,7 @@ describe('ModelCard', () => {
           queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
         ).toBeTruthy();
       });
-      expect(queryByTestId('model-card-context-length')).toBeNull();
+      expect(queryByTestId(contextCell)).toBeNull();
 
       act(() => {
         runInAction(() => {
@@ -741,7 +753,7 @@ describe('ModelCard', () => {
       expect(
         queryByText(l10n.en.models.modelCard.labels.visionSupported),
       ).toBeTruthy();
-      expect(getByTestId('model-card-context-length')).toBeTruthy();
+      expect(getByTestId(contextCell)).toBeTruthy();
     });
 
     it('keeps capability entries per model, not per server', async () => {
@@ -767,14 +779,50 @@ describe('ModelCard', () => {
       runInAction(() => {
         serverStore.remoteCaps = {[remoteModel.id]: {supportsVision: true}};
       });
-      const {getByTestId, getByLabelText} = customRender(
+      const {getByTestId, getAllByLabelText} = customRender(
+        <ModelCard model={remoteModel} />,
+      );
+      expand(getByTestId);
+
+      // Header glyph and expanded cell, reading the same value — the pair is
+      // the assertion, since a header that disagreed with the body would
+      // otherwise still satisfy a single-match query.
+      await waitFor(() => {
+        expect(getAllByLabelText('Vision: Supported')).toHaveLength(2);
+      });
+    });
+
+    it('announces an unresolved capability as unknown in both places', async () => {
+      const {getByTestId, getAllByLabelText} = customRender(
         <ModelCard model={remoteModel} />,
       );
       expand(getByTestId);
 
       await waitFor(() => {
-        expect(getByLabelText('Vision: Supported')).toBeTruthy();
+        expect(getAllByLabelText('Vision: Unknown')).toHaveLength(2);
       });
+    });
+
+    it('shows the vision glyph without the model ever being activated', () => {
+      runInAction(() => {
+        serverStore.remoteCaps = {[remoteModel.id]: {supportsVision: true}};
+      });
+      const {getByTestId} = customRender(<ModelCard model={remoteModel} />);
+
+      expect(glyphStroke(getByTestId(headerGlyph))).toBe(
+        themeFixtures.lightTheme.colors.iconModelTypeVision,
+      );
+    });
+
+    it('keeps the text glyph when the server reports no vision', () => {
+      runInAction(() => {
+        serverStore.remoteCaps = {[remoteModel.id]: {supportsVision: false}};
+      });
+      const {getByTestId} = customRender(<ModelCard model={remoteModel} />);
+
+      expect(glyphStroke(getByTestId(headerGlyph))).toBe(
+        themeFixtures.lightTheme.colors.iconModelTypeText,
+      );
     });
 
     it('gives every remote card an addressable root', () => {
@@ -795,6 +843,26 @@ describe('ModelCard', () => {
     await waitFor(() => {
       expect(getByTestId('memory-requirement')).toBeTruthy();
     });
-    expect(queryByTestId('model-card-vision-capability')).toBeNull();
+    expect(
+      queryByTestId(`model-card-vision-capability-${downloadedModel.filename}`),
+    ).toBeNull();
+  });
+
+  it('gives a local card no spoken vision stop at all', async () => {
+    const {getByTestId, queryAllByLabelText} = customRender(
+      <ModelCard model={downloadedModel} />,
+    );
+
+    act(() => {
+      fireEvent.press(getByTestId('expand-details-button'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('memory-requirement')).toBeTruthy();
+    });
+    // The local card states vision through the toggle, which is its own
+    // labelled control; a second unlabelled-value announcement on the header
+    // glyph would be new noise on every text model.
+    expect(queryAllByLabelText(/^Vision:/)).toHaveLength(0);
   });
 });

--- a/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
+++ b/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
@@ -703,7 +703,6 @@ describe('ModelCard', () => {
       expect(queryByTestId('open-huggingface-url')).toBeNull();
       expect(queryByTestId('vision-skill-touchable')).toBeNull();
 
-      // What does render: the server-reported facts.
       expect(getByTestId(contextCell)).toBeTruthy();
       expect(
         queryByText(l10n.en.models.modelCard.labels.visionSupported),
@@ -750,7 +749,6 @@ describe('ModelCard', () => {
         });
       });
 
-      // No press, no navigation, no prop change in between.
       expect(
         queryByText(l10n.en.models.modelCard.labels.visionSupported),
       ).toBeTruthy();
@@ -876,7 +874,6 @@ describe('ModelCard', () => {
           ).toBeTruthy();
         });
         expect(getByTestId(contextCell)).toBeTruthy();
-        // Nothing was asked of the server to say any of that.
         expect(serverStore.fetchRemoteModelCaps).not.toHaveBeenCalled();
       });
 
@@ -964,7 +961,6 @@ describe('ModelCard', () => {
           });
         });
 
-        // No press, no navigation, no prop change in between.
         expect(
           queryByText(l10n.en.models.modelCard.labels.visionSupported),
         ).toBeTruthy();

--- a/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
+++ b/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Linking, Alert} from 'react-native';
 
+import {runInAction} from 'mobx';
+
 import {render, fireEvent, waitFor, act} from '../../../../../jest/test-utils';
 import {
   basicModel,
@@ -8,6 +10,7 @@ import {
   downloadingModel,
   largeMemoryModel,
   remoteModel,
+  remoteModelSibling,
 } from '../../../../../jest/fixtures/models';
 
 // Unmock useMemoryCheck for memory warning tests
@@ -632,5 +635,166 @@ describe('ModelCard', () => {
         remoteModel.serverId,
       );
     });
+  });
+
+  describe('Remote model capabilities', () => {
+    const expand = (getByTestId: any) => {
+      act(() => {
+        fireEvent.press(getByTestId('expand-details-button'));
+      });
+    };
+
+    afterEach(() => {
+      runInAction(() => {
+        serverStore.remoteCaps = {};
+      });
+    });
+
+    it('offers the expand affordance and opens the details block', async () => {
+      const {getByTestId} = customRender(<ModelCard model={remoteModel} />);
+
+      expect(getByTestId('expand-details-button')).toBeTruthy();
+      expand(getByTestId);
+
+      await waitFor(() => {
+        expect(getByTestId('model-card-vision-capability')).toBeTruthy();
+      });
+    });
+
+    it('renders no on-device or local-file value in the expanded block', async () => {
+      runInAction(() => {
+        serverStore.remoteCaps = {
+          [remoteModel.id]: {supportsVision: true, contextLength: 8192},
+        };
+      });
+      const {getByTestId, queryByTestId, queryByText} = customRender(
+        <ModelCard model={remoteModel} />,
+      );
+      expand(getByTestId);
+
+      await waitFor(() => {
+        expect(getByTestId('model-card-vision-capability')).toBeTruthy();
+      });
+
+      // The estimator has no local file to measure, so this row would read
+      // "Estimated memory: 0 B" — a device claim about someone else's hardware.
+      expect(queryByTestId('memory-requirement')).toBeNull();
+      // `author` is the server name, already in the header chip.
+      expect(queryByText(l10n.en.models.modelCard.labels.author)).toBeNull();
+      expect(
+        queryByText(l10n.en.models.modelDescription.parameters),
+      ).toBeNull();
+      expect(
+        queryByText(l10n.en.models.modelCard.labels.architecture),
+      ).toBeNull();
+      expect(queryByTestId('open-huggingface-url')).toBeNull();
+      expect(queryByTestId('vision-skill-touchable')).toBeNull();
+
+      // What does render: the server-reported facts.
+      expect(getByTestId('model-card-context-length')).toBeTruthy();
+      expect(
+        queryByText(l10n.en.models.modelCard.labels.visionSupported),
+      ).toBeTruthy();
+    });
+
+    it('reports vision as unknown, never unsupported, when the server has no /props', async () => {
+      const {getByTestId, queryByTestId, queryByText} = customRender(
+        <ModelCard model={remoteModel} />,
+      );
+      expand(getByTestId);
+
+      await waitFor(() => {
+        expect(getByTestId('model-card-vision-capability')).toBeTruthy();
+      });
+
+      expect(
+        queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+      ).toBeTruthy();
+      expect(
+        queryByText(l10n.en.models.modelCard.labels.visionNotSupported),
+      ).toBeNull();
+      expect(queryByTestId('model-card-context-length')).toBeNull();
+    });
+
+    it('reflects capabilities that land while the card is already open', async () => {
+      const {getByTestId, queryByTestId, queryByText} = customRender(
+        <ModelCard model={remoteModel} />,
+      );
+      expand(getByTestId);
+
+      await waitFor(() => {
+        expect(
+          queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+        ).toBeTruthy();
+      });
+      expect(queryByTestId('model-card-context-length')).toBeNull();
+
+      act(() => {
+        runInAction(() => {
+          serverStore.remoteCaps = {
+            [remoteModel.id]: {supportsVision: true, contextLength: 8192},
+          };
+        });
+      });
+
+      // No press, no navigation, no prop change in between.
+      expect(
+        queryByText(l10n.en.models.modelCard.labels.visionSupported),
+      ).toBeTruthy();
+      expect(getByTestId('model-card-context-length')).toBeTruthy();
+    });
+
+    it('keeps capability entries per model, not per server', async () => {
+      runInAction(() => {
+        serverStore.remoteCaps = {
+          [remoteModel.id]: {supportsVision: true},
+          [remoteModelSibling.id]: {supportsVision: false},
+        };
+      });
+      const {getByTestId, queryByText} = customRender(
+        <ModelCard model={remoteModelSibling} />,
+      );
+      expand(getByTestId);
+
+      await waitFor(() => {
+        expect(
+          queryByText(l10n.en.models.modelCard.labels.visionNotSupported),
+        ).toBeTruthy();
+      });
+    });
+
+    it('carries the capability value in the accessibility label', async () => {
+      runInAction(() => {
+        serverStore.remoteCaps = {[remoteModel.id]: {supportsVision: true}};
+      });
+      const {getByTestId, getByLabelText} = customRender(
+        <ModelCard model={remoteModel} />,
+      );
+      expand(getByTestId);
+
+      await waitFor(() => {
+        expect(getByLabelText('Vision: Supported')).toBeTruthy();
+      });
+    });
+
+    it('gives every remote card an addressable root', () => {
+      const {getByTestId} = customRender(<ModelCard model={remoteModel} />);
+      expect(getByTestId(`model-card-${remoteModel.id}`)).toBeTruthy();
+    });
+  });
+
+  it('renders no vision cell on a local card', async () => {
+    const {getByTestId, queryByTestId} = customRender(
+      <ModelCard model={downloadedModel} />,
+    );
+
+    act(() => {
+      fireEvent.press(getByTestId('expand-details-button'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('memory-requirement')).toBeTruthy();
+    });
+    expect(queryByTestId('model-card-vision-capability')).toBeNull();
   });
 });

--- a/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
+++ b/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
@@ -721,7 +721,7 @@ describe('ModelCard', () => {
       });
 
       expect(
-        queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+        queryByText(l10n.en.models.modelCard.labels.visionUnknown),
       ).toBeTruthy();
       expect(
         queryByText(l10n.en.models.modelCard.labels.visionNotSupported),
@@ -737,7 +737,7 @@ describe('ModelCard', () => {
 
       await waitFor(() => {
         expect(
-          queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+          queryByText(l10n.en.models.modelCard.labels.visionUnknown),
         ).toBeTruthy();
       });
       expect(queryByTestId(contextCell)).toBeNull();
@@ -951,7 +951,7 @@ describe('ModelCard', () => {
         expand(getByTestId);
         await waitFor(() => {
           expect(
-            queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+            queryByText(l10n.en.models.modelCard.labels.visionUnknown),
           ).toBeTruthy();
         });
         expect(queryByTestId(contextCell)).toBeNull();
@@ -987,7 +987,7 @@ describe('ModelCard', () => {
         expand(getByTestId);
         await waitFor(() => {
           expect(
-            queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+            queryByText(l10n.en.models.modelCard.labels.visionUnknown),
           ).toBeTruthy();
         });
         expect(queryByTestId(contextCell)).toBeNull();

--- a/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
+++ b/src/screens/ModelsScreen/ModelCard/__tests__/ModelCard.test.tsx
@@ -13,6 +13,7 @@ import {
   remoteModelSibling,
 } from '../../../../../jest/fixtures/models';
 import {themeFixtures} from '../../../../../jest/fixtures/theme';
+import {routerModelsBody} from '../../../../../jest/fixtures/remoteModelList';
 
 // Unmock useMemoryCheck for memory warning tests
 jest.unmock('../../../../hooks/useMemoryCheck');
@@ -823,6 +824,174 @@ describe('ModelCard', () => {
       expect(glyphStroke(getByTestId(headerGlyph))).toBe(
         themeFixtures.lightTheme.colors.iconModelTypeText,
       );
+    });
+
+    describe('capabilities the models list already carried', () => {
+      // The card fixture id and the captured row are joined here so the store
+      // derivation runs over a real body: `${serverId}/${row.id}` is the key a
+      // remote card looks itself up by.
+      const rowFor = (id: string, sourceId: string) => ({
+        ...(routerModelsBody.data.find(r => r.id === sourceId) as any),
+        id,
+      });
+
+      const listServer = (serverType?: string, rows?: any[]) => {
+        runInAction(() => {
+          serverStore.servers = [
+            {
+              id: remoteModel.serverId!,
+              name: 'router',
+              url: 'http://localhost:8080',
+              serverType,
+            },
+          ];
+          serverStore.serverModels.set(
+            remoteModel.serverId!,
+            rows ?? [rowFor(remoteModel.remoteModelId!, 'gemma-4-e2b')],
+          );
+        });
+      };
+
+      afterEach(() => {
+        runInAction(() => {
+          serverStore.servers = [];
+          serverStore.serverModels.clear();
+        });
+      });
+
+      it('states vision and the window without the model ever being activated', async () => {
+        listServer('llama.cpp');
+
+        const {getByTestId, queryByText} = customRender(
+          <ModelCard model={remoteModel} />,
+        );
+
+        expect(glyphStroke(getByTestId(headerGlyph))).toBe(
+          themeFixtures.lightTheme.colors.iconModelTypeVision,
+        );
+        expand(getByTestId);
+        await waitFor(() => {
+          expect(
+            queryByText(l10n.en.models.modelCard.labels.visionSupported),
+          ).toBeTruthy();
+        });
+        expect(getByTestId(contextCell)).toBeTruthy();
+        // Nothing was asked of the server to say any of that.
+        expect(serverStore.fetchRemoteModelCaps).not.toHaveBeenCalled();
+      });
+
+      it('says not supported for a sibling the same list describes as text-only', async () => {
+        listServer('llama.cpp', [
+          rowFor(remoteModel.remoteModelId!, 'gemma-4-e2b'),
+          rowFor(remoteModelSibling.remoteModelId!, 'gemma-3-4b'),
+        ]);
+
+        const {getByTestId, queryByText} = customRender(
+          <ModelCard model={remoteModelSibling} />,
+        );
+        expand(getByTestId);
+
+        await waitFor(() => {
+          expect(
+            queryByText(l10n.en.models.modelCard.labels.visionNotSupported),
+          ).toBeTruthy();
+        });
+      });
+
+      it('changes nothing visible when the model is then activated', async () => {
+        listServer('llama.cpp');
+
+        const {getByTestId, queryByText} = customRender(
+          <ModelCard model={remoteModel} />,
+        );
+        expand(getByTestId);
+        await waitFor(() => {
+          expect(getByTestId(contextCell)).toBeTruthy();
+        });
+        const before = [
+          glyphStroke(getByTestId(headerGlyph)),
+          getByTestId(visionCell).props.accessibilityLabel,
+          getByTestId(contextCell).props.children,
+        ];
+
+        act(() => {
+          runInAction(() => {
+            serverStore.remoteCaps = {
+              [remoteModel.id]: {supportsVision: true, contextLength: 8192},
+            };
+          });
+        });
+
+        expect([
+          glyphStroke(getByTestId(headerGlyph)),
+          getByTestId(visionCell).props.accessibilityLabel,
+          getByTestId(contextCell).props.children,
+        ]).toEqual(before);
+        expect(
+          queryByText(l10n.en.models.modelCard.labels.visionSupported),
+        ).toBeTruthy();
+      });
+
+      it('fills in when the first fetch lands, with no user action', async () => {
+        // Cold start: hydration has restored the server but no list yet.
+        runInAction(() => {
+          serverStore.servers = [
+            {
+              id: remoteModel.serverId!,
+              name: 'router',
+              url: 'http://localhost:8080',
+              serverType: 'llama.cpp',
+            },
+          ];
+        });
+
+        const {getByTestId, queryByTestId, queryByText} = customRender(
+          <ModelCard model={remoteModel} />,
+        );
+        expand(getByTestId);
+        await waitFor(() => {
+          expect(
+            queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+          ).toBeTruthy();
+        });
+        expect(queryByTestId(contextCell)).toBeNull();
+
+        act(() => {
+          runInAction(() => {
+            serverStore.serverModels.set(remoteModel.serverId!, [
+              rowFor(remoteModel.remoteModelId!, 'gemma-4-e2b'),
+            ]);
+          });
+        });
+
+        // No press, no navigation, no prop change in between.
+        expect(
+          queryByText(l10n.en.models.modelCard.labels.visionSupported),
+        ).toBeTruthy();
+        expect(getByTestId(contextCell)).toBeTruthy();
+        expect(glyphStroke(getByTestId(headerGlyph))).toBe(
+          themeFixtures.lightTheme.colors.iconModelTypeVision,
+        );
+      });
+
+      it('reads nothing off a server of another type', async () => {
+        listServer('Ollama');
+
+        const {getByTestId, queryByTestId, queryByText} = customRender(
+          <ModelCard model={remoteModel} />,
+        );
+
+        expect(glyphStroke(getByTestId(headerGlyph))).toBe(
+          themeFixtures.lightTheme.colors.iconModelTypeText,
+        );
+        expand(getByTestId);
+        await waitFor(() => {
+          expect(
+            queryByText(l10n.en.models.modelCard.labels.capabilityUnknown),
+          ).toBeTruthy();
+        });
+        expect(queryByTestId(contextCell)).toBeNull();
+      });
     });
 
     it('gives every remote card an addressable root', () => {

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -84,6 +84,8 @@ import {
 import {detectThinkingCapability} from '../utils/thinkingCapabilityDetection';
 import {ReasoningCapability} from '../utils/reasoningCapability';
 import {capsMatchBinding, resolveRemoteCaps} from '../utils/remoteCaps';
+import {resolveModelCaps} from '../utils/modelCaps';
+import type {CapabilityEnv, ModelCapabilityView} from '../utils/modelCaps';
 import {t} from '../locales';
 import {resolveUseMmap} from '../utils/memorySettings';
 import {
@@ -223,6 +225,7 @@ class ModelStore {
   constructor() {
     makeAutoObservable(this, {
       activeModel: computed,
+      activeModelCaps: computed,
       contextId: computed,
       remoteModels: computed,
       activeDownloads: computed,
@@ -2136,6 +2139,33 @@ class ModelStore {
       this.models.find(model => model.id === this.activeModelId) ||
       this.remoteModels.find(model => model.id === this.activeModelId)
     );
+  }
+
+  /**
+   * The resolver env, assembled here and nowhere else. Kept private so no
+   * caller can build its own and answer a capability question a different way.
+   */
+  private get capabilityEnv(): CapabilityEnv {
+    return {
+      remoteCaps: serverStore.remoteCaps,
+      binding: this.activeRemoteBinding,
+      isMultimodalActive: this.isMultimodalActive,
+      activeContextSettings: this.activeContextSettings,
+      activeModelId: this.activeModelId,
+    };
+  }
+
+  /**
+   * Capabilities of any model, active or not — the model card's entry point.
+   * An arrow property so `makeAutoObservable` annotates it `autoAction`, which
+   * keeps the observable reads tracked inside an `observer` render body.
+   */
+  capsFor = (model: Model | undefined): ModelCapabilityView =>
+    resolveModelCaps(model, this.capabilityEnv);
+
+  /** Capabilities of the live session — chat's entry point. */
+  get activeModelCaps(): ModelCapabilityView {
+    return this.capsFor(this.activeModel);
   }
 
   get lastUsedModel(): Model | undefined {

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2231,8 +2231,9 @@ class ModelStore {
     // Capabilities are per model, so they are probed on activation. Detached:
     // a lazily-started server can take seconds to answer, and neither the
     // engine nor the chat screen may wait on it. ServerStore owns the write.
-    // The api key is already resolved here, so the probe skips a second
-    // Keychain read.
+    // The key resolved for the engine is forwarded; a keyless server resolves
+    // to undefined, which the probe cannot tell from "not supplied", so it
+    // reads the Keychain itself in that case.
     serverStore
       .fetchRemoteModelCaps(model.serverId, model.remoteModelId, apiKey)
       .catch(() => {});

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -82,6 +82,7 @@ import {
 } from '../utils/deviceCapabilities';
 import {detectThinkingCapability} from '../utils/thinkingCapabilityDetection';
 import {ReasoningCapability} from '../utils/reasoningCapability';
+import {resolveRemoteCaps} from '../utils/remoteCaps';
 import {t} from '../locales';
 import {resolveUseMmap} from '../utils/memorySettings';
 import {
@@ -2856,15 +2857,17 @@ class ModelStore {
     }
 
     // Remote models have no local context; their vision capability comes from
-    // the active server's /props self-report. releaseContext clears both
-    // context and the cached flag on switch, so this is never stale-true for a
-    // remote model. Placed before the !context early-return so a remote model
-    // is not shadowed into that dead branch.
+    // the /props self-report for that model, resolved through the same
+    // selector the chat UI uses so the send path cannot disagree with the
+    // attach affordance. Placed before the !context early-return so a remote
+    // model is not shadowed into that dead branch.
     if (!this.context && this.activeModel?.origin === ModelOrigin.REMOTE) {
-      const serverId = this.activeModel?.serverId;
       return (
-        serverStore.servers.find(s => s.id === serverId)?.supportsVision ===
-        true
+        resolveRemoteCaps(
+          this.activeModel,
+          serverStore.remoteCaps,
+          serverStore.servers,
+        ).supportsVision === true
       );
     }
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2162,6 +2162,13 @@ class ModelStore {
       this.setActiveModel(model.id);
       // Do NOT set lastUsedModelId for remote models -- server may be offline on next launch
     });
+
+    // Capabilities are per model, so they are probed on activation. Detached:
+    // a lazily-started server can take seconds to answer, and neither the
+    // engine nor the chat screen may wait on it. ServerStore owns the write.
+    serverStore
+      .fetchRemoteModelCaps(model.serverId, model.remoteModelId)
+      .catch(() => {});
   };
 
   /**

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -83,7 +83,7 @@ import {
 } from '../utils/deviceCapabilities';
 import {detectThinkingCapability} from '../utils/thinkingCapabilityDetection';
 import {ReasoningCapability} from '../utils/reasoningCapability';
-import {capsMatchBinding, resolveRemoteCaps} from '../utils/remoteCaps';
+import {capsMatchBinding} from '../utils/remoteCaps';
 import {resolveModelCaps} from '../utils/modelCaps';
 import type {CapabilityEnv, ModelCapabilityView} from '../utils/modelCaps';
 import {t} from '../locales';
@@ -2053,8 +2053,7 @@ class ModelStore {
       }
 
       // Step 3: Now safe to release - First check if multimodal is enabled and release it if needed
-      const isMultimodalEnabled = await this.isMultimodalEnabled();
-      if (isMultimodalEnabled) {
+      if (this.isMultimodalActive) {
         console.log('Releasing multimodal context first');
         try {
           await this.context.releaseMultimodal();
@@ -2952,53 +2951,6 @@ class ModelStore {
   }
 
   /**
-   * Checks if the current context supports multimodal input
-   * @returns Promise<boolean> - True if multimodal is enabled, false otherwise
-   */
-  isMultimodalEnabled = async (): Promise<boolean> => {
-    // First check our cached flag for quick responses
-    if (this.isMultimodalActive) {
-      return true;
-    }
-
-    // Remote models have no local context; their vision capability comes from
-    // the /props self-report for that model, resolved through the same
-    // selector the chat UI uses so the send path cannot disagree with the
-    // attach affordance. Placed before the !context early-return so a remote
-    // model is not shadowed into that dead branch.
-    if (!this.context && this.activeModel?.origin === ModelOrigin.REMOTE) {
-      return (
-        resolveRemoteCaps(
-          this.activeModel,
-          serverStore.remoteCaps,
-          this.activeRemoteBinding,
-        ).supportsVision === true
-      );
-    }
-
-    // Avoid "Context not found" errors during transitions
-    if (!this.context || this.isContextLoading) {
-      return false;
-    }
-
-    try {
-      const isEnabled = await this.context.isMultimodalEnabled();
-
-      // Update our cached flag
-      if (isEnabled !== this.isMultimodalActive) {
-        runInAction(() => {
-          this.isMultimodalActive = isEnabled;
-        });
-      }
-
-      return isEnabled;
-    } catch (error) {
-      console.error('Error checking multimodal capability:', error);
-      return false;
-    }
-  };
-
-  /**
    * Get compatible projection models for a given LLM
    * @param modelId The ID of the LLM model
    * @returns Array of compatible projection models
@@ -3362,8 +3314,7 @@ class ModelStore {
     }
 
     // Check if multimodal is enabled
-    const isMultimodalEnabled = await this.isMultimodalEnabled();
-    if (!isMultimodalEnabled) {
+    if (!this.isMultimodalActive) {
       throw new Error('Multimodal is not enabled for this model');
     }
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -177,9 +177,6 @@ class ModelStore {
 
   engine: CompletionEngine | undefined = undefined;
 
-  // Which backend the live remote session talks to. Set with the engine and
-  // cleared with it, so it is defined exactly while a remote session exists.
-  // Not persisted: a session does not survive a launch.
   activeRemoteBinding: RemoteSessionBinding | undefined = undefined;
 
   lastUsedModelId: string | undefined = undefined;
@@ -952,10 +949,6 @@ class ModelStore {
    * local-network prompt, so a grant always arrives after it already failed.
    * Without this, caps stay unknown for the rest of the session and the only
    * recovery is re-selecting the model by hand.
-   *
-   * Fires only while the active remote model has no caps for the backend the
-   * session is bound to, so a valid entry is never re-fetched. Detached, and
-   * `ServerStore` still owns the write.
    *
    * Also skipped once the server record has been repointed away from that
    * backend: the probe would read a backend this session never talks to, and
@@ -2140,10 +2133,6 @@ class ModelStore {
     );
   }
 
-  /**
-   * The resolver env, assembled here and nowhere else. Kept private so no
-   * caller can build its own and answer a capability question a different way.
-   */
   private get capabilityEnv(): CapabilityEnv {
     return {
       remoteCaps: serverStore.remoteCaps,
@@ -2247,9 +2236,6 @@ class ModelStore {
         server.requestTimeoutMs,
         server.serverType,
       );
-      // Same values the engine was built from. The server record is mutable
-      // and the engine is not rebuilt when it changes, so this is what the
-      // session is talking to until the model is selected again.
       this.activeRemoteBinding = {
         modelId: model.id,
         serverId: model.serverId!,
@@ -2261,12 +2247,6 @@ class ModelStore {
       // Do NOT set lastUsedModelId for remote models -- server may be offline on next launch
     });
 
-    // Capabilities are per model, so they are probed on activation. Detached:
-    // a lazily-started server can take seconds to answer, and neither the
-    // engine nor the chat screen may wait on it. ServerStore owns the write.
-    // The key resolved for the engine is forwarded; a keyless server resolves
-    // to undefined, which the probe cannot tell from "not supplied", so it
-    // reads the Keychain itself in that case.
     serverStore
       .fetchRemoteModelCaps(model.serverId, model.remoteModelId, apiKey)
       .catch(() => {});

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -70,6 +70,7 @@ import {
   ModelFile,
   ModelOrigin,
   ModelType,
+  RemoteSessionBinding,
 } from '../utils/types';
 
 import {ErrorState, createErrorState} from '../utils/errors';
@@ -82,7 +83,7 @@ import {
 } from '../utils/deviceCapabilities';
 import {detectThinkingCapability} from '../utils/thinkingCapabilityDetection';
 import {ReasoningCapability} from '../utils/reasoningCapability';
-import {resolveRemoteCaps} from '../utils/remoteCaps';
+import {capsMatchBinding, resolveRemoteCaps} from '../utils/remoteCaps';
 import {t} from '../locales';
 import {resolveUseMmap} from '../utils/memorySettings';
 import {
@@ -173,6 +174,11 @@ class ModelStore {
   context: LlamaContext | undefined = undefined;
 
   engine: CompletionEngine | undefined = undefined;
+
+  // Which backend the live remote session talks to. Set with the engine and
+  // cleared with it, so it is defined exactly while a remote session exists.
+  // Not persisted: a session does not survive a launch.
+  activeRemoteBinding: RemoteSessionBinding | undefined = undefined;
 
   lastUsedModelId: string | undefined = undefined;
 
@@ -944,8 +950,14 @@ class ModelStore {
    * Without this, caps stay unknown for the rest of the session and the only
    * recovery is re-selecting the model by hand.
    *
-   * Fires only while the active remote model has no caps entry, so a populated
-   * one is never re-fetched. Detached, and `ServerStore` still owns the write.
+   * Fires only while the active remote model has no caps for the backend the
+   * session is bound to, so a valid entry is never re-fetched. Detached, and
+   * `ServerStore` still owns the write.
+   *
+   * Also skipped once the server record has been repointed away from that
+   * backend: the probe would read a backend this session never talks to, and
+   * it cannot produce caps this session could use. The next activation
+   * rebuilds the binding and probes the url it is built from.
    */
   private reprobeRemoteCapsIfUnknown = () => {
     const model = this.activeModel;
@@ -953,9 +965,22 @@ class ModelStore {
       model?.origin !== ModelOrigin.REMOTE ||
       !model.serverId ||
       !model.remoteModelId ||
-      serverStore.remoteCaps[model.id]
+      capsMatchBinding(
+        serverStore.remoteCaps[model.id],
+        this.activeRemoteBinding,
+        model.id,
+      )
     ) {
       return;
+    }
+    const binding = this.activeRemoteBinding;
+    if (binding?.modelId === model.id) {
+      const configuredUrl = serverStore.servers.find(
+        s => s.id === model.serverId,
+      )?.url;
+      if (configuredUrl !== undefined && configuredUrl !== binding.url) {
+        return;
+      }
     }
     serverStore
       .fetchRemoteModelCaps(model.serverId, model.remoteModelId)
@@ -1897,6 +1922,7 @@ class ModelStore {
       runInAction(() => {
         this.context = ctx;
         this.engine = new LocalCompletionEngine(ctx);
+        this.activeRemoteBinding = undefined;
         this.activeContextSettings = contextInitParams;
         this.setActiveModel(model.id);
         this.pendingModelId = null;
@@ -1970,6 +1996,7 @@ class ModelStore {
         }
         runInAction(() => {
           this.engine = undefined;
+          this.activeRemoteBinding = undefined;
           if (clearActiveModel) {
             this.activeModelId = undefined;
           }
@@ -2053,6 +2080,7 @@ class ModelStore {
       runInAction(() => {
         this.context = undefined;
         this.engine = undefined;
+        this.activeRemoteBinding = undefined;
         this.activeContextSettings = undefined;
         // Ensure multimodal state is cleared even if something went wrong above
         this.isMultimodalActive = false;
@@ -2186,6 +2214,16 @@ class ModelStore {
         server.requestTimeoutMs,
         server.serverType,
       );
+      // Same values the engine was built from. The server record is mutable
+      // and the engine is not rebuilt when it changes, so this is what the
+      // session is talking to until the model is selected again.
+      this.activeRemoteBinding = {
+        modelId: model.id,
+        serverId: model.serverId!,
+        remoteModelId: model.remoteModelId!,
+        url: server.url,
+        serverType: server.serverType,
+      };
       this.setActiveModel(model.id);
       // Do NOT set lastUsedModelId for remote models -- server may be offline on next launch
     });
@@ -2902,7 +2940,7 @@ class ModelStore {
         resolveRemoteCaps(
           this.activeModel,
           serverStore.remoteCaps,
-          serverStore.servers,
+          this.activeRemoteBinding,
         ).supportsVision === true
       );
     }

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2193,8 +2193,10 @@ class ModelStore {
     // Capabilities are per model, so they are probed on activation. Detached:
     // a lazily-started server can take seconds to answer, and neither the
     // engine nor the chat screen may wait on it. ServerStore owns the write.
+    // The api key is already resolved here, so the probe skips a second
+    // Keychain read.
     serverStore
-      .fetchRemoteModelCaps(model.serverId, model.remoteModelId)
+      .fetchRemoteModelCaps(model.serverId, model.remoteModelId, apiKey)
       .catch(() => {});
   };
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2147,6 +2147,7 @@ class ModelStore {
   private get capabilityEnv(): CapabilityEnv {
     return {
       remoteCaps: serverStore.remoteCaps,
+      listCaps: serverStore.listCaps,
       binding: this.activeRemoteBinding,
       isMultimodalActive: this.isMultimodalActive,
       activeContextSettings: this.activeContextSettings,

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -900,6 +900,7 @@ class ModelStore {
     ) {
       // Coming to foreground - check if we need to reload auto-released model
       await this.checkAndReloadAutoReleasedModel();
+      this.reprobeRemoteCapsIfUnknown();
     } else if (this.appState === 'active' && nextAppState === 'inactive') {
       // active → inactive: NO action (per requirements)
       console.log('Active → Inactive: No auto-release action');
@@ -933,6 +934,32 @@ class ModelStore {
     runInAction(() => {
       this.appState = nextAppState;
     });
+  };
+
+  /**
+   * Remote models are exempt from auto-release, so a session survives
+   * backgrounding — but the capability probe behind it may not have: iOS can
+   * tear the request down, and the first probe is the request that raises the
+   * local-network prompt, so a grant always arrives after it already failed.
+   * Without this, caps stay unknown for the rest of the session and the only
+   * recovery is re-selecting the model by hand.
+   *
+   * Fires only while the active remote model has no caps entry, so a populated
+   * one is never re-fetched. Detached, and `ServerStore` still owns the write.
+   */
+  private reprobeRemoteCapsIfUnknown = () => {
+    const model = this.activeModel;
+    if (
+      model?.origin !== ModelOrigin.REMOTE ||
+      !model.serverId ||
+      !model.remoteModelId ||
+      serverStore.remoteCaps[model.id]
+    ) {
+      return;
+    }
+    serverStore
+      .fetchRemoteModelCaps(model.serverId, model.remoteModelId)
+      .catch(() => {});
   };
 
   reinitializeContext = async () => {

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2157,8 +2157,9 @@ class ModelStore {
 
   /**
    * Capabilities of any model, active or not — the model card's entry point.
-   * Must stay unannotated: `action` untracks the observable reads, so every
-   * card would freeze on its first value while the suite stayed green.
+   * Never annotate it explicitly as `action`: that untracks the observable
+   * reads, so every card would freeze on its first value while the suite
+   * stayed green.
    */
   capsFor = (model: Model | undefined): ModelCapabilityView =>
     resolveModelCaps(model, this.capabilityEnv);

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -2156,8 +2156,8 @@ class ModelStore {
 
   /**
    * Capabilities of any model, active or not — the model card's entry point.
-   * An arrow property so `makeAutoObservable` annotates it `autoAction`, which
-   * keeps the observable reads tracked inside an `observer` render body.
+   * Must stay unannotated: `action` untracks the observable reads, so every
+   * card would freeze on its first value while the suite stayed green.
    */
   capsFor = (model: Model | undefined): ModelCapabilityView =>
     resolveModelCaps(model, this.capabilityEnv);
@@ -2190,8 +2190,10 @@ class ModelStore {
   }
 
   /**
-   * Computed property that derives remote models from serverStore.serverModels.
-   * Remote models are never stored in the models array (which is persisted).
+   * Derived from `serverStore.userSelectedModels` and `serverStore.servers` —
+   * not from `serverModels`, so the list a server currently advertises does not
+   * change which cards exist. Remote models are never stored in the persisted
+   * `models` array.
    */
   get remoteModels(): Model[] {
     const models: Model[] = [];

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -20,6 +20,13 @@ const KEYCHAIN_SERVICE_PREFIX = 'pocketpal-server-';
 const FETCH_THROTTLE_MS = 60000;
 
 /**
+ * The capability fields of a `RemoteModelCaps` entry — everything except the
+ * provenance the entry carries. Enumerated once so the usability check and the
+ * no-op write check cannot drift apart when a field is added.
+ */
+const CAPS_FIELDS = ['contextLength', 'supportsVision'] as const;
+
+/**
  * Drop every entry of a per-model map (keyed `${serverId}/${remoteModelId}`)
  * that belongs to one server. Shared by every path that invalidates per-model
  * state, so a new map cannot be added to one and forgotten in the other.
@@ -271,8 +278,13 @@ class ServerStore {
    * server the bare form describes whichever model happens to be resident, so
    * it is never issued there and the caps simply stay unknown.
    *
-   * Merges field-wise: a response that resolves only one field must not blank
-   * a known other, and a probe that resolves nothing writes nothing.
+   * Merges field-wise within one backend: a response that resolves only one
+   * field must not blank a known other, and a probe that resolves nothing
+   * writes nothing. Across backends there is nothing to merge — an entry
+   * probed against another url is replaced, not blended.
+   *
+   * The written entry carries the url it was probed against, so a reader can
+   * tell whether it describes the backend a live session is bound to.
    *
    * A shorter server timeout is honoured, a longer one is not:
    * `requestTimeoutMs` is a free numeric input, and detached work must stay
@@ -289,7 +301,7 @@ class ServerStore {
     }
 
     const isUnusable = (caps: RemoteModelCaps) =>
-      caps.contextLength === undefined && caps.supportsVision === undefined;
+      CAPS_FIELDS.every(f => caps[f] === undefined);
 
     // Snapshot: `server` is the live observable, so updateServer mutates it
     // in place while the probe is in flight.
@@ -332,11 +344,16 @@ class ServerStore {
       }
       const key = `${serverId}/${remoteModelId}`;
       const prior = this.remoteCaps[key];
-      const merged = {...prior, ...caps};
+      const sameBackend = prior?.probedUrl === probedUrl;
+      const merged: RemoteModelCaps = {
+        ...(sameBackend ? prior : undefined),
+        ...caps,
+        probedUrl,
+      };
       if (
         prior &&
-        prior.contextLength === merged.contextLength &&
-        prior.supportsVision === merged.supportsVision
+        prior.probedUrl === merged.probedUrl &&
+        CAPS_FIELDS.every(f => prior[f] === merged[f])
       ) {
         return;
       }

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -19,6 +19,21 @@ const KEYCHAIN_SERVICE_PREFIX = 'pocketpal-server-';
 /** Minimum interval between auto-fetch cycles (ms) */
 const FETCH_THROTTLE_MS = 60000;
 
+/**
+ * Drop every entry of a per-model map (keyed `${serverId}/${remoteModelId}`)
+ * that belongs to one server. Shared by every path that invalidates per-model
+ * state, so a new map cannot be added to one and forgotten in the other.
+ */
+function dropServerEntries<T>(
+  map: Record<string, T>,
+  serverId: string,
+): Record<string, T> {
+  const prefix = `${serverId}/`;
+  return Object.fromEntries(
+    Object.entries(map).filter(([k]) => !k.startsWith(prefix)),
+  );
+}
+
 class ServerStore {
   servers: ServerConfig[] = [];
   // Remote reasoning capability keyed by full model id (`${serverId}/${remoteModelId}`).
@@ -73,8 +88,23 @@ class ServerStore {
 
   updateServer(id: string, updates: Partial<ServerConfig>): void {
     const server = this.servers.find(s => s.id === id);
-    if (server) {
-      Object.assign(server, updates);
+    if (!server) {
+      return;
+    }
+    // Caps describe what the configured backend reported. Repointing the url or
+    // switching the server type makes them describe something else, and
+    // resolveRemoteCaps has no way to tell — so drop them and let the next
+    // activation re-probe. Reasoning state survives: it carries user
+    // declarations, and it is not server-reported.
+    const invalidatesCaps =
+      (updates.url !== undefined && updates.url !== server.url) ||
+      (updates.serverType !== undefined &&
+        updates.serverType !== server.serverType);
+
+    Object.assign(server, updates);
+
+    if (invalidatesCaps) {
+      this.remoteCaps = dropServerEntries(this.remoteCaps, id);
     }
   }
 
@@ -86,15 +116,8 @@ class ServerStore {
       m => m.serverId !== id,
     );
     // Drop per-model state keyed by this server's model ids.
-    const prefix = `${id}/`;
-    this.remoteReasoning = Object.fromEntries(
-      Object.entries(this.remoteReasoning).filter(
-        ([k]) => !k.startsWith(prefix),
-      ),
-    );
-    this.remoteCaps = Object.fromEntries(
-      Object.entries(this.remoteCaps).filter(([k]) => !k.startsWith(prefix)),
-    );
+    this.remoteReasoning = dropServerEntries(this.remoteReasoning, id);
+    this.remoteCaps = dropServerEntries(this.remoteCaps, id);
     // Clean up API key from keychain
     this.removeApiKey(id);
   }

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -281,6 +281,7 @@ class ServerStore {
   async fetchRemoteModelCaps(
     serverId: string,
     remoteModelId: string,
+    resolvedApiKey?: string,
   ): Promise<void> {
     const server = this.servers.find(s => s.id === serverId);
     if (!server || server.serverType !== 'llama.cpp') {
@@ -290,21 +291,26 @@ class ServerStore {
     const isUnusable = (caps: RemoteModelCaps) =>
       caps.contextLength === undefined && caps.supportsVision === undefined;
 
+    // Snapshot: `server` is the live observable, so updateServer mutates it
+    // in place while the probe is in flight.
+    const probedUrl = server.url;
+    const probedType = server.serverType;
+
     const timeoutMs = Math.min(
       server.requestTimeoutMs ?? PROPS_TIMEOUT_MS,
       PROPS_TIMEOUT_MS,
     );
 
-    const apiKey = await this.getApiKey(serverId);
+    const apiKey = resolvedApiKey ?? (await this.getApiKey(serverId));
     let caps = await fetchServerProps(
-      server.url,
+      probedUrl,
       apiKey,
       timeoutMs,
       remoteModelId,
     );
 
     if (isUnusable(caps) && this.servesOnlyModel(serverId, remoteModelId)) {
-      caps = await fetchServerProps(server.url, apiKey, timeoutMs);
+      caps = await fetchServerProps(probedUrl, apiKey, timeoutMs);
     }
 
     if (isUnusable(caps)) {
@@ -312,15 +318,39 @@ class ServerStore {
     }
 
     runInAction(() => {
+      // The probe is detached, so the server may have been removed or
+      // repointed while it was in flight. Both prune this key, and both make
+      // the answer describe a backend that is no longer configured — writing
+      // now would resurrect it.
+      const current = this.servers.find(s => s.id === serverId);
+      if (
+        !current ||
+        current.url !== probedUrl ||
+        current.serverType !== probedType
+      ) {
+        return;
+      }
       const key = `${serverId}/${remoteModelId}`;
-      this.remoteCaps[key] = {...this.remoteCaps[key], ...caps};
+      const prior = this.remoteCaps[key];
+      const merged = {...prior, ...caps};
+      if (
+        prior &&
+        prior.contextLength === merged.contextLength &&
+        prior.supportsVision === merged.supportsVision
+      ) {
+        return;
+      }
+      this.remoteCaps[key] = merged;
     });
   }
 
   /**
    * True only when the server's model list is known and holds exactly this one
-   * model. The list is not persisted, so an absent one means unknown — and
-   * unknown is precisely the multi-model case after a failed model fetch.
+   * model. The list is not persisted, so an absent one means unknown, and
+   * unknown does not pass: a genuine single-model server that was offline
+   * during the post-hydration fetch is skipped here too. Losing a bare retry
+   * costs nothing but an unknown capability; taking one on a multi-model
+   * server would attribute the resident model's props to this one.
    */
   private servesOnlyModel(serverId: string, remoteModelId: string): boolean {
     const models = this.serverModels.get(serverId);

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -11,7 +11,7 @@ import {
   RemoteModelInfo,
   PROPS_TIMEOUT_MS,
 } from '../api/openai';
-import {ServerConfig} from '../utils/types';
+import {RemoteModelCaps, ServerConfig} from '../utils/types';
 import {ReasoningCapability} from '../utils/reasoningCapability';
 
 const KEYCHAIN_SERVICE_PREFIX = 'pocketpal-server-';
@@ -25,6 +25,9 @@ class ServerStore {
   // Remote Models are rebuilt each launch and not persisted, so their capability
   // lives here and persists with the store.
   remoteReasoning: Record<string, ReasoningCapability> = {};
+  // Server-reported capabilities keyed by the same full model id. /props
+  // answers per model on a multi-model server, so caps cannot live per server.
+  remoteCaps: Record<string, RemoteModelCaps> = {};
   serverModels: Map<string, RemoteModelInfo[]> = observable.map();
   userSelectedModels: Array<{serverId: string; remoteModelId: string}> = [];
   isLoading = false;
@@ -46,6 +49,7 @@ class ServerStore {
         'privacyNoticeAcknowledged',
         'userSelectedModels',
         'remoteReasoning',
+        'remoteCaps',
       ],
       storage: AsyncStorage,
     }).then(() => {

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -13,6 +13,8 @@ import {
 } from '../api/openai';
 import {RemoteModelCaps, ServerConfig} from '../utils/types';
 import {ReasoningCapability} from '../utils/reasoningCapability';
+import {deriveListCapsMap} from '../utils/listCaps';
+import type {ListDerivedCaps} from '../utils/listCaps';
 
 const KEYCHAIN_SERVICE_PREFIX = 'pocketpal-server-';
 
@@ -178,6 +180,16 @@ class ServerStore {
     if (!hasModels) {
       this.removeServer(serverId);
     }
+  }
+
+  /**
+   * What the fetched model lists say about each model, keyed by full model id.
+   * A computed with no writer and no persistence: `serverModels` is already
+   * replaced by every fetch, dropped when a server url or type changes and
+   * dropped with the server, so these cannot outlive the url they came from.
+   */
+  get listCaps(): Record<string, ListDerivedCaps> {
+    return deriveListCapsMap(this.servers, this.serverModels);
   }
 
   getModelsNotYetAdded(serverId: string): RemoteModelInfo[] {

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -29,9 +29,8 @@ const FETCH_THROTTLE_MS = 60000;
 const CAPS_FIELDS = ['contextLength', 'supportsVision'] as const;
 
 /**
- * Drop every entry of a per-model map (keyed `${serverId}/${remoteModelId}`)
- * that belongs to one server. Shared by every path that invalidates per-model
- * state, so a new map cannot be added to one and forgotten in the other.
+ * Shared by every path that invalidates per-model state, so a new map cannot
+ * be added to one and forgotten in the other.
  */
 function dropServerEntries<T>(
   map: Record<string, T>,
@@ -127,7 +126,6 @@ class ServerStore {
     this.userSelectedModels = this.userSelectedModels.filter(
       m => m.serverId !== id,
     );
-    // Drop per-model state keyed by this server's model ids.
     this.remoteReasoning = dropServerEntries(this.remoteReasoning, id);
     this.remoteCaps = dropServerEntries(this.remoteCaps, id);
     // Clean up API key from keychain
@@ -304,6 +302,9 @@ class ServerStore {
    * A shorter server timeout is honoured, a longer one is not:
    * `requestTimeoutMs` is a free numeric input, and detached work must stay
    * bounded by `PROPS_TIMEOUT_MS` per request.
+   *
+   * `resolvedApiKey` undefined is indistinguishable from a keyless server, so
+   * the probe re-reads the Keychain in that case.
    */
   async fetchRemoteModelCaps(
     serverId: string,

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -8,6 +8,7 @@ import {
   fetchModels,
   fetchServerProps,
   testConnection,
+  PROPS_TIMEOUT_MS,
   RemoteModelInfo,
 } from '../api/openai';
 import {RemoteModelCaps, ServerConfig} from '../utils/types';
@@ -249,6 +250,10 @@ class ServerStore {
    *
    * Merges field-wise: a response that resolves only one field must not blank
    * a known other, and a probe that resolves nothing writes nothing.
+   *
+   * A shorter server timeout is honoured, a longer one is not:
+   * `requestTimeoutMs` is a free numeric input, and detached work must stay
+   * bounded by `PROPS_TIMEOUT_MS` per request.
    */
   async fetchRemoteModelCaps(
     serverId: string,
@@ -262,20 +267,21 @@ class ServerStore {
     const isUnusable = (caps: RemoteModelCaps) =>
       caps.contextLength === undefined && caps.supportsVision === undefined;
 
+    const timeoutMs = Math.min(
+      server.requestTimeoutMs ?? PROPS_TIMEOUT_MS,
+      PROPS_TIMEOUT_MS,
+    );
+
     const apiKey = await this.getApiKey(serverId);
     let caps = await fetchServerProps(
       server.url,
       apiKey,
-      server.requestTimeoutMs,
+      timeoutMs,
       remoteModelId,
     );
 
     if (isUnusable(caps) && this.servesOnlyModel(serverId, remoteModelId)) {
-      caps = await fetchServerProps(
-        server.url,
-        apiKey,
-        server.requestTimeoutMs,
-      );
+      caps = await fetchServerProps(server.url, apiKey, timeoutMs);
     }
 
     if (isUnusable(caps)) {

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -98,20 +98,23 @@ class ServerStore {
     if (!server) {
       return;
     }
-    // Caps describe what the configured backend reported. Repointing the url or
-    // switching the server type makes them describe something else, and
-    // resolveRemoteCaps has no way to tell — so drop them and let the next
-    // activation re-probe. Reasoning state survives: it carries user
-    // declarations, and it is not server-reported.
-    const invalidatesCaps =
+    // Caps and the model list are both what the configured backend reported.
+    // Repointing the url or switching the server type makes them describe
+    // something else: resolveRemoteCaps has no way to tell, and a stale
+    // single-entry list would let servesOnlyModel clear the bare-retry gate
+    // against a router. Drop both and let the next probe / fetch repopulate.
+    // Reasoning state survives: it carries user declarations, and it is not
+    // server-reported.
+    const invalidatesDiscovery =
       (updates.url !== undefined && updates.url !== server.url) ||
       (updates.serverType !== undefined &&
         updates.serverType !== server.serverType);
 
     Object.assign(server, updates);
 
-    if (invalidatesCaps) {
+    if (invalidatesDiscovery) {
       this.remoteCaps = dropServerEntries(this.remoteCaps, id);
+      this.serverModels.delete(id);
     }
   }
 

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -9,7 +9,6 @@ import {
   fetchServerProps,
   testConnection,
   RemoteModelInfo,
-  PROPS_TIMEOUT_MS,
 } from '../api/openai';
 import {RemoteModelCaps, ServerConfig} from '../utils/types';
 import {ReasoningCapability} from '../utils/reasoningCapability';
@@ -229,35 +228,6 @@ class ServerStore {
           s.lastConnected = Date.now();
         }
       });
-
-      // llama.cpp serves GET /props with the context window and vision
-      // capability. Detached (fire-and-forget) so a slow/hung probe can't hold
-      // the add-server sheet in the saving state: fetchModelsForServer resolves
-      // as soon as the models list is stored. Best-effort and llama.cpp-only;
-      // the bounded PROPS_TIMEOUT_MS caps the detached probe. Other server
-      // types skip it entirely (no request).
-      if (server.serverType === 'llama.cpp') {
-        (async () => {
-          const props = await fetchServerProps(
-            server.url,
-            apiKey,
-            PROPS_TIMEOUT_MS,
-          );
-          if (
-            props.contextLength !== undefined ||
-            props.supportsVision !== undefined
-          ) {
-            runInAction(() => {
-              // updateServer re-finds by id, so a delete-during-fetch race is a
-              // no-op rather than a stale write to a removed server.
-              this.updateServer(serverId, props);
-            });
-          }
-        })().catch(() => {
-          // Defense-in-depth: fetchServerProps never throws today; swallow to
-          // satisfy no-floating-promises on the detached probe.
-        });
-      }
     } catch (error: any) {
       runInAction(() => {
         this.error = error.message || 'Failed to fetch models';

--- a/src/store/ServerStore.ts
+++ b/src/store/ServerStore.ts
@@ -85,12 +85,15 @@ class ServerStore {
     this.userSelectedModels = this.userSelectedModels.filter(
       m => m.serverId !== id,
     );
-    // Drop remote reasoning entries keyed by this server's model ids.
+    // Drop per-model state keyed by this server's model ids.
     const prefix = `${id}/`;
     this.remoteReasoning = Object.fromEntries(
       Object.entries(this.remoteReasoning).filter(
         ([k]) => !k.startsWith(prefix),
       ),
+    );
+    this.remoteCaps = Object.fromEntries(
+      Object.entries(this.remoteCaps).filter(([k]) => !k.startsWith(prefix)),
     );
     // Clean up API key from keychain
     this.removeApiKey(id);
@@ -261,6 +264,68 @@ class ServerStore {
         this.isLoading = false;
       });
     }
+  }
+
+  /**
+   * Probe GET /props for one remote model and merge what it reports into
+   * remoteCaps. llama.cpp only; callers invoke it detached, and it never
+   * throws or rejects.
+   *
+   * At most two requests: the scoped one, and — only when the server is
+   * provably serving this one model — a bare retry, which is what a
+   * single-model llama-server has always answered correctly. On a multi-model
+   * server the bare form describes whichever model happens to be resident, so
+   * it is never issued there and the caps simply stay unknown.
+   *
+   * Merges field-wise: a response that resolves only one field must not blank
+   * a known other, and a probe that resolves nothing writes nothing.
+   */
+  async fetchRemoteModelCaps(
+    serverId: string,
+    remoteModelId: string,
+  ): Promise<void> {
+    const server = this.servers.find(s => s.id === serverId);
+    if (!server || server.serverType !== 'llama.cpp') {
+      return;
+    }
+
+    const isUnusable = (caps: RemoteModelCaps) =>
+      caps.contextLength === undefined && caps.supportsVision === undefined;
+
+    const apiKey = await this.getApiKey(serverId);
+    let caps = await fetchServerProps(
+      server.url,
+      apiKey,
+      server.requestTimeoutMs,
+      remoteModelId,
+    );
+
+    if (isUnusable(caps) && this.servesOnlyModel(serverId, remoteModelId)) {
+      caps = await fetchServerProps(
+        server.url,
+        apiKey,
+        server.requestTimeoutMs,
+      );
+    }
+
+    if (isUnusable(caps)) {
+      return;
+    }
+
+    runInAction(() => {
+      const key = `${serverId}/${remoteModelId}`;
+      this.remoteCaps[key] = {...this.remoteCaps[key], ...caps};
+    });
+  }
+
+  /**
+   * True only when the server's model list is known and holds exactly this one
+   * model. The list is not persisted, so an absent one means unknown — and
+   * unknown is precisely the multi-model case after a failed model fetch.
+   */
+  private servesOnlyModel(serverId: string, remoteModelId: string): boolean {
+    const models = this.serverModels.get(serverId);
+    return models?.length === 1 && models[0].id === remoteModelId;
   }
 
   async fetchAllRemoteModels(): Promise<void> {

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4277,6 +4277,81 @@ describe('ModelStore', () => {
     });
   });
 
+  describe('foreground capability re-probe', () => {
+    let probe: jest.SpyInstance;
+
+    beforeEach(() => {
+      runInAction(() => {
+        modelStore.context = undefined;
+        modelStore.appState = 'background';
+        modelStore.activeModelId = 'srv-1/llama-7b';
+        modelStore.models = [];
+        serverStore.servers = [
+          {id: 'srv-1', name: 'llama', url: 'http://localhost:8080'},
+        ];
+        serverStore.serverModels.set('srv-1', [
+          {id: 'llama-7b', object: 'model', owned_by: 'system'},
+        ]);
+        serverStore.userSelectedModels = [
+          {serverId: 'srv-1', remoteModelId: 'llama-7b'},
+        ];
+        serverStore.remoteCaps = {};
+      });
+      probe = jest
+        .spyOn(serverStore, 'fetchRemoteModelCaps')
+        .mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      probe.mockRestore();
+      runInAction(() => {
+        modelStore.activeModelId = undefined;
+        serverStore.servers = [];
+        serverStore.serverModels.clear();
+        serverStore.userSelectedModels = [];
+        serverStore.remoteCaps = {};
+      });
+    });
+
+    it('probes once for an active remote model with no capabilities', async () => {
+      await modelStore.handleAppStateChange('active');
+
+      expect(probe).toHaveBeenCalledTimes(1);
+      expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b');
+    });
+
+    it('issues no probe when capabilities are already known', async () => {
+      runInAction(() => {
+        serverStore.remoteCaps['srv-1/llama-7b'] = {contextLength: 8192};
+      });
+
+      await modelStore.handleAppStateChange('active');
+
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('issues no probe for an active local model', async () => {
+      const model = {...presetModelFixture, isDownloaded: true};
+      runInAction(() => {
+        modelStore.models = [model];
+        modelStore.activeModelId = model.id;
+      });
+
+      await modelStore.handleAppStateChange('active');
+
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('survives a re-probe that rejects', async () => {
+      probe.mockRejectedValue(new Error('boom'));
+
+      await expect(
+        modelStore.handleAppStateChange('active'),
+      ).resolves.toBeUndefined();
+      await new Promise(setImmediate);
+    });
+  });
+
   describe('fetchAndPersistGGUFMetadata error handling', () => {
     const {loadLlamaModelInfo} = require('llama.rn');
 

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -2404,6 +2404,66 @@ describe('ModelStore', () => {
       });
     });
 
+    describe('capability resolution', () => {
+      afterEach(() => {
+        runInAction(() => {
+          serverStore.servers = [];
+          serverStore.remoteCaps = {};
+          modelStore.models = [];
+          modelStore.activeModelId = undefined;
+          modelStore.activeRemoteBinding = undefined;
+          modelStore.isMultimodalActive = false;
+        });
+      });
+
+      it('resolves an active remote model against the stored capabilities', () => {
+        runInAction(() => {
+          modelStore.models = [
+            {
+              id: 'srv-1/remote-model',
+              origin: ModelOrigin.REMOTE,
+              serverId: 'srv-1',
+            } as any,
+          ];
+          modelStore.activeModelId = 'srv-1/remote-model';
+          serverStore.remoteCaps = {
+            'srv-1/remote-model': {supportsVision: true, contextLength: 8192},
+          };
+        });
+
+        expect(modelStore.activeModelCaps).toEqual({
+          vision: 'yes',
+          visionActive: true,
+          contextLength: 8192,
+          effectiveContextLength: 8192,
+        });
+      });
+
+      it('does not report another model as vision-active', () => {
+        const other = {
+          id: 'other-local',
+          origin: ModelOrigin.PRESET,
+          supportsMultimodal: true,
+        } as any;
+        runInAction(() => {
+          modelStore.models = [
+            {id: 'active-local', origin: ModelOrigin.PRESET} as any,
+            other,
+          ];
+          modelStore.activeModelId = 'active-local';
+          modelStore.isMultimodalActive = true;
+          modelStore.activeContextSettings = {n_ctx: 4096} as any;
+        });
+
+        expect(modelStore.capsFor(other).vision).toBe('yes');
+        expect(modelStore.capsFor(other).visionActive).toBe(false);
+        expect(
+          modelStore.capsFor(other).effectiveContextLength,
+        ).toBeUndefined();
+        expect(modelStore.activeModelCaps.effectiveContextLength).toBe(4096);
+      });
+    });
+
     it('should get compatible projection models from explicit list', () => {
       const llmModel = {
         id: 'test-llm',

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -2345,32 +2345,61 @@ describe('ModelStore', () => {
               name: 'llama',
               url: 'http://localhost:8080',
               serverType: 'llama.cpp',
-              supportsVision,
             },
           ];
+          serverStore.remoteCaps =
+            supportsVision === undefined
+              ? {}
+              : {
+                  'srv-1/remote-model': {
+                    supportsVision,
+                    probedUrl: 'http://localhost:8080',
+                  },
+                };
+          modelStore.activeRemoteBinding = {
+            modelId: 'srv-1/remote-model',
+            serverId: 'srv-1',
+            remoteModelId: 'remote-model',
+            url: 'http://localhost:8080',
+            serverType: 'llama.cpp',
+          };
         });
       };
 
       afterEach(() => {
         runInAction(() => {
           serverStore.servers = [];
+          serverStore.remoteCaps = {};
           modelStore.models = [];
           modelStore.activeModelId = undefined;
+          modelStore.activeRemoteBinding = undefined;
         });
       });
 
-      it('returns true when the active server reports vision', async () => {
+      it('returns true when the probe reported vision', async () => {
         setRemoteActive(true);
         await expect(modelStore.isMultimodalEnabled()).resolves.toBe(true);
       });
 
-      it('returns false when the active server does not report vision', async () => {
+      it('returns false when the probe reported no vision', async () => {
         setRemoteActive(false);
         await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
       });
 
-      it('returns false when the server capability is unprobed', async () => {
+      it('returns false when the capability is unprobed', async () => {
         setRemoteActive(undefined);
+        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
+      });
+
+      it('returns false when the capabilities describe another backend', async () => {
+        setRemoteActive(true);
+        runInAction(() => {
+          serverStore.remoteCaps['srv-1/remote-model'].probedUrl =
+            'http://localhost:9090';
+        });
+
+        // The session still posts to :8080; a capability read from :9090 says
+        // nothing about it, so vision stays unknown and fails closed.
         await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
       });
     });
@@ -4305,6 +4334,8 @@ describe('ModelStore', () => {
     beforeEach(() => {
       runInAction(() => {
         modelStore.context = undefined;
+        modelStore.engine = undefined;
+        modelStore.activeRemoteBinding = undefined;
         modelStore.appState = 'background';
         modelStore.activeModelId = 'srv-1/llama-7b';
         modelStore.models = [];
@@ -4328,6 +4359,8 @@ describe('ModelStore', () => {
       probe.mockRestore();
       runInAction(() => {
         modelStore.activeModelId = undefined;
+        modelStore.engine = undefined;
+        modelStore.activeRemoteBinding = undefined;
         serverStore.servers = [];
         serverStore.serverModels.clear();
         serverStore.userSelectedModels = [];
@@ -4362,6 +4395,27 @@ describe('ModelStore', () => {
       expect(probe).not.toHaveBeenCalled();
     });
 
+    it('probes again when the stored capabilities describe another backend', async () => {
+      runInAction(() => {
+        serverStore.remoteCaps['srv-1/llama-7b'] = {
+          contextLength: 8192,
+          probedUrl: 'http://localhost:9090',
+        };
+        modelStore.activeRemoteBinding = {
+          modelId: 'srv-1/llama-7b',
+          serverId: 'srv-1',
+          remoteModelId: 'llama-7b',
+          url: 'http://localhost:8080',
+        };
+      });
+
+      await modelStore.handleAppStateChange('active');
+
+      // Populated is not the same as usable: that entry is unusable for this
+      // session, and the server still serves the url the session is bound to.
+      expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b');
+    });
+
     it('issues no probe for an active local model', async () => {
       const model = {...presetModelFixture, isDownloaded: true};
       runInAction(() => {
@@ -4381,6 +4435,66 @@ describe('ModelStore', () => {
         modelStore.handleAppStateChange('active'),
       ).resolves.toBeUndefined();
       await new Promise(setImmediate);
+    });
+
+    describe('after an in-session url edit', () => {
+      const remoteModel = {
+        id: 'srv-1/llama-7b',
+        name: 'llama-7b',
+        origin: ModelOrigin.REMOTE,
+        serverId: 'srv-1',
+        remoteModelId: 'llama-7b',
+      } as any;
+
+      // Activate for real so the binding is built from the url of the moment,
+      // the way updateServer leaves it.
+      const activateThenBackground = async () => {
+        await modelStore.setRemoteModel(remoteModel);
+        runInAction(() => {
+          modelStore.appState = 'background';
+          serverStore.remoteCaps = {};
+        });
+        probe.mockClear();
+      };
+
+      it('issues no probe while the session is bound to the old url', async () => {
+        await activateThenBackground();
+        serverStore.updateServer('srv-1', {url: 'http://localhost:9090'});
+
+        await modelStore.handleAppStateChange('active');
+
+        // The session still posts to :8080, so :9090 cannot answer for it.
+        expect(modelStore.activeRemoteBinding?.url).toBe(
+          'http://localhost:8080',
+        );
+        expect(probe).not.toHaveBeenCalled();
+        expect(serverStore.remoteCaps['srv-1/llama-7b']).toBeUndefined();
+      });
+
+      it('probes when the edit left the url untouched', async () => {
+        await activateThenBackground();
+        serverStore.updateServer('srv-1', {requestTimeoutMs: 30000});
+
+        await modelStore.handleAppStateChange('active');
+
+        expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b');
+      });
+
+      it('probes again once the model is re-selected on the new url', async () => {
+        await activateThenBackground();
+        serverStore.updateServer('srv-1', {url: 'http://localhost:9090'});
+
+        await modelStore.setRemoteModel(remoteModel);
+
+        // Re-selection is what moves the session, and the probe goes with it.
+        expect(modelStore.activeRemoteBinding?.url).toBe(
+          'http://localhost:9090',
+        );
+        expect(probe.mock.calls.at(-1)?.slice(0, 2)).toEqual([
+          'srv-1',
+          'llama-7b',
+        ]);
+      });
     });
   });
 

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -1842,6 +1842,23 @@ describe('ModelStore', () => {
       expect(modelStore.context).toBeUndefined();
       expect(modelStore.activeModelId).toBeUndefined();
     });
+
+    it('releases the multimodal context first when one is active', async () => {
+      const releaseMultimodal = jest.fn();
+      modelStore.context = {
+        release: jest.fn(),
+        releaseMultimodal,
+      } as any;
+      modelStore.activeModelId = 'test-id';
+      runInAction(() => {
+        modelStore.isMultimodalActive = true;
+      });
+
+      await modelStore.manualReleaseContext();
+
+      expect(releaseMultimodal).toHaveBeenCalled();
+      expect(modelStore.isMultimodalActive).toBe(false);
+    });
   });
 
   // Add tests for HF model handling
@@ -2282,50 +2299,6 @@ describe('ModelStore', () => {
       modelStore.isMultimodalActive = false;
     });
 
-    it('should return true for isMultimodalEnabled when cached flag is true', async () => {
-      modelStore.isMultimodalActive = true;
-      const result = await modelStore.isMultimodalEnabled();
-      expect(result).toBe(true);
-    });
-
-    it('should return false for isMultimodalEnabled when no context', async () => {
-      modelStore.context = undefined;
-      const result = await modelStore.isMultimodalEnabled();
-      expect(result).toBe(false);
-    });
-
-    it('should check context and update cached flag for isMultimodalEnabled', async () => {
-      const mockContext = {
-        isMultimodalEnabled: jest.fn().mockResolvedValue(true),
-      };
-      modelStore.context = mockContext as any;
-
-      const result = await modelStore.isMultimodalEnabled();
-      expect(result).toBe(true);
-      expect(mockContext.isMultimodalEnabled).toHaveBeenCalled();
-      expect(modelStore.isMultimodalActive).toBe(true);
-    });
-
-    it('should handle error in isMultimodalEnabled', async () => {
-      const mockContext = {
-        isMultimodalEnabled: jest
-          .fn()
-          .mockRejectedValue(new Error('Test error')),
-      };
-      modelStore.context = mockContext as any;
-
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-      const result = await modelStore.isMultimodalEnabled();
-      expect(result).toBe(false);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error checking multimodal capability:',
-        expect.any(Error),
-      );
-
-      consoleErrorSpy.mockRestore();
-    });
-
     describe('remote model vision (server /props self-report)', () => {
       const setRemoteActive = (supportsVision?: boolean) => {
         runInAction(() => {
@@ -2376,22 +2349,24 @@ describe('ModelStore', () => {
         });
       });
 
-      it('returns true when the probe reported vision', async () => {
+      it('is vision-active when the probe reported vision', () => {
         setRemoteActive(true);
-        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(true);
+        expect(modelStore.activeModelCaps.visionActive).toBe(true);
       });
 
-      it('returns false when the probe reported no vision', async () => {
+      it('is not vision-active when the probe reported no vision', () => {
         setRemoteActive(false);
-        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
+        expect(modelStore.activeModelCaps.vision).toBe('no');
+        expect(modelStore.activeModelCaps.visionActive).toBe(false);
       });
 
-      it('returns false when the capability is unprobed', async () => {
+      it('is not vision-active when the capability is unprobed', () => {
         setRemoteActive(undefined);
-        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
+        expect(modelStore.activeModelCaps.vision).toBe('unknown');
+        expect(modelStore.activeModelCaps.visionActive).toBe(false);
       });
 
-      it('returns false when the capabilities describe another backend', async () => {
+      it('is not vision-active when the capabilities describe another backend', () => {
         setRemoteActive(true);
         runInAction(() => {
           serverStore.remoteCaps['srv-1/remote-model'].probedUrl =
@@ -2400,7 +2375,8 @@ describe('ModelStore', () => {
 
         // The session still posts to :8080; a capability read from :9090 says
         // nothing about it, so vision stays unknown and fails closed.
-        await expect(modelStore.isMultimodalEnabled()).resolves.toBe(false);
+        expect(modelStore.activeModelCaps.vision).toBe('unknown');
+        expect(modelStore.activeModelCaps.visionActive).toBe(false);
       });
     });
 
@@ -3135,6 +3111,15 @@ describe('ModelStore', () => {
       modelStore.context = undefined;
       modelStore.inferencing = false;
       modelStore.isStreaming = false;
+      runInAction(() => {
+        modelStore.isMultimodalActive = true;
+      });
+    });
+
+    afterEach(() => {
+      runInAction(() => {
+        modelStore.isMultimodalActive = false;
+      });
     });
 
     it('should throw error when no context available', async () => {
@@ -3149,10 +3134,10 @@ describe('ModelStore', () => {
     });
 
     it('should throw error when multimodal is not enabled', async () => {
-      const mockContext = {
-        isMultimodalEnabled: jest.fn().mockResolvedValue(false),
-      };
-      modelStore.context = mockContext as any;
+      modelStore.context = {} as any;
+      runInAction(() => {
+        modelStore.isMultimodalActive = false;
+      });
 
       await expect(
         modelStore.startImageCompletion({
@@ -3163,32 +3148,20 @@ describe('ModelStore', () => {
     });
 
     it('should call onError when no images provided', async () => {
-      const mockContext = {
-        isMultimodalEnabled: jest.fn().mockResolvedValue(true),
-      };
-      modelStore.context = mockContext as any;
-
-      // Mock the isMultimodalEnabled method on the store to return true
-      const originalIsMultimodalEnabled = modelStore.isMultimodalEnabled;
-      modelStore.isMultimodalEnabled = jest.fn().mockResolvedValue(true);
+      modelStore.context = {} as any;
 
       const onError = jest.fn();
 
-      try {
-        await modelStore.startImageCompletion({
-          prompt: 'Test prompt',
-          onError,
-        });
+      await modelStore.startImageCompletion({
+        prompt: 'Test prompt',
+        onError,
+      });
 
-        expect(onError).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'No images provided for multimodal completion',
-          }),
-        );
-      } finally {
-        // Restore original method
-        modelStore.isMultimodalEnabled = originalIsMultimodalEnabled;
-      }
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'No images provided for multimodal completion',
+        }),
+      );
     });
 
     it('should handle single image completion successfully', async () => {

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4240,8 +4240,30 @@ describe('ModelStore', () => {
 
       await modelStore.setRemoteModel(remoteModel);
 
-      expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b');
+      // The api key resolved for the engine is handed to the probe, which
+      // therefore makes no second Keychain read.
+      expect(probe).toHaveBeenCalledWith(
+        'srv-1',
+        'llama-7b',
+        expect.anything(),
+      );
       probe.mockRestore();
+    });
+
+    it('hands the resolved api key to the probe', async () => {
+      const getApiKey = jest
+        .spyOn(serverStore, 'getApiKey')
+        .mockResolvedValue('sk-test');
+      const probe = jest
+        .spyOn(serverStore, 'fetchRemoteModelCaps')
+        .mockResolvedValue(undefined);
+
+      await modelStore.setRemoteModel(remoteModel);
+
+      expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b', 'sk-test');
+      expect(getApiKey).toHaveBeenCalledTimes(1);
+      probe.mockRestore();
+      getApiKey.mockRestore();
     });
 
     it('resolves without waiting on a probe that never settles', async () => {
@@ -4318,6 +4340,16 @@ describe('ModelStore', () => {
 
       expect(probe).toHaveBeenCalledTimes(1);
       expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b');
+    });
+
+    it('probes again on a later foreground while caps stay unknown', async () => {
+      await modelStore.handleAppStateChange('active');
+      runInAction(() => {
+        modelStore.appState = 'background';
+      });
+      await modelStore.handleAppStateChange('active');
+
+      expect(probe).toHaveBeenCalledTimes(2);
     });
 
     it('issues no probe when capabilities are already known', async () => {

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4519,7 +4519,6 @@ describe('ModelStore', () => {
 
         await modelStore.setRemoteModel(remoteModel);
 
-        // Re-selection is what moves the session, and the probe goes with it.
         expect(modelStore.activeRemoteBinding?.url).toBe(
           'http://localhost:9090',
         );

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4215,6 +4215,68 @@ describe('ModelStore', () => {
     });
   });
 
+  describe('setRemoteModel capability probe', () => {
+    const remoteModel = {
+      id: 'srv-1/llama-7b',
+      name: 'llama-7b',
+      origin: ModelOrigin.REMOTE,
+      serverId: 'srv-1',
+      remoteModelId: 'llama-7b',
+    } as any;
+
+    beforeEach(() => {
+      runInAction(() => {
+        modelStore.context = undefined;
+        serverStore.servers = [
+          {id: 'srv-1', name: 'llama', url: 'http://localhost:8080'},
+        ];
+      });
+    });
+
+    it('probes capabilities for the model being activated', async () => {
+      const probe = jest
+        .spyOn(serverStore, 'fetchRemoteModelCaps')
+        .mockResolvedValue(undefined);
+
+      await modelStore.setRemoteModel(remoteModel);
+
+      expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b');
+      probe.mockRestore();
+    });
+
+    it('resolves without waiting on a probe that never settles', async () => {
+      let release: () => void = () => {};
+      const probe = jest
+        .spyOn(serverStore, 'fetchRemoteModelCaps')
+        .mockReturnValue(
+          new Promise<void>(resolve => {
+            release = resolve;
+          }),
+        );
+
+      await modelStore.setRemoteModel(remoteModel);
+
+      // The engine is live and the model active while the probe is pending, so
+      // a lazily-starting server can never delay a send.
+      expect(modelStore.activeModelId).toBe('srv-1/llama-7b');
+      expect(modelStore.engine).toBeTruthy();
+      release();
+      probe.mockRestore();
+    });
+
+    it('survives a probe that rejects', async () => {
+      const probe = jest
+        .spyOn(serverStore, 'fetchRemoteModelCaps')
+        .mockRejectedValue(new Error('boom'));
+
+      await expect(
+        modelStore.setRemoteModel(remoteModel),
+      ).resolves.toBeUndefined();
+      await new Promise(setImmediate);
+      probe.mockRestore();
+    });
+  });
+
   describe('fetchAndPersistGGUFMetadata error handling', () => {
     const {loadLlamaModelInfo} = require('llama.rn');
 

--- a/src/store/__tests__/ModelStore.test.ts
+++ b/src/store/__tests__/ModelStore.test.ts
@@ -4262,24 +4262,7 @@ describe('ModelStore', () => {
       });
     });
 
-    it('probes capabilities for the model being activated', async () => {
-      const probe = jest
-        .spyOn(serverStore, 'fetchRemoteModelCaps')
-        .mockResolvedValue(undefined);
-
-      await modelStore.setRemoteModel(remoteModel);
-
-      // The api key resolved for the engine is handed to the probe, which
-      // therefore makes no second Keychain read.
-      expect(probe).toHaveBeenCalledWith(
-        'srv-1',
-        'llama-7b',
-        expect.anything(),
-      );
-      probe.mockRestore();
-    });
-
-    it('hands the resolved api key to the probe', async () => {
+    it('probes the activated model, forwarding the key resolved for the engine', async () => {
       const getApiKey = jest
         .spyOn(serverStore, 'getApiKey')
         .mockResolvedValue('sk-test');
@@ -4291,6 +4274,23 @@ describe('ModelStore', () => {
 
       expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b', 'sk-test');
       expect(getApiKey).toHaveBeenCalledTimes(1);
+      probe.mockRestore();
+      getApiKey.mockRestore();
+    });
+
+    it('forwards undefined for a keyless server', async () => {
+      const getApiKey = jest
+        .spyOn(serverStore, 'getApiKey')
+        .mockResolvedValue(undefined);
+      const probe = jest
+        .spyOn(serverStore, 'fetchRemoteModelCaps')
+        .mockResolvedValue(undefined);
+
+      await modelStore.setRemoteModel(remoteModel);
+
+      // Nothing is forwarded when there is no key, so the probe falls back to
+      // its own Keychain read — the common local llama.cpp case.
+      expect(probe).toHaveBeenCalledWith('srv-1', 'llama-7b', undefined);
       probe.mockRestore();
       getApiKey.mockRestore();
     });

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -43,6 +43,7 @@ describe('ServerStore', () => {
       serverStore.error = null;
       serverStore.privacyNoticeAcknowledged = false;
       serverStore.remoteReasoning = {};
+      serverStore.remoteCaps = {};
     });
   });
 
@@ -916,6 +917,214 @@ describe('ServerStore', () => {
       expect(serverStore.servers.find(s => s.id === id)?.serverType).toBe(
         'Ollama',
       );
+    });
+  });
+
+  describe('fetchRemoteModelCaps', () => {
+    const addLlamaServer = (overrides: any = {}) =>
+      serverStore.addServer({
+        name: 'llama server',
+        url: 'http://localhost:8080',
+        serverType: 'llama.cpp',
+        ...overrides,
+      });
+
+    it('writes the scoped probe result under the full model id', async () => {
+      const id = addLlamaServer({requestTimeoutMs: 20000});
+      jest.clearAllMocks();
+      mockedFetchServerProps.mockResolvedValueOnce({
+        contextLength: 8192,
+        supportsVision: true,
+      });
+
+      await serverStore.fetchRemoteModelCaps(id, 'gemma-4-e2b');
+
+      // The server's own timeout is forwarded raw; the API layer owns the floor.
+      expect(mockedFetchServerProps).toHaveBeenCalledTimes(1);
+      expect(mockedFetchServerProps).toHaveBeenCalledWith(
+        'http://localhost:8080',
+        undefined,
+        20000,
+        'gemma-4-e2b',
+      );
+      expect(serverStore.remoteCaps[`${id}/gemma-4-e2b`]).toEqual({
+        contextLength: 8192,
+        supportsVision: true,
+      });
+    });
+
+    it('keys by the raw model id even when it contains a slash', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      mockedFetchServerProps.mockResolvedValueOnce({supportsVision: false});
+
+      await serverStore.fetchRemoteModelCaps(id, 'unsloth/gemma-3-4b');
+
+      // Encoding belongs to the request, not the key.
+      expect(serverStore.remoteCaps[`${id}/unsloth/gemma-3-4b`]).toEqual({
+        supportsVision: false,
+      });
+    });
+
+    it('does not let a sibling model inherit another model caps', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      mockedFetchServerProps.mockResolvedValueOnce({
+        contextLength: 8192,
+        supportsVision: true,
+      });
+      await serverStore.fetchRemoteModelCaps(id, 'gemma-4-e2b');
+
+      mockedFetchServerProps.mockResolvedValueOnce({
+        contextLength: 4096,
+        supportsVision: false,
+      });
+      await serverStore.fetchRemoteModelCaps(id, 'gemma-3-4b');
+
+      expect(serverStore.remoteCaps[`${id}/gemma-4-e2b`]).toEqual({
+        contextLength: 8192,
+        supportsVision: true,
+      });
+      expect(serverStore.remoteCaps[`${id}/gemma-3-4b`]).toEqual({
+        contextLength: 4096,
+        supportsVision: false,
+      });
+    });
+
+    it('merges field-wise so a partial result never blanks a known field', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      runInAction(() => {
+        serverStore.remoteCaps[`${id}/m`] = {
+          contextLength: 8192,
+          supportsVision: true,
+        };
+      });
+      mockedFetchServerProps.mockResolvedValueOnce({supportsVision: false});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
+        contextLength: 8192,
+        supportsVision: false,
+      });
+    });
+
+    it('leaves a prior entry untouched when the probe yields nothing', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      runInAction(() => {
+        serverStore.serverModels.set(id, [
+          {id: 'm', object: 'model', owned_by: 'system'},
+          {id: 'other', object: 'model', owned_by: 'system'},
+        ]);
+        serverStore.remoteCaps[`${id}/m`] = {
+          contextLength: 8192,
+          supportsVision: true,
+        };
+      });
+      mockedFetchServerProps.mockResolvedValueOnce({});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
+        contextLength: 8192,
+        supportsVision: true,
+      });
+    });
+
+    it('retries bare when the server serves only the probed model', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      runInAction(() => {
+        serverStore.serverModels.set(id, [
+          {id: 'm', object: 'model', owned_by: 'system'},
+        ]);
+      });
+      mockedFetchServerProps
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({contextLength: 4096, supportsVision: true});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      expect(mockedFetchServerProps).toHaveBeenCalledTimes(2);
+      expect(mockedFetchServerProps).toHaveBeenLastCalledWith(
+        'http://localhost:8080',
+        undefined,
+        undefined,
+      );
+      expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
+        contextLength: 4096,
+        supportsVision: true,
+      });
+    });
+
+    it.each([
+      [
+        'a multi-model list',
+        Array.from({length: 45}, (_, i) => ({
+          id: `m${i}`,
+          object: 'model',
+          owned_by: 'system',
+        })),
+      ],
+      [
+        'a single non-matching model',
+        [{id: 'other', object: 'model', owned_by: 'system'}],
+      ],
+      ['an empty list', []],
+      ['an unknown list', undefined],
+    ])('issues no bare retry against %s', async (_label, models: any) => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      runInAction(() => {
+        if (models) {
+          serverStore.serverModels.set(id, models);
+        }
+      });
+      mockedFetchServerProps.mockResolvedValueOnce({});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm0');
+
+      // A bare probe on a multi-model server describes whichever model is
+      // resident, so it must not be attributed to the one being probed.
+      expect(mockedFetchServerProps).toHaveBeenCalledTimes(1);
+      expect(serverStore.remoteCaps[`${id}/m0`]).toBeUndefined();
+    });
+
+    it('issues no request at all for a non-llama.cpp server', async () => {
+      const id = serverStore.addServer({
+        name: 'LM Studio',
+        url: 'http://localhost:1234',
+        serverType: 'LM Studio',
+      });
+      jest.clearAllMocks();
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      expect(mockedFetchServerProps).not.toHaveBeenCalled();
+      expect(serverStore.remoteCaps[`${id}/m`]).toBeUndefined();
+    });
+
+    it('issues no request for a server that no longer exists', async () => {
+      jest.clearAllMocks();
+
+      await serverStore.fetchRemoteModelCaps('gone', 'm');
+
+      expect(mockedFetchServerProps).not.toHaveBeenCalled();
+    });
+
+    it('drops caps for a removed server, keeping other servers entries', () => {
+      const id = addLlamaServer();
+      runInAction(() => {
+        serverStore.remoteCaps[`${id}/m1`] = {contextLength: 4096};
+        serverStore.remoteCaps['other-server/m2'] = {contextLength: 2048};
+      });
+
+      serverStore.removeServer(id);
+
+      expect(serverStore.remoteCaps[`${id}/m1`]).toBeUndefined();
+      expect(serverStore.remoteCaps['other-server/m2']).toBeDefined();
     });
   });
 });

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -25,6 +25,14 @@ jest
 
 // Import the singleton after mocks
 import {serverStore} from '../ServerStore';
+import {routerModelsBody} from '../../../jest/fixtures/remoteModelList';
+import type {RemoteModelInfo} from '../../api/openai';
+
+// Captured at import time: the constructor runs once, and `clearAllMocks`
+// between tests would otherwise erase the only call there ever is.
+const persistedProperties: string[] = (
+  jest.requireMock('mobx-persist-store').makePersistable as jest.Mock
+).mock.calls[0][1].properties;
 
 const mockedFetchModels = openaiModule.fetchModels as jest.Mock;
 const mockedFetchServerProps = openaiModule.fetchServerProps as jest.Mock;
@@ -427,6 +435,64 @@ describe('ServerStore', () => {
       expect(Keychain.resetGenericPassword).toHaveBeenCalledWith({
         service: `pocketpal-server-${id}`,
       });
+    });
+  });
+
+  describe('listCaps', () => {
+    const addRouter = (serverType = 'llama.cpp') => {
+      const id = serverStore.addServer({
+        name: 'router',
+        url: 'http://localhost:8080',
+        serverType,
+      });
+      runInAction(() => {
+        serverStore.serverModels.set(
+          id,
+          routerModelsBody.data as RemoteModelInfo[],
+        );
+      });
+      return id;
+    };
+
+    it('answers for every fetched model, keyed as a remote model id is', () => {
+      const id = addRouter();
+
+      expect(serverStore.listCaps[`${id}/gemma-4-e2b`]).toEqual({
+        tier: 'list',
+        supportsVision: true,
+        contextLength: 8192,
+      });
+    });
+
+    it('recomputes when a fetch replaces the list', () => {
+      const id = addRouter();
+      expect(Object.keys(serverStore.listCaps)).toHaveLength(5);
+
+      runInAction(() => {
+        serverStore.serverModels.set(id, []);
+      });
+
+      expect(Object.keys(serverStore.listCaps)).toHaveLength(0);
+    });
+
+    it('reads nothing off a server that is not llama.cpp', () => {
+      const id = addRouter('Ollama');
+
+      expect(serverStore.listCaps[`${id}/gemma-4-e2b`]).toEqual({
+        tier: 'list',
+      });
+    });
+
+    it('empties when the url changes, along with the models it derived from', () => {
+      const id = addRouter();
+
+      serverStore.updateServer(id, {url: 'http://localhost:9090'});
+
+      expect(serverStore.listCaps).toEqual({});
+    });
+
+    it('is not persisted', () => {
+      expect(persistedProperties).not.toContain('listCaps');
     });
   });
 

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -907,6 +907,7 @@ describe('ServerStore', () => {
       expect(serverStore.remoteCaps[`${id}/gemma-4-e2b`]).toEqual({
         contextLength: 8192,
         supportsVision: true,
+        probedUrl: 'http://localhost:8080',
       });
     });
 
@@ -935,6 +936,7 @@ describe('ServerStore', () => {
       // Encoding belongs to the request, not the key.
       expect(serverStore.remoteCaps[`${id}/unsloth/gemma-3-4b`]).toEqual({
         supportsVision: false,
+        probedUrl: 'http://localhost:8080',
       });
     });
 
@@ -956,10 +958,12 @@ describe('ServerStore', () => {
       expect(serverStore.remoteCaps[`${id}/gemma-4-e2b`]).toEqual({
         contextLength: 8192,
         supportsVision: true,
+        probedUrl: 'http://localhost:8080',
       });
       expect(serverStore.remoteCaps[`${id}/gemma-3-4b`]).toEqual({
         contextLength: 4096,
         supportsVision: false,
+        probedUrl: 'http://localhost:8080',
       });
     });
 
@@ -970,6 +974,7 @@ describe('ServerStore', () => {
         serverStore.remoteCaps[`${id}/m`] = {
           contextLength: 8192,
           supportsVision: true,
+          probedUrl: 'http://localhost:8080',
         };
       });
       mockedFetchServerProps.mockResolvedValueOnce({supportsVision: false});
@@ -979,6 +984,50 @@ describe('ServerStore', () => {
       expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
         contextLength: 8192,
         supportsVision: false,
+        probedUrl: 'http://localhost:8080',
+      });
+    });
+
+    it('replaces, not merges, an entry probed against another backend', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      runInAction(() => {
+        serverStore.remoteCaps[`${id}/m`] = {
+          contextLength: 8192,
+          supportsVision: true,
+          probedUrl: 'http://localhost:9090',
+        };
+      });
+      mockedFetchServerProps.mockResolvedValueOnce({supportsVision: false});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      // Carrying the old context length across would leave one entry
+      // describing two backends and labelled as one of them.
+      expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
+        supportsVision: false,
+        probedUrl: 'http://localhost:8080',
+      });
+    });
+
+    it('writes when only the probed backend changed', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      runInAction(() => {
+        serverStore.remoteCaps[`${id}/m`] = {
+          contextLength: 8192,
+          probedUrl: 'http://localhost:9090',
+        };
+      });
+      mockedFetchServerProps.mockResolvedValueOnce({contextLength: 8192});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      // Same numbers, different backend — the no-op short-circuit must not
+      // swallow this or the entry keeps claiming the old url.
+      expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
+        contextLength: 8192,
+        probedUrl: 'http://localhost:8080',
       });
     });
 
@@ -1028,6 +1077,7 @@ describe('ServerStore', () => {
       expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
         contextLength: 4096,
         supportsVision: true,
+        probedUrl: 'http://localhost:8080',
       });
     });
 

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -139,6 +139,71 @@ describe('ServerStore', () => {
 
       expect(serverStore.servers[0].url).toBe('http://localhost:5678');
     });
+
+    describe('capability invalidation', () => {
+      const addProbedServer = () => {
+        const id = serverStore.addServer({
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+        });
+        runInAction(() => {
+          serverStore.remoteCaps[`${id}/m`] = {
+            contextLength: 8192,
+            supportsVision: true,
+          };
+          serverStore.remoteCaps['other/m'] = {contextLength: 4096};
+          serverStore.remoteReasoning[`${id}/m`] = {
+            isReasoning: 'yes',
+            source: 'user',
+            supportsEffort: false,
+            effortValues: [],
+            effortSource: 'none',
+          };
+        });
+        return id;
+      };
+
+      it('drops this server caps when the url is repointed', () => {
+        const id = addProbedServer();
+
+        serverStore.updateServer(id, {url: 'http://localhost:9090'});
+
+        expect(serverStore.remoteCaps[`${id}/m`]).toBeUndefined();
+        expect(serverStore.remoteCaps['other/m']).toBeDefined();
+      });
+
+      it('drops this server caps when the server type changes', () => {
+        const id = addProbedServer();
+
+        serverStore.updateServer(id, {serverType: 'LM Studio'});
+
+        expect(serverStore.remoteCaps[`${id}/m`]).toBeUndefined();
+      });
+
+      it('keeps reasoning state, which is user-declarable', () => {
+        const id = addProbedServer();
+
+        serverStore.updateServer(id, {serverType: 'LM Studio'});
+
+        expect(serverStore.remoteReasoning[`${id}/m`]).toBeDefined();
+      });
+
+      it('keeps caps when neither the url nor the server type changes', () => {
+        const id = addProbedServer();
+
+        serverStore.updateServer(id, {
+          name: 'renamed',
+          url: 'http://localhost:8080',
+          requestTimeoutMs: 60000,
+        });
+
+        expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
+          contextLength: 8192,
+          supportsVision: true,
+        });
+      });
+    });
   });
 
   describe('removeServer', () => {

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -1064,6 +1064,50 @@ describe('ServerStore', () => {
       expect(serverStore.remoteCaps[`${id}/m0`]).toBeUndefined();
     });
 
+    it('uses a supplied api key instead of reading the keychain', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      const getApiKey = jest.spyOn(serverStore, 'getApiKey');
+      mockedFetchServerProps.mockResolvedValueOnce({contextLength: 8192});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm', 'sk-test');
+
+      expect(getApiKey).not.toHaveBeenCalled();
+      expect(mockedFetchServerProps).toHaveBeenCalledWith(
+        'http://localhost:8080',
+        'sk-test',
+        PROPS_TIMEOUT_MS,
+        'm',
+      );
+      getApiKey.mockRestore();
+    });
+
+    it('does not resurrect caps for a server removed mid-probe', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      mockedFetchServerProps.mockImplementationOnce(async () => {
+        serverStore.removeServer(id);
+        return {contextLength: 8192, supportsVision: true};
+      });
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      expect(serverStore.remoteCaps[`${id}/m`]).toBeUndefined();
+    });
+
+    it('does not write caps probed against a url that has since changed', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      mockedFetchServerProps.mockImplementationOnce(async () => {
+        serverStore.updateServer(id, {url: 'http://localhost:9090'});
+        return {contextLength: 8192, supportsVision: true};
+      });
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      expect(serverStore.remoteCaps[`${id}/m`]).toBeUndefined();
+    });
+
     it('issues no request at all for a non-llama.cpp server', async () => {
       const id = serverStore.addServer({
         name: 'LM Studio',

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -29,6 +29,7 @@ import {serverStore} from '../ServerStore';
 const mockedFetchModels = openaiModule.fetchModels as jest.Mock;
 const mockedFetchServerProps = openaiModule.fetchServerProps as jest.Mock;
 const mockedTestConnection = openaiModule.testConnection as jest.Mock;
+const {PROPS_TIMEOUT_MS} = openaiModule;
 
 describe('ServerStore', () => {
   beforeEach(() => {
@@ -830,18 +831,33 @@ describe('ServerStore', () => {
 
       await serverStore.fetchRemoteModelCaps(id, 'gemma-4-e2b');
 
-      // The server's own timeout is forwarded raw; the API layer owns the floor.
+      // A server timeout longer than the probe bound is clamped down to it.
       expect(mockedFetchServerProps).toHaveBeenCalledTimes(1);
       expect(mockedFetchServerProps).toHaveBeenCalledWith(
         'http://localhost:8080',
         undefined,
-        20000,
+        PROPS_TIMEOUT_MS,
         'gemma-4-e2b',
       );
       expect(serverStore.remoteCaps[`${id}/gemma-4-e2b`]).toEqual({
         contextLength: 8192,
         supportsVision: true,
       });
+    });
+
+    it('honours a server timeout shorter than the probe bound', async () => {
+      const id = addLlamaServer({requestTimeoutMs: 1500});
+      jest.clearAllMocks();
+      mockedFetchServerProps.mockResolvedValueOnce({contextLength: 8192});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm');
+
+      expect(mockedFetchServerProps).toHaveBeenCalledWith(
+        'http://localhost:8080',
+        undefined,
+        1500,
+        'm',
+      );
     });
 
     it('keys by the raw model id even when it contains a slash', async () => {
@@ -942,7 +958,7 @@ describe('ServerStore', () => {
       expect(mockedFetchServerProps).toHaveBeenLastCalledWith(
         'http://localhost:8080',
         undefined,
-        undefined,
+        PROPS_TIMEOUT_MS,
       );
       expect(serverStore.remoteCaps[`${id}/m`]).toEqual({
         contextLength: 4096,

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -1158,6 +1158,28 @@ describe('ServerStore', () => {
       getApiKey.mockRestore();
     });
 
+    it('reads the keychain when the caller supplies no key', async () => {
+      const id = addLlamaServer();
+      jest.clearAllMocks();
+      // A keyless server resolves to undefined, which is indistinguishable
+      // from "not supplied" — the read happens either way.
+      const getApiKey = jest
+        .spyOn(serverStore, 'getApiKey')
+        .mockResolvedValue(undefined);
+      mockedFetchServerProps.mockResolvedValueOnce({contextLength: 8192});
+
+      await serverStore.fetchRemoteModelCaps(id, 'm', undefined);
+
+      expect(getApiKey).toHaveBeenCalledWith(id);
+      expect(mockedFetchServerProps).toHaveBeenCalledWith(
+        'http://localhost:8080',
+        undefined,
+        PROPS_TIMEOUT_MS,
+        'm',
+      );
+      getApiKey.mockRestore();
+    });
+
     it('does not resurrect caps for a server removed mid-probe', async () => {
       const id = addLlamaServer();
       jest.clearAllMocks();

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -577,39 +577,7 @@ describe('ServerStore', () => {
       expect(server!.lastConnected).toBeGreaterThanOrEqual(before);
     });
 
-    it('fetches /props and writes discovered caps for a llama.cpp server', async () => {
-      const id = serverStore.addServer({
-        name: 'llama server',
-        url: 'http://localhost:8080',
-        serverType: 'llama.cpp',
-      });
-      jest.clearAllMocks();
-
-      mockedFetchModels.mockResolvedValueOnce([]);
-      mockedFetchServerProps.mockResolvedValueOnce({
-        contextLength: 4096,
-        supportsVision: true,
-      });
-      (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
-
-      await serverStore.fetchModelsForServer(id);
-
-      // The /props probe is bounded by PROPS_TIMEOUT_MS (5000), not the
-      // server's requestTimeoutMs or the omitted 30 s default.
-      expect(mockedFetchServerProps).toHaveBeenCalledWith(
-        'http://localhost:8080',
-        undefined,
-        5000,
-      );
-      // The probe is detached: fetchModelsForServer resolves before caps land,
-      // so the write is only observable after a microtask flush.
-      await new Promise(setImmediate);
-      const server = serverStore.servers.find(s => s.id === id);
-      expect(server!.contextLength).toBe(4096);
-      expect(server!.supportsVision).toBe(true);
-    });
-
-    it('resolves fetchModelsForServer without waiting on the /props probe', async () => {
+    it('issues no /props request when fetching the models list', async () => {
       const id = serverStore.addServer({
         name: 'llama server',
         url: 'http://localhost:8080',
@@ -619,93 +587,16 @@ describe('ServerStore', () => {
 
       const mockModels = [{id: 'm', object: 'model', owned_by: 'system'}];
       mockedFetchModels.mockResolvedValueOnce(mockModels);
-      // A /props probe that never settles must not block the resolution.
-      let released: (v: {supportsVision: boolean}) => void = () => {};
-      mockedFetchServerProps.mockReturnValueOnce(
-        new Promise(resolve => {
-          released = resolve;
-        }),
-      );
       (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
 
       await serverStore.fetchModelsForServer(id);
+      await new Promise(setImmediate);
 
-      // Models are present immediately even though the probe is still pending.
-      expect(serverStore.serverModels.get(id)).toEqual(mockModels);
-      released({supportsVision: true});
-    });
-
-    it('does not fetch /props for a non-llama.cpp server', async () => {
-      const id = serverStore.addServer({
-        name: 'LM Studio',
-        url: 'http://localhost:1234',
-        serverType: 'LM Studio',
-      });
-      jest.clearAllMocks();
-
-      mockedFetchModels.mockResolvedValueOnce([]);
-      (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
-
-      await serverStore.fetchModelsForServer(id);
-
+      // Capabilities are per model, so listing a server's models discovers
+      // none of them.
       expect(mockedFetchServerProps).not.toHaveBeenCalled();
-      const server = serverStore.servers.find(s => s.id === id);
-      expect(server!.contextLength).toBeUndefined();
-      expect(server!.supportsVision).toBeUndefined();
-    });
-
-    it('clears a stale supportsVision true when a later probe reports false', async () => {
-      const id = serverStore.addServer({
-        name: 'llama server',
-        url: 'http://localhost:8080',
-        serverType: 'llama.cpp',
-      });
-      jest.clearAllMocks();
-
-      mockedFetchModels.mockResolvedValue([]);
-      (Keychain.getGenericPassword as jest.Mock).mockResolvedValue(false);
-
-      mockedFetchServerProps.mockResolvedValueOnce({
-        contextLength: 4096,
-        supportsVision: true,
-      });
-      await serverStore.fetchModelsForServer(id);
-      await new Promise(setImmediate);
-      expect(serverStore.servers.find(s => s.id === id)!.supportsVision).toBe(
-        true,
-      );
-
-      // A model swap drops vision: the always-defined false overwrites the
-      // stale true so attach disables.
-      mockedFetchServerProps.mockResolvedValueOnce({supportsVision: false});
-      await serverStore.fetchModelsForServer(id);
-      await new Promise(setImmediate);
-      const server = serverStore.servers.find(s => s.id === id);
-      expect(server!.supportsVision).toBe(false);
-      expect(server!.contextLength).toBe(4096);
-    });
-
-    it('leaves caps unchanged and models intact when /props yields nothing', async () => {
-      const id = serverStore.addServer({
-        name: 'llama server',
-        url: 'http://localhost:8080',
-        serverType: 'llama.cpp',
-      });
-      jest.clearAllMocks();
-
-      const mockModels = [{id: 'm', object: 'model', owned_by: 'system'}];
-      mockedFetchModels.mockResolvedValueOnce(mockModels);
-      // Silent no-op: fetchServerProps swallows timeout/500/bad-JSON into {}.
-      mockedFetchServerProps.mockResolvedValueOnce({});
-      (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
-
-      await serverStore.fetchModelsForServer(id);
-
       expect(serverStore.serverModels.get(id)).toEqual(mockModels);
-      expect(serverStore.error).toBeNull();
-      const server = serverStore.servers.find(s => s.id === id);
-      expect(server!.contextLength).toBeUndefined();
-      expect(server!.supportsVision).toBeUndefined();
+      expect(serverStore.remoteCaps).toEqual({});
     });
   });
 

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -153,6 +153,12 @@ describe('ServerStore', () => {
             supportsVision: true,
           };
           serverStore.remoteCaps['other/m'] = {contextLength: 4096};
+          serverStore.serverModels.set(id, [
+            {id: 'm', object: 'model', owned_by: 'system'},
+          ]);
+          serverStore.serverModels.set('other', [
+            {id: 'm', object: 'model', owned_by: 'system'},
+          ]);
           serverStore.remoteReasoning[`${id}/m`] = {
             isReasoning: 'yes',
             source: 'user',
@@ -181,6 +187,25 @@ describe('ServerStore', () => {
         expect(serverStore.remoteCaps[`${id}/m`]).toBeUndefined();
       });
 
+      it('drops this server model list when the url is repointed', () => {
+        const id = addProbedServer();
+
+        serverStore.updateServer(id, {url: 'http://localhost:9090'});
+
+        // A single-entry list from the old backend would clear the bare-retry
+        // gate against a router that serves many models.
+        expect(serverStore.serverModels.has(id)).toBe(false);
+        expect(serverStore.serverModels.has('other')).toBe(true);
+      });
+
+      it('drops this server model list when the server type changes', () => {
+        const id = addProbedServer();
+
+        serverStore.updateServer(id, {serverType: 'LM Studio'});
+
+        expect(serverStore.serverModels.has(id)).toBe(false);
+      });
+
       it('keeps reasoning state, which is user-declarable', () => {
         const id = addProbedServer();
 
@@ -202,6 +227,7 @@ describe('ServerStore', () => {
           contextLength: 8192,
           supportsVision: true,
         });
+        expect(serverStore.serverModels.has(id)).toBe(true);
       });
     });
   });

--- a/src/store/__tests__/ServerStore.test.ts
+++ b/src/store/__tests__/ServerStore.test.ts
@@ -464,6 +464,26 @@ describe('ServerStore', () => {
       });
     });
 
+    it('derives from the fetch alone for a newly added llama.cpp server', async () => {
+      mockedFetchModels.mockResolvedValue(
+        routerModelsBody.data as RemoteModelInfo[],
+      );
+      const id = serverStore.addServer({
+        name: 'router',
+        url: 'http://localhost:8080',
+        serverType: 'llama.cpp',
+      });
+
+      await serverStore.fetchModelsForServer(id);
+
+      expect(serverStore.listCaps[`${id}/gemma-4-e2b`]).toEqual({
+        tier: 'list',
+        supportsVision: true,
+        contextLength: 8192,
+      });
+      expect(mockedFetchServerProps).not.toHaveBeenCalled();
+    });
+
     it('recomputes when a fetch replaces the list', () => {
       const id = addRouter();
       expect(Object.keys(serverStore.listCaps)).toHaveLength(5);
@@ -492,7 +512,13 @@ describe('ServerStore', () => {
     });
 
     it('is not persisted', () => {
-      expect(persistedProperties).not.toContain('listCaps');
+      expect(persistedProperties).toEqual([
+        'servers',
+        'privacyNoticeAcknowledged',
+        'userSelectedModels',
+        'remoteReasoning',
+        'remoteCaps',
+      ]);
     });
   });
 

--- a/src/utils/__tests__/listCaps.test.ts
+++ b/src/utils/__tests__/listCaps.test.ts
@@ -1,0 +1,220 @@
+import {
+  directTextModelsBody,
+  directVisionModelsBody,
+  routerModelsBody,
+} from '../../../jest/fixtures/remoteModelList';
+import {deriveListCaps, deriveListCapsMap} from '../listCaps';
+import type {ListDerivedCaps} from '../listCaps';
+import type {RemoteModelCaps, ServerConfig} from '../types';
+
+import type {RemoteModelInfo} from '../../api/openai';
+
+const routerRow = (id: string): RemoteModelInfo => {
+  const row = routerModelsBody.data.find(r => r.id === id);
+  if (!row) {
+    throw new Error(`fixture has no row ${id}`);
+  }
+  return row as RemoteModelInfo;
+};
+
+const VISION = 'gemma-4-e2b';
+const VISION_UNLOADED = 'ggml-org/gemma-4-31B-it-GGUF:Q8_0';
+const TEXT = 'gemma-3-4b';
+
+/**
+ * A real unloaded row — no `meta`, so the launch arguments are the only source
+ * left — with its argument list swapped for the one under test.
+ */
+const withArgs = (args: string[]): RemoteModelInfo => {
+  const row = routerRow(VISION_UNLOADED);
+  return {...row, status: {...row.status, args}};
+};
+
+describe('deriveListCaps', () => {
+  describe('vision, router form', () => {
+    it('reads image support off the declared input modalities', () => {
+      expect(
+        deriveListCaps(routerRow(VISION), 'llama.cpp').supportsVision,
+      ).toBe(true);
+    });
+
+    it('answers for a model the server has not loaded', () => {
+      expect(
+        deriveListCaps(routerRow(VISION_UNLOADED), 'llama.cpp').supportsVision,
+      ).toBe(true);
+    });
+
+    it('treats a missing image modality as a definite no', () => {
+      expect(deriveListCaps(routerRow(TEXT), 'llama.cpp').supportsVision).toBe(
+        false,
+      );
+    });
+
+    it('says nothing when the row declares no architecture at all', () => {
+      // A router build predating the field, or a proxy in front of one — the
+      // whole list lands here, and "cannot tell" must not read as "no".
+      const row = {...routerRow(VISION)};
+      delete row.architecture;
+
+      expect('supportsVision' in deriveListCaps(row, 'llama.cpp')).toBe(false);
+    });
+
+    it('says nothing when the modalities key is not an array', () => {
+      const row = {
+        ...routerRow(VISION),
+        architecture: {input_modalities: 'text,image' as any},
+      };
+
+      expect('supportsVision' in deriveListCaps(row, 'llama.cpp')).toBe(false);
+    });
+  });
+
+  describe('vision, direct form', () => {
+    const directRow = (body: typeof directVisionModelsBody): RemoteModelInfo =>
+      ({
+        ...body.data[0],
+        capabilities: body.models[0].capabilities,
+      }) as RemoteModelInfo;
+
+    it('reads multimodal off the joined capabilities', () => {
+      expect(
+        deriveListCaps(directRow(directVisionModelsBody), 'llama.cpp')
+          .supportsVision,
+      ).toBe(true);
+    });
+
+    it('reads its absence as a definite no', () => {
+      expect(
+        deriveListCaps(directRow(directTextModelsBody), 'llama.cpp')
+          .supportsVision,
+      ).toBe(false);
+    });
+
+    it('never consults capabilities when the modalities answered', () => {
+      // The router form separates image from audio and the direct form cannot,
+      // so the more precise source has to win where both are present.
+      const row = {...routerRow(TEXT), capabilities: ['multimodal']};
+
+      expect(deriveListCaps(row, 'llama.cpp').supportsVision).toBe(false);
+    });
+  });
+
+  describe('context length', () => {
+    it('prefers what a loaded model reports over how it was launched', () => {
+      const row = routerRow(VISION);
+      const raised = {...row, meta: {...row.meta, n_ctx: 32768}};
+
+      expect(deriveListCaps(raised, 'llama.cpp').contextLength).toBe(32768);
+    });
+
+    it('falls back to the launch window when nothing is loaded', () => {
+      const row = routerRow(VISION_UNLOADED);
+
+      expect(row.meta).toBeUndefined();
+      expect(deriveListCaps(row, 'llama.cpp').contextLength).toBe(8192);
+    });
+
+    it.each([
+      ['space form', ['--ctx-size', '4096'], 4096],
+      ['inline form', ['--ctx-size=4096'], 4096],
+      ['short flag', ['-c', '4096'], 4096],
+      ['short inline flag', ['-c=4096'], 4096],
+      ['last occurrence wins', ['--ctx-size', '2048', '-c', '4096'], 4096],
+      [
+        'last occurrence wins across forms',
+        ['-c=2048', '--ctx-size=4096'],
+        4096,
+      ],
+    ])('parses the %s', (_label, args, expected) => {
+      expect(deriveListCaps(withArgs(args), 'llama.cpp').contextLength).toBe(
+        expected,
+      );
+    });
+
+    it.each([
+      ['zero, which means the trained window', ['--ctx-size', '0']],
+      ['a non-numeric value', ['--ctx-size', 'abc']],
+      ['a negative value', ['--ctx-size', '-4096']],
+      ['a trailing flag with no value', ['--jinja', '--ctx-size']],
+      ['a flag that only looks similar', ['--ctx-size-foo', '4096']],
+      ['no window argument at all', ['--jinja', '--flash-attn', 'auto']],
+    ])('reports no window for %s', (_label, args) => {
+      const caps = deriveListCaps(withArgs(args), 'llama.cpp');
+
+      expect('contextLength' in caps).toBe(false);
+    });
+
+    it('does not let a later bad value revive an earlier good one', () => {
+      const caps = deriveListCaps(
+        withArgs(['--ctx-size', '4096', '--ctx-size', '0']),
+        'llama.cpp',
+      );
+
+      expect('contextLength' in caps).toBe(false);
+    });
+  });
+
+  describe('the serverType gate', () => {
+    it.each(['Ollama', 'LM Studio', 'OpenAI', 'vLLM', undefined])(
+      'reads nothing off a %s server',
+      serverType => {
+        // The fully-populated router row: everything to parse, nothing parsed.
+        expect(deriveListCaps(routerRow(VISION), serverType)).toEqual({
+          tier: 'list',
+        });
+      },
+    );
+
+    it('reads nothing off an absent row', () => {
+      expect(deriveListCaps(undefined, 'llama.cpp')).toEqual({tier: 'list'});
+    });
+  });
+
+  describe('the tier brand', () => {
+    it('is enforced by the compiler, not at runtime', () => {
+      const listed: ListDerivedCaps = {tier: 'list', supportsVision: true};
+      const probed: RemoteModelCaps = {supportsVision: true};
+
+      // @ts-expect-error a list answer must never pass as a probed one
+      const asProbed: RemoteModelCaps = listed;
+      // @ts-expect-error and a probed answer is not a list answer either
+      const asListed: ListDerivedCaps = probed;
+
+      expect([asProbed, asListed]).toHaveLength(2);
+    });
+  });
+});
+
+describe('deriveListCapsMap', () => {
+  const servers: ServerConfig[] = [
+    {id: 'srv-1', name: 'router', url: 'http://x', serverType: 'llama.cpp'},
+    {id: 'srv-2', name: 'ollama', url: 'http://y', serverType: 'Ollama'},
+  ];
+  const rows = routerModelsBody.data as RemoteModelInfo[];
+  const serverModels = new Map<string, RemoteModelInfo[]>([
+    ['srv-1', rows],
+    ['srv-2', rows],
+  ]);
+
+  it('keys every model by the id its card carries', () => {
+    const map = deriveListCapsMap(servers, serverModels);
+
+    expect(map[`srv-1/${VISION}`]).toEqual({
+      tier: 'list',
+      supportsVision: true,
+      contextLength: 8192,
+    });
+  });
+
+  it('applies each server own type to its own rows', () => {
+    const map = deriveListCapsMap(servers, serverModels);
+
+    expect(map[`srv-2/${VISION}`]).toEqual({tier: 'list'});
+  });
+
+  it('omits servers that have not been fetched yet', () => {
+    const map = deriveListCapsMap(servers, new Map());
+
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+});

--- a/src/utils/__tests__/listCaps.test.ts
+++ b/src/utils/__tests__/listCaps.test.ts
@@ -138,10 +138,42 @@ describe('deriveListCaps', () => {
       ['a trailing flag with no value', ['--jinja', '--ctx-size']],
       ['a flag that only looks similar', ['--ctx-size-foo', '4096']],
       ['no window argument at all', ['--jinja', '--flash-attn', 'auto']],
+      [
+        'a value beyond the safe-integer range',
+        ['--ctx-size', '9'.repeat(400)],
+      ],
     ])('reports no window for %s', (_label, args) => {
       const caps = deriveListCaps(withArgs(args), 'llama.cpp');
 
       expect('contextLength' in caps).toBe(false);
+    });
+
+    it('reports no window when the argument list is not an array', () => {
+      const row = routerRow(VISION_UNLOADED);
+      const mangled = {
+        ...row,
+        status: {...row.status, args: '--ctx-size 8192' as any},
+      };
+
+      expect('contextLength' in deriveListCaps(mangled, 'llama.cpp')).toBe(
+        false,
+      );
+    });
+
+    it('reports no window when the flag is followed by a non-string', () => {
+      const caps = deriveListCaps(
+        withArgs(['--ctx-size', 4096 as any]),
+        'llama.cpp',
+      );
+
+      expect('contextLength' in caps).toBe(false);
+    });
+
+    it('ignores a fractional report and falls through to the launch window', () => {
+      const row = routerRow(VISION);
+      const fractional = {...row, meta: {...row.meta, n_ctx: 8192.5}};
+
+      expect(deriveListCaps(fractional, 'llama.cpp').contextLength).toBe(8192);
     });
 
     it('does not let a later bad value revive an earlier good one', () => {

--- a/src/utils/__tests__/modelCaps.test.ts
+++ b/src/utils/__tests__/modelCaps.test.ts
@@ -173,9 +173,12 @@ describe('resolveModelCaps', () => {
       it('never reaches the session axis, even for the active model', () => {
         // The card describes the configured server; attach, the send gate and
         // the context banner describe the bound session, which is only ever
-        // answered by a probe. A model can therefore read Vision: Supported
-        // while attach stays disabled — fail-closed, and self-correcting on
-        // the next successful probe.
+        // answered by a probe. So the active model can read Vision: Supported
+        // with attach still disabled — whenever the list has an answer and the
+        // probe has no entry, because it timed out, answered non-2xx, or was
+        // dropped with the models list by a url edit and only the list came
+        // back. Activating *attempts* confirmation; it does not guarantee it.
+        // Fail-closed, and self-correcting on the next successful probe.
         const caps = resolveModelCaps(
           remoteModel(),
           env({

--- a/src/utils/__tests__/modelCaps.test.ts
+++ b/src/utils/__tests__/modelCaps.test.ts
@@ -171,14 +171,10 @@ describe('resolveModelCaps', () => {
       });
 
       it('never reaches the session axis, even for the active model', () => {
-        // The card describes the configured server; attach, the send gate and
-        // the context banner describe the bound session, which is only ever
-        // answered by a probe. So the active model can read Vision: Supported
-        // with attach still disabled — whenever the list has an answer and the
-        // probe has no entry, because it timed out, answered non-2xx, or was
-        // dropped with the models list by a url edit and only the list came
-        // back. Activating *attempts* confirmation; it does not guarantee it.
-        // Fail-closed, and self-correcting on the next successful probe.
+        // The list answers the declared axis only; the session axis is only
+        // ever answered by a probe, so the active model can read "Supported"
+        // with attach still disabled. Fail-closed, self-correcting on the
+        // next successful probe.
         const caps = resolveModelCaps(
           remoteModel(),
           env({

--- a/src/utils/__tests__/modelCaps.test.ts
+++ b/src/utils/__tests__/modelCaps.test.ts
@@ -1,0 +1,204 @@
+import {CapabilityEnv, resolveModelCaps} from '../modelCaps';
+import {Model, ModelOrigin} from '../types';
+
+const env = (overrides: Partial<CapabilityEnv> = {}): CapabilityEnv => ({
+  remoteCaps: {},
+  binding: undefined,
+  isMultimodalActive: false,
+  activeContextSettings: undefined,
+  activeModelId: undefined,
+  ...overrides,
+});
+
+const remoteModel = (): Model =>
+  ({
+    id: 'srv/gemma-4-e2b',
+    origin: ModelOrigin.REMOTE,
+    serverId: 'srv',
+    remoteModelId: 'gemma-4-e2b',
+  }) as unknown as Model;
+
+const localModel = (overrides: Partial<Model> = {}): Model =>
+  ({
+    id: 'local-1',
+    origin: ModelOrigin.LOCAL,
+    ...overrides,
+  }) as unknown as Model;
+
+describe('resolveModelCaps', () => {
+  it('reports unknown for no model', () => {
+    expect(resolveModelCaps(undefined, env())).toEqual({
+      vision: 'unknown',
+      visionActive: false,
+    });
+  });
+
+  describe('remote', () => {
+    it.each([
+      [true, 'yes', true],
+      [false, 'no', false],
+      [undefined, 'unknown', false],
+    ])(
+      'maps supportsVision %p to %s',
+      (supportsVision, vision, visionActive) => {
+        const caps = resolveModelCaps(
+          remoteModel(),
+          env({remoteCaps: {'srv/gemma-4-e2b': {supportsVision}}}),
+        );
+        expect(caps.vision).toBe(vision);
+        expect(caps.visionActive).toBe(visionActive);
+      },
+    );
+
+    it('populates both length fields from the probed window', () => {
+      const caps = resolveModelCaps(
+        remoteModel(),
+        env({remoteCaps: {'srv/gemma-4-e2b': {contextLength: 8192}}}),
+      );
+      expect(caps.contextLength).toBe(8192);
+      expect(caps.effectiveContextLength).toBe(8192);
+    });
+
+    it('treats a zero window as absent', () => {
+      const caps = resolveModelCaps(
+        remoteModel(),
+        env({remoteCaps: {'srv/gemma-4-e2b': {contextLength: 0}}}),
+      );
+      expect(caps.contextLength).toBeUndefined();
+      expect(caps.effectiveContextLength).toBeUndefined();
+    });
+
+    it('resolves to unknown when the caps describe another backend', () => {
+      const caps = resolveModelCaps(
+        remoteModel(),
+        env({
+          remoteCaps: {
+            'srv/gemma-4-e2b': {
+              supportsVision: true,
+              contextLength: 8192,
+              probedUrl: 'http://localhost:8080',
+            },
+          },
+          binding: {
+            modelId: 'srv/gemma-4-e2b',
+            serverId: 'srv',
+            remoteModelId: 'gemma-4-e2b',
+            url: 'http://localhost:9090',
+            serverType: 'llama.cpp',
+          },
+        }),
+      );
+      expect(caps.vision).toBe('unknown');
+      expect(caps.contextLength).toBeUndefined();
+    });
+
+    it('ignores local session state', () => {
+      const caps = resolveModelCaps(
+        remoteModel(),
+        env({
+          isMultimodalActive: true,
+          activeModelId: 'srv/gemma-4-e2b',
+          activeContextSettings: {n_ctx: 4096} as any,
+        }),
+      );
+      expect(caps.visionActive).toBe(false);
+      expect(caps.effectiveContextLength).toBeUndefined();
+    });
+  });
+
+  describe('local', () => {
+    it.each([
+      [true, 'yes'],
+      [false, 'no'],
+      [undefined, 'unknown'],
+    ])('maps supportsMultimodal %p to %s', (supportsMultimodal, vision) => {
+      expect(
+        resolveModelCaps(localModel({supportsMultimodal}), env()).vision,
+      ).toBe(vision);
+    });
+
+    it('prefers the hf window over gguf metadata', () => {
+      const caps = resolveModelCaps(
+        localModel({
+          hfModel: {specs: {gguf: {context_length: 32768}}},
+          ggufMetadata: {context_length: 8192},
+        } as unknown as Partial<Model>),
+        env(),
+      );
+      expect(caps.contextLength).toBe(32768);
+    });
+
+    it('falls through to gguf metadata when the hf window is zero', () => {
+      const caps = resolveModelCaps(
+        localModel({
+          hfModel: {specs: {gguf: {context_length: 0}}},
+          ggufMetadata: {context_length: 8192},
+        } as unknown as Partial<Model>),
+        env(),
+      );
+      expect(caps.contextLength).toBe(8192);
+    });
+
+    it('reports an absent window rather than zero', () => {
+      const caps = resolveModelCaps(
+        localModel({
+          ggufMetadata: {context_length: 0},
+        } as unknown as Partial<Model>),
+        env(),
+      );
+      expect(caps.contextLength).toBeUndefined();
+    });
+
+    it('reports the live session state for the active model', () => {
+      const caps = resolveModelCaps(
+        localModel({supportsMultimodal: true}),
+        env({
+          activeModelId: 'local-1',
+          isMultimodalActive: true,
+          activeContextSettings: {n_ctx: 4096} as any,
+        }),
+      );
+      expect(caps.visionActive).toBe(true);
+      expect(caps.effectiveContextLength).toBe(4096);
+    });
+
+    it('never borrows the active model session state for another model', () => {
+      const caps = resolveModelCaps(
+        localModel({id: 'local-2', supportsMultimodal: true}),
+        env({
+          activeModelId: 'local-1',
+          isMultimodalActive: true,
+          activeContextSettings: {n_ctx: 4096} as any,
+        }),
+      );
+      expect(caps.vision).toBe('yes');
+      expect(caps.visionActive).toBe(false);
+      expect(caps.effectiveContextLength).toBeUndefined();
+    });
+
+    it('separates the declared window from the one the session measures against', () => {
+      const caps = resolveModelCaps(
+        localModel({
+          ggufMetadata: {context_length: 32768},
+        } as unknown as Partial<Model>),
+        env({
+          activeModelId: 'local-1',
+          activeContextSettings: {n_ctx: 4096} as any,
+        }),
+      );
+      expect(caps.contextLength).toBe(32768);
+      expect(caps.effectiveContextLength).toBe(4096);
+    });
+
+    it('treats a zero session window as absent', () => {
+      const caps = resolveModelCaps(
+        localModel(),
+        env({
+          activeModelId: 'local-1',
+          activeContextSettings: {n_ctx: 0} as any,
+        }),
+      );
+      expect(caps.effectiveContextLength).toBeUndefined();
+    });
+  });
+});

--- a/src/utils/__tests__/modelCaps.test.ts
+++ b/src/utils/__tests__/modelCaps.test.ts
@@ -1,8 +1,10 @@
 import {CapabilityEnv, resolveModelCaps} from '../modelCaps';
 import {Model, ModelOrigin} from '../types';
+import type {ListDerivedCaps} from '../listCaps';
 
 const env = (overrides: Partial<CapabilityEnv> = {}): CapabilityEnv => ({
   remoteCaps: {},
+  listCaps: {},
   binding: undefined,
   isMultimodalActive: false,
   activeContextSettings: undefined,
@@ -115,6 +117,104 @@ describe('resolveModelCaps', () => {
       );
       expect(caps.vision).toBe('unknown');
       expect(caps.contextLength).toBeUndefined();
+    });
+
+    describe('the list tier', () => {
+      const listed = (caps: Partial<ListDerivedCaps>) => ({
+        'srv/gemma-4-e2b': {tier: 'list' as const, ...caps},
+      });
+
+      it('answers the declared axis when nothing has been probed', () => {
+        const caps = resolveModelCaps(
+          remoteModel(),
+          env({listCaps: listed({supportsVision: true, contextLength: 8192})}),
+        );
+        expect(caps.vision).toBe('yes');
+        expect(caps.contextLength).toBe(8192);
+      });
+
+      it('loses to the probe field by field', () => {
+        const caps = resolveModelCaps(
+          remoteModel(),
+          env({
+            remoteCaps: {
+              'srv/gemma-4-e2b': {supportsVision: false, contextLength: 4096},
+            },
+            listCaps: listed({supportsVision: true, contextLength: 8192}),
+          }),
+        );
+        expect(caps.vision).toBe('no');
+        expect(caps.contextLength).toBe(4096);
+      });
+
+      it('still answers the field the probe left empty', () => {
+        const caps = resolveModelCaps(
+          remoteModel(),
+          env({
+            remoteCaps: {'srv/gemma-4-e2b': {supportsVision: true}},
+            listCaps: listed({contextLength: 8192}),
+          }),
+        );
+        expect(caps.vision).toBe('yes');
+        expect(caps.contextLength).toBe(8192);
+      });
+
+      it('survives a probe entry carrying a legacy zero window', () => {
+        const caps = resolveModelCaps(
+          remoteModel(),
+          env({
+            remoteCaps: {'srv/gemma-4-e2b': {contextLength: 0}},
+            listCaps: listed({contextLength: 8192}),
+          }),
+        );
+        expect(caps.contextLength).toBe(8192);
+      });
+
+      it('never reaches the session axis, even for the active model', () => {
+        // The card describes the configured server; attach, the send gate and
+        // the context banner describe the bound session, which is only ever
+        // answered by a probe. A model can therefore read Vision: Supported
+        // while attach stays disabled — fail-closed, and self-correcting on
+        // the next successful probe.
+        const caps = resolveModelCaps(
+          remoteModel(),
+          env({
+            listCaps: listed({supportsVision: true, contextLength: 8192}),
+            activeModelId: 'srv/gemma-4-e2b',
+          }),
+        );
+        expect(caps.vision).toBe('yes');
+        expect(caps.visionActive).toBe(false);
+        expect(caps.effectiveContextLength).toBeUndefined();
+      });
+
+      it('answers the declared axis when a probe entry describes another backend', () => {
+        // Defensive only: a url edit drops the probe entry and the list
+        // together, and the write guard refuses a probe whose url has moved,
+        // so nothing normally leaves a mismatched entry behind.
+        const caps = resolveModelCaps(
+          remoteModel(),
+          env({
+            remoteCaps: {
+              'srv/gemma-4-e2b': {
+                supportsVision: false,
+                probedUrl: 'http://localhost:8080',
+              },
+            },
+            binding: {
+              modelId: 'srv/gemma-4-e2b',
+              serverId: 'srv',
+              remoteModelId: 'gemma-4-e2b',
+              url: 'http://localhost:9090',
+              serverType: 'llama.cpp',
+            },
+            listCaps: listed({supportsVision: true}),
+            activeModelId: 'srv/gemma-4-e2b',
+          }),
+        );
+        expect(caps.vision).toBe('yes');
+        expect(caps.visionActive).toBe(false);
+      });
     });
 
     it('ignores local session state', () => {

--- a/src/utils/__tests__/modelCaps.test.ts
+++ b/src/utils/__tests__/modelCaps.test.ts
@@ -43,7 +43,10 @@ describe('resolveModelCaps', () => {
       (supportsVision, vision, visionActive) => {
         const caps = resolveModelCaps(
           remoteModel(),
-          env({remoteCaps: {'srv/gemma-4-e2b': {supportsVision}}}),
+          env({
+            remoteCaps: {'srv/gemma-4-e2b': {supportsVision}},
+            activeModelId: 'srv/gemma-4-e2b',
+          }),
         );
         expect(caps.vision).toBe(vision);
         expect(caps.visionActive).toBe(visionActive);
@@ -53,7 +56,10 @@ describe('resolveModelCaps', () => {
     it('populates both length fields from the probed window', () => {
       const caps = resolveModelCaps(
         remoteModel(),
-        env({remoteCaps: {'srv/gemma-4-e2b': {contextLength: 8192}}}),
+        env({
+          remoteCaps: {'srv/gemma-4-e2b': {contextLength: 8192}},
+          activeModelId: 'srv/gemma-4-e2b',
+        }),
       );
       expect(caps.contextLength).toBe(8192);
       expect(caps.effectiveContextLength).toBe(8192);
@@ -62,9 +68,28 @@ describe('resolveModelCaps', () => {
     it('treats a zero window as absent', () => {
       const caps = resolveModelCaps(
         remoteModel(),
-        env({remoteCaps: {'srv/gemma-4-e2b': {contextLength: 0}}}),
+        env({
+          remoteCaps: {'srv/gemma-4-e2b': {contextLength: 0}},
+          activeModelId: 'srv/gemma-4-e2b',
+        }),
       );
       expect(caps.contextLength).toBeUndefined();
+      expect(caps.effectiveContextLength).toBeUndefined();
+    });
+
+    it('keeps the session axis empty for a model that is not active', () => {
+      const caps = resolveModelCaps(
+        remoteModel(),
+        env({
+          remoteCaps: {
+            'srv/gemma-4-e2b': {supportsVision: true, contextLength: 8192},
+          },
+          activeModelId: 'srv/other-model',
+        }),
+      );
+      expect(caps.vision).toBe('yes');
+      expect(caps.contextLength).toBe(8192);
+      expect(caps.visionActive).toBe(false);
       expect(caps.effectiveContextLength).toBeUndefined();
     });
 

--- a/src/utils/__tests__/remoteCaps.test.ts
+++ b/src/utils/__tests__/remoteCaps.test.ts
@@ -1,0 +1,86 @@
+import {resolveRemoteCaps} from '../remoteCaps';
+import {Model, ModelOrigin, ServerConfig} from '../types';
+
+const server = (overrides: Partial<ServerConfig> = {}): ServerConfig => ({
+  id: 'srv',
+  name: 'llama server',
+  url: 'http://localhost:8080',
+  serverType: 'llama.cpp',
+  ...overrides,
+});
+
+const remoteModel = (remoteModelId = 'gemma-4-e2b'): Model =>
+  ({
+    id: `srv/${remoteModelId}`,
+    origin: ModelOrigin.REMOTE,
+    serverId: 'srv',
+    remoteModelId,
+  }) as unknown as Model;
+
+const localModel = (): Model =>
+  ({id: 'local-1', origin: ModelOrigin.LOCAL}) as unknown as Model;
+
+describe('resolveRemoteCaps', () => {
+  it('returns the per-model entry when one exists', () => {
+    expect(
+      resolveRemoteCaps(
+        remoteModel(),
+        {'srv/gemma-4-e2b': {contextLength: 8192, supportsVision: true}},
+        [server()],
+      ),
+    ).toEqual({contextLength: 8192, supportsVision: true});
+  });
+
+  it('does not let one model inherit a sibling model entry', () => {
+    expect(
+      resolveRemoteCaps(
+        remoteModel('gemma-3-4b'),
+        {'srv/gemma-4-e2b': {contextLength: 8192, supportsVision: true}},
+        [server()],
+      ),
+    ).toEqual({});
+  });
+
+  it('prefers the per-model entry over the legacy per-server fields', () => {
+    expect(
+      resolveRemoteCaps(
+        remoteModel(),
+        {'srv/gemma-4-e2b': {contextLength: 8192, supportsVision: true}},
+        [server({contextLength: 2048, supportsVision: false})],
+      ),
+    ).toEqual({contextLength: 8192, supportsVision: true});
+  });
+
+  it('falls back to legacy per-server fields when no entry exists', () => {
+    expect(
+      resolveRemoteCaps(remoteModel(), {}, [
+        server({contextLength: 4096, supportsVision: false}),
+      ]),
+    ).toEqual({contextLength: 4096, supportsVision: false});
+  });
+
+  it('ignores a legacy context length of 0 left by a router probe', () => {
+    expect(
+      resolveRemoteCaps(remoteModel(), {}, [
+        server({contextLength: 0, supportsVision: false}),
+      ]),
+    ).toEqual({supportsVision: false});
+  });
+
+  it('resolves fields independently when the entry is partial', () => {
+    expect(
+      resolveRemoteCaps(
+        remoteModel(),
+        {'srv/gemma-4-e2b': {contextLength: 8192}},
+        [server({contextLength: 2048, supportsVision: true})],
+      ),
+    ).toEqual({contextLength: 8192, supportsVision: true});
+  });
+
+  it('resolves nothing for a local model, an absent model, or an unknown server', () => {
+    const caps = {'srv/gemma-4-e2b': {contextLength: 8192}};
+    expect(resolveRemoteCaps(localModel(), caps, [server()])).toEqual({});
+    expect(resolveRemoteCaps(undefined, caps, [server()])).toEqual({});
+    expect(resolveRemoteCaps(remoteModel(), {}, [])).toEqual({});
+  });
+});

--- a/src/utils/__tests__/remoteCaps.test.ts
+++ b/src/utils/__tests__/remoteCaps.test.ts
@@ -1,10 +1,16 @@
-import {resolveRemoteCaps} from '../remoteCaps';
-import {Model, ModelOrigin, ServerConfig} from '../types';
+import {capsMatchBinding, resolveRemoteCaps} from '../remoteCaps';
+import {Model, ModelOrigin, RemoteSessionBinding} from '../types';
 
-const server = (overrides: Partial<ServerConfig> = {}): ServerConfig => ({
-  id: 'srv',
-  name: 'llama server',
-  url: 'http://localhost:8080',
+const URL_A = 'http://localhost:8080';
+const URL_B = 'http://localhost:9090';
+
+const binding = (
+  overrides: Partial<RemoteSessionBinding> = {},
+): RemoteSessionBinding => ({
+  modelId: 'srv/gemma-4-e2b',
+  serverId: 'srv',
+  remoteModelId: 'gemma-4-e2b',
+  url: URL_A,
   serverType: 'llama.cpp',
   ...overrides,
 });
@@ -25,8 +31,14 @@ describe('resolveRemoteCaps', () => {
     expect(
       resolveRemoteCaps(
         remoteModel(),
-        {'srv/gemma-4-e2b': {contextLength: 8192, supportsVision: true}},
-        [server()],
+        {
+          'srv/gemma-4-e2b': {
+            contextLength: 8192,
+            supportsVision: true,
+            probedUrl: URL_A,
+          },
+        },
+        binding(),
       ),
     ).toEqual({contextLength: 8192, supportsVision: true});
   });
@@ -36,51 +48,82 @@ describe('resolveRemoteCaps', () => {
       resolveRemoteCaps(
         remoteModel('gemma-3-4b'),
         {'srv/gemma-4-e2b': {contextLength: 8192, supportsVision: true}},
-        [server()],
+        binding(),
       ),
     ).toEqual({});
-  });
-
-  it('prefers the per-model entry over the legacy per-server fields', () => {
-    expect(
-      resolveRemoteCaps(
-        remoteModel(),
-        {'srv/gemma-4-e2b': {contextLength: 8192, supportsVision: true}},
-        [server({contextLength: 2048, supportsVision: false})],
-      ),
-    ).toEqual({contextLength: 8192, supportsVision: true});
-  });
-
-  it('falls back to legacy per-server fields when no entry exists', () => {
-    expect(
-      resolveRemoteCaps(remoteModel(), {}, [
-        server({contextLength: 4096, supportsVision: false}),
-      ]),
-    ).toEqual({contextLength: 4096, supportsVision: false});
-  });
-
-  it('ignores a legacy context length of 0 left by a router probe', () => {
-    expect(
-      resolveRemoteCaps(remoteModel(), {}, [
-        server({contextLength: 0, supportsVision: false}),
-      ]),
-    ).toEqual({supportsVision: false});
   });
 
   it('resolves fields independently when the entry is partial', () => {
     expect(
       resolveRemoteCaps(
         remoteModel(),
-        {'srv/gemma-4-e2b': {contextLength: 8192}},
-        [server({contextLength: 2048, supportsVision: true})],
+        {'srv/gemma-4-e2b': {contextLength: 8192, probedUrl: URL_A}},
+        binding(),
       ),
-    ).toEqual({contextLength: 8192, supportsVision: true});
+    ).toEqual({contextLength: 8192});
   });
 
-  it('resolves nothing for a local model, an absent model, or an unknown server', () => {
+  it('drops an entry probed against a different backend', () => {
+    expect(
+      resolveRemoteCaps(
+        remoteModel(),
+        {
+          'srv/gemma-4-e2b': {
+            contextLength: 8192,
+            supportsVision: true,
+            probedUrl: URL_B,
+          },
+        },
+        binding({url: URL_A}),
+      ),
+    ).toEqual({});
+  });
+
+  it('keeps an entry that predates probedUrl', () => {
+    expect(
+      resolveRemoteCaps(
+        remoteModel(),
+        {'srv/gemma-4-e2b': {contextLength: 8192}},
+        binding(),
+      ),
+    ).toEqual({contextLength: 8192});
+  });
+
+  it('keeps an entry when no session is bound to that model', () => {
+    const caps = {'srv/gemma-4-e2b': {contextLength: 8192, probedUrl: URL_B}};
+    expect(resolveRemoteCaps(remoteModel(), caps, undefined)).toEqual({
+      contextLength: 8192,
+    });
+    expect(
+      resolveRemoteCaps(
+        remoteModel(),
+        caps,
+        binding({modelId: 'srv/other-model'}),
+      ),
+    ).toEqual({contextLength: 8192});
+  });
+
+  it('resolves nothing for a local model, an absent model, or an absent entry', () => {
     const caps = {'srv/gemma-4-e2b': {contextLength: 8192}};
-    expect(resolveRemoteCaps(localModel(), caps, [server()])).toEqual({});
-    expect(resolveRemoteCaps(undefined, caps, [server()])).toEqual({});
-    expect(resolveRemoteCaps(remoteModel(), {}, [])).toEqual({});
+    expect(resolveRemoteCaps(localModel(), caps, binding())).toEqual({});
+    expect(resolveRemoteCaps(undefined, caps, binding())).toEqual({});
+    expect(resolveRemoteCaps(remoteModel(), {}, binding())).toEqual({});
+  });
+});
+
+describe('capsMatchBinding', () => {
+  it('is false for an absent entry, so callers probe', () => {
+    expect(capsMatchBinding(undefined, binding(), 'srv/gemma-4-e2b')).toBe(
+      false,
+    );
+  });
+
+  it('matches on the url the entry was probed against', () => {
+    expect(
+      capsMatchBinding({probedUrl: URL_A}, binding(), 'srv/gemma-4-e2b'),
+    ).toBe(true);
+    expect(
+      capsMatchBinding({probedUrl: URL_B}, binding(), 'srv/gemma-4-e2b'),
+    ).toBe(false);
   });
 });

--- a/src/utils/listCaps.ts
+++ b/src/utils/listCaps.ts
@@ -23,7 +23,7 @@ const positiveInt = (raw: string | undefined): number | undefined => {
     return undefined;
   }
   const value = parseInt(raw, 10);
-  return value > 0 ? value : undefined;
+  return Number.isSafeInteger(value) && value > 0 ? value : undefined;
 };
 
 /**
@@ -88,7 +88,7 @@ export function deriveListCaps(
   }
 
   const reported =
-    typeof row.meta?.n_ctx === 'number' && Number.isFinite(row.meta.n_ctx)
+    typeof row.meta?.n_ctx === 'number' && Number.isSafeInteger(row.meta.n_ctx)
       ? row.meta.n_ctx
       : undefined;
   // A loaded child's own report beats the command that launched it.

--- a/src/utils/listCaps.ts
+++ b/src/utils/listCaps.ts
@@ -1,0 +1,120 @@
+import type {RemoteModelInfo} from '../api/openai';
+import type {ServerConfig} from './types';
+
+/**
+ * What a `GET /v1/models` row already says about a model, before anything is
+ * activated or probed. Weaker than a probe: the fields describe how the server
+ * was configured, not what a loaded session reports.
+ *
+ * The required `tier` makes this and `RemoteModelCaps` mutually non-assignable,
+ * so "a list answer can never be mistaken for a confirmed one" is a compile
+ * error rather than a rule to remember.
+ */
+export interface ListDerivedCaps {
+  tier: 'list';
+  supportsVision?: boolean;
+  contextLength?: number;
+}
+
+const CONTEXT_FLAGS = ['--ctx-size', '-c'];
+
+const positiveInt = (raw: string | undefined): number | undefined => {
+  if (raw === undefined || !/^\d+$/.test(raw)) {
+    return undefined;
+  }
+  const value = parseInt(raw, 10);
+  return value > 0 ? value : undefined;
+};
+
+/**
+ * The launch window, from the last `--ctx-size`/`-c` in either the
+ * `--ctx-size 8192` or `--ctx-size=8192` form. Last occurrence wins, matching
+ * the server's own argument handling. No other argument is read.
+ *
+ * `--ctx-size 0` means "use the model's trained window", which is not a window
+ * this can report, so it resolves to unknown like every other parse failure.
+ */
+const contextFromArgs = (args: unknown): number | undefined => {
+  if (!Array.isArray(args)) {
+    return undefined;
+  }
+  let found: number | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (typeof arg !== 'string') {
+      continue;
+    }
+    if (CONTEXT_FLAGS.includes(arg)) {
+      found = positiveInt(
+        typeof args[i + 1] === 'string' ? args[i + 1] : undefined,
+      );
+      continue;
+    }
+    const inline = CONTEXT_FLAGS.map(flag => `${flag}=`).find(prefix =>
+      arg.startsWith(prefix),
+    );
+    if (inline) {
+      found = positiveInt(arg.slice(inline.length));
+    }
+  }
+  return found;
+};
+
+/**
+ * Read a models-list row for capabilities. Pure, and never a default: anything
+ * absent, wrongly typed or unparseable yields no field at all, so a caller can
+ * tell "this server says no" from "this server did not say".
+ *
+ * The `serverType` gate lives here rather than at the call sites because the
+ * two callers source that type differently, and a gate outside the function is
+ * a gate that can disagree with itself.
+ */
+export function deriveListCaps(
+  row: RemoteModelInfo | undefined,
+  serverType: string | undefined,
+): ListDerivedCaps {
+  const caps: ListDerivedCaps = {tier: 'list'};
+  if (!row || serverType !== 'llama.cpp') {
+    return caps;
+  }
+
+  const modalities = row.architecture?.input_modalities;
+  if (Array.isArray(modalities)) {
+    // The array always carries `text`, so a missing `image` is the server
+    // answering "no", not failing to answer.
+    caps.supportsVision = modalities.includes('image');
+  } else if (Array.isArray(row.capabilities)) {
+    caps.supportsVision = row.capabilities.includes('multimodal');
+  }
+
+  const reported =
+    typeof row.meta?.n_ctx === 'number' && Number.isFinite(row.meta.n_ctx)
+      ? row.meta.n_ctx
+      : undefined;
+  // A loaded child's own report beats the command that launched it.
+  const contextLength =
+    (reported !== undefined && reported > 0 ? reported : undefined) ??
+    contextFromArgs(row.status?.args);
+  if (contextLength !== undefined) {
+    caps.contextLength = contextLength;
+  }
+
+  return caps;
+}
+
+/**
+ * The same derivation for every model of every server, keyed as
+ * `${serverId}/${remoteModelId}` — the id a remote `Model` carries.
+ */
+export function deriveListCapsMap(
+  servers: ServerConfig[],
+  serverModels: {get(serverId: string): RemoteModelInfo[] | undefined},
+): Record<string, ListDerivedCaps> {
+  const map: Record<string, ListDerivedCaps> = {};
+  for (const server of servers) {
+    for (const row of serverModels.get(server.id) ?? []) {
+      map[`${server.id}/${row.id}`] = deriveListCaps(row, server.serverType);
+    }
+  }
+  return map;
+}

--- a/src/utils/modelCaps.ts
+++ b/src/utils/modelCaps.ts
@@ -1,0 +1,92 @@
+import {resolveRemoteCaps} from './remoteCaps';
+import {ModelOrigin} from './types';
+import type {
+  ContextInitParams,
+  Model,
+  RemoteModelCaps,
+  RemoteSessionBinding,
+} from './types';
+
+/**
+ * Effective capabilities of a model, kept as two independent axes.
+ *
+ * Axis 1 (`vision` / `contextLength`) — what the model declares, independent of
+ * load state; describes the model itself, so it is meaningful for any model.
+ * Axis 2 (`visionActive` / `effectiveContextLength`) — what the session that
+ * exists right now can actually do; meaningful only for the active model.
+ *
+ * Both length fields are a number > 0 or absent, never 0 — callers do not
+ * re-check.
+ */
+export interface ModelCapabilityView {
+  vision: 'yes' | 'no' | 'unknown';
+  visionActive: boolean;
+  contextLength?: number;
+  effectiveContextLength?: number;
+}
+
+/** Resolver inputs. Assembled in one place — `ModelStore`. */
+export interface CapabilityEnv {
+  remoteCaps: Record<string, RemoteModelCaps>;
+  binding: RemoteSessionBinding | undefined;
+  isMultimodalActive: boolean;
+  activeContextSettings: ContextInitParams | undefined;
+  activeModelId: string | undefined;
+}
+
+const UNKNOWN: ModelCapabilityView = {vision: 'unknown', visionActive: false};
+
+const positive = (value: number | undefined): number | undefined =>
+  value !== undefined && value > 0 ? value : undefined;
+
+const triState = (value: boolean | undefined): 'yes' | 'no' | 'unknown' => {
+  if (value === undefined) {
+    return 'unknown';
+  }
+  return value ? 'yes' : 'no';
+};
+
+/**
+ * Resolve the effective capabilities of a model. Single source of truth — the
+ * only place `model.origin` is branched on to answer a capability question, so
+ * the attach affordance, the send path, the context banner and the model card
+ * cannot structurally disagree.
+ *
+ * Pure and synchronous by design: callers resolve inside an `observer` render
+ * body, so a capability landing from a detached probe re-renders on its own.
+ */
+export function resolveModelCaps(
+  model: Model | undefined,
+  env: CapabilityEnv,
+): ModelCapabilityView {
+  if (!model) {
+    return UNKNOWN;
+  }
+
+  if (model.origin === ModelOrigin.REMOTE) {
+    const caps = resolveRemoteCaps(model, env.remoteCaps, env.binding);
+    const vision = triState(caps.supportsVision);
+    const contextLength = positive(caps.contextLength);
+    return {
+      vision,
+      visionActive: vision === 'yes',
+      contextLength,
+      effectiveContextLength: contextLength,
+    };
+  }
+
+  // Local context facts describe the live session, so they apply to the active
+  // model alone — a card must never borrow another model's load state.
+  const isActiveModel = model.id === env.activeModelId;
+
+  return {
+    vision: triState(model.supportsMultimodal),
+    visionActive: isActiveModel && env.isMultimodalActive,
+    contextLength:
+      positive(model.hfModel?.specs?.gguf?.context_length) ??
+      positive(model.ggufMetadata?.context_length),
+    effectiveContextLength: isActiveModel
+      ? positive(env.activeContextSettings?.n_ctx)
+      : undefined,
+  };
+}

--- a/src/utils/modelCaps.ts
+++ b/src/utils/modelCaps.ts
@@ -1,5 +1,6 @@
 import {resolveRemoteCaps} from './remoteCaps';
 import {ModelOrigin} from './types';
+import type {ListDerivedCaps} from './listCaps';
 import type {
   ContextInitParams,
   Model,
@@ -28,6 +29,7 @@ export interface ModelCapabilityView {
 /** Resolver inputs. Assembled in one place — `ModelStore`. */
 export interface CapabilityEnv {
   remoteCaps: Record<string, RemoteModelCaps>;
+  listCaps: Record<string, ListDerivedCaps>;
   binding: RemoteSessionBinding | undefined;
   isMultimodalActive: boolean;
   activeContextSettings: ContextInitParams | undefined;
@@ -68,13 +70,22 @@ export function resolveModelCaps(
   const isActiveModel = model.id === env.activeModelId;
 
   if (model.origin === ModelOrigin.REMOTE) {
-    const caps = resolveRemoteCaps(model, env.remoteCaps, env.binding);
-    const contextLength = positive(caps.contextLength);
+    // Two tiers, merged field by field rather than entry by entry: a probe
+    // answers about a loaded model, the models list about a configured one, so
+    // one can answer where the other is silent. `positive` runs per tier — a
+    // legacy zero in a probe entry must not discard a usable listed window.
+    const confirmed = resolveRemoteCaps(model, env.remoteCaps, env.binding);
+    const listed = env.listCaps[model.id];
     return {
-      vision: triState(caps.supportsVision),
-      visionActive: isActiveModel && caps.supportsVision === true,
-      contextLength,
-      effectiveContextLength: isActiveModel ? contextLength : undefined,
+      vision: triState(confirmed.supportsVision ?? listed?.supportsVision),
+      contextLength:
+        positive(confirmed.contextLength) ?? positive(listed?.contextLength),
+      // The session axis reads the probe alone: a listed value describes how
+      // the server is configured, never what the live session can do.
+      visionActive: isActiveModel && confirmed.supportsVision === true,
+      effectiveContextLength: isActiveModel
+        ? positive(confirmed.contextLength)
+        : undefined,
     };
   }
 

--- a/src/utils/modelCaps.ts
+++ b/src/utils/modelCaps.ts
@@ -63,21 +63,20 @@ export function resolveModelCaps(
     return UNKNOWN;
   }
 
+  // Context facts describe the live session, so they apply to the active model
+  // alone — a card must never borrow another model's load state.
+  const isActiveModel = model.id === env.activeModelId;
+
   if (model.origin === ModelOrigin.REMOTE) {
     const caps = resolveRemoteCaps(model, env.remoteCaps, env.binding);
-    const vision = triState(caps.supportsVision);
     const contextLength = positive(caps.contextLength);
     return {
-      vision,
-      visionActive: vision === 'yes',
+      vision: triState(caps.supportsVision),
+      visionActive: isActiveModel && caps.supportsVision === true,
       contextLength,
-      effectiveContextLength: contextLength,
+      effectiveContextLength: isActiveModel ? contextLength : undefined,
     };
   }
-
-  // Local context facts describe the live session, so they apply to the active
-  // model alone — a card must never borrow another model's load state.
-  const isActiveModel = model.id === env.activeModelId;
 
   return {
     vision: triState(model.supportsMultimodal),

--- a/src/utils/modelCaps.ts
+++ b/src/utils/modelCaps.ts
@@ -51,8 +51,7 @@ const triState = (value: boolean | undefined): 'yes' | 'no' | 'unknown' => {
 /**
  * Resolve the effective capabilities of a model. Single source of truth — the
  * only place `model.origin` is branched on to answer a capability question, so
- * the attach affordance, the send path, the context banner and the model card
- * cannot structurally disagree.
+ * its consumers cannot structurally disagree.
  *
  * Pure and synchronous by design: callers resolve inside an `observer` render
  * body, so a capability landing from a detached probe re-renders on its own.

--- a/src/utils/remoteCaps.ts
+++ b/src/utils/remoteCaps.ts
@@ -1,0 +1,46 @@
+import {Model, ModelOrigin, RemoteModelCaps, ServerConfig} from './types';
+
+/**
+ * Resolve the effective capabilities of a remote model. Single source of truth
+ * for both the chat UI and the send path, so the attach affordance and
+ * isMultimodalEnabled can never disagree.
+ *
+ * Pure and synchronous by design: callers resolve inside an `observer` render
+ * body, so a capability landing from a detached probe re-renders on its own.
+ *
+ * Per-model caps win. The per-server fields are pre-per-model leftovers with no
+ * writer left; they are read only as a fallback, and a persisted context length
+ * of 0 is ignored because it came from a router placeholder, not a real window.
+ */
+export function resolveRemoteCaps(
+  model: Model | undefined,
+  remoteCaps: Record<string, RemoteModelCaps>,
+  servers: ServerConfig[],
+): RemoteModelCaps {
+  if (!model || model.origin !== ModelOrigin.REMOTE) {
+    return {};
+  }
+
+  const perModel = remoteCaps[model.id];
+  const server = servers.find(s => s.id === model.serverId);
+
+  const resolved: RemoteModelCaps = {};
+
+  const legacyContextLength =
+    typeof server?.contextLength === 'number' &&
+    Number.isFinite(server.contextLength) &&
+    server.contextLength > 0
+      ? server.contextLength
+      : undefined;
+  const contextLength = perModel?.contextLength ?? legacyContextLength;
+  if (contextLength !== undefined) {
+    resolved.contextLength = contextLength;
+  }
+
+  const supportsVision = perModel?.supportsVision ?? server?.supportsVision;
+  if (supportsVision !== undefined) {
+    resolved.supportsVision = supportsVision;
+  }
+
+  return resolved;
+}

--- a/src/utils/remoteCaps.ts
+++ b/src/utils/remoteCaps.ts
@@ -30,12 +30,8 @@ export function capsMatchBinding(
 }
 
 /**
- * Resolve the effective capabilities of a remote model. Single source of truth
- * for both the chat UI and the send path, so the attach affordance and
- * isMultimodalEnabled can never disagree.
- *
- * Pure and synchronous by design: callers resolve inside an `observer` render
- * body, so a capability landing from a detached probe re-renders on its own.
+ * Resolve the effective capabilities of a remote model. The remote leg of
+ * `resolveModelCaps`, which is what every caller goes through.
  *
  * Capabilities that describe a different backend than the session is bound to
  * resolve to unknown, which fails closed.

--- a/src/utils/remoteCaps.ts
+++ b/src/utils/remoteCaps.ts
@@ -1,4 +1,33 @@
-import {Model, ModelOrigin, RemoteModelCaps, ServerConfig} from './types';
+import {
+  Model,
+  ModelOrigin,
+  RemoteModelCaps,
+  RemoteSessionBinding,
+} from './types';
+
+/**
+ * Whether stored capabilities describe the backend the live session is bound
+ * to. Caps carry the url they were probed against; the session carries the url
+ * it was built with. A server edit moves neither, so this is the only
+ * comparison that answers "do these describe what we are talking to".
+ *
+ * No binding (or one for another model) means there is no live session to
+ * contradict, and an entry with no `probedUrl` predates the field — both are
+ * taken at face value.
+ */
+export function capsMatchBinding(
+  caps: RemoteModelCaps | undefined,
+  binding: RemoteSessionBinding | undefined,
+  modelId: string,
+): boolean {
+  if (!caps) {
+    return false;
+  }
+  if (!binding || binding.modelId !== modelId) {
+    return true;
+  }
+  return caps.probedUrl === undefined || caps.probedUrl === binding.url;
+}
 
 /**
  * Resolve the effective capabilities of a remote model. Single source of truth
@@ -8,39 +37,29 @@ import {Model, ModelOrigin, RemoteModelCaps, ServerConfig} from './types';
  * Pure and synchronous by design: callers resolve inside an `observer` render
  * body, so a capability landing from a detached probe re-renders on its own.
  *
- * Per-model caps win. The per-server fields are pre-per-model leftovers with no
- * writer left; they are read only as a fallback, and a persisted context length
- * of 0 is ignored because it came from a router placeholder, not a real window.
+ * Capabilities that describe a different backend than the session is bound to
+ * resolve to unknown, which fails closed.
  */
 export function resolveRemoteCaps(
   model: Model | undefined,
   remoteCaps: Record<string, RemoteModelCaps>,
-  servers: ServerConfig[],
+  binding: RemoteSessionBinding | undefined,
 ): RemoteModelCaps {
   if (!model || model.origin !== ModelOrigin.REMOTE) {
     return {};
   }
 
   const perModel = remoteCaps[model.id];
-  const server = servers.find(s => s.id === model.serverId);
+  if (!capsMatchBinding(perModel, binding, model.id)) {
+    return {};
+  }
 
   const resolved: RemoteModelCaps = {};
-
-  const legacyContextLength =
-    typeof server?.contextLength === 'number' &&
-    Number.isFinite(server.contextLength) &&
-    server.contextLength > 0
-      ? server.contextLength
-      : undefined;
-  const contextLength = perModel?.contextLength ?? legacyContextLength;
-  if (contextLength !== undefined) {
-    resolved.contextLength = contextLength;
+  if (perModel.contextLength !== undefined) {
+    resolved.contextLength = perModel.contextLength;
   }
-
-  const supportsVision = perModel?.supportsVision ?? server?.supportsVision;
-  if (supportsVision !== undefined) {
-    resolved.supportsVision = supportsVision;
+  if (perModel.supportsVision !== undefined) {
+    resolved.supportsVision = perModel.supportsVision;
   }
-
   return resolved;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -487,6 +487,10 @@ export interface ServerConfig {
  * describes an actually loaded model, never from a router placeholder.
  */
 export interface RemoteModelCaps {
+  // Never written or read. Every other field here is optional, so without a
+  // discriminant the weaker list-derived type would be silently assignable to
+  // this one and could be passed wherever a probed answer is expected.
+  tier?: 'probe';
   contextLength?: number; // /props n_ctx; only ever a finite number > 0
   supportsVision?: boolean; // /props modalities.vision
   // The backend these describe. ServerConfig.url is mutable and a live session

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -478,9 +478,20 @@ export interface ServerConfig {
     | 'OpenAI'
     | 'vLLM'
     | string;
-  // Server-reported capabilities discovered from llama.cpp GET /props.
-  // ServerStore is the sole writer; undefined = unknown/not probed.
-  contextLength?: number; // /props n_ctx
+  // Legacy per-server caps. No writer: capabilities are per model and live in
+  // ServerStore.remoteCaps. Persisted values are read as a fallback only.
+  contextLength?: number;
+  supportsVision?: boolean;
+}
+
+/**
+ * Capabilities a llama.cpp server reports for one model via GET /props.
+ * Keyed per full model id (`${serverId}/${remoteModelId}`) in ServerStore.
+ * An absent field means unknown; a field is only ever set from a response that
+ * describes an actually loaded model, never from a router placeholder.
+ */
+export interface RemoteModelCaps {
+  contextLength?: number; // /props n_ctx; only ever a finite number > 0
   supportsVision?: boolean; // /props modalities.vision
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -478,10 +478,6 @@ export interface ServerConfig {
     | 'OpenAI'
     | 'vLLM'
     | string;
-  // Legacy per-server caps. No writer: capabilities are per model and live in
-  // ServerStore.remoteCaps. Persisted values are read as a fallback only.
-  contextLength?: number;
-  supportsVision?: boolean;
 }
 
 /**
@@ -493,6 +489,25 @@ export interface ServerConfig {
 export interface RemoteModelCaps {
   contextLength?: number; // /props n_ctx; only ever a finite number > 0
   supportsVision?: boolean; // /props modalities.vision
+  // The backend these describe. ServerConfig.url is mutable and a live session
+  // does not follow it, so caps that do not carry their own url cannot be
+  // matched against the session. Absent on an entry written before this field
+  // existed: taken at face value, no migration.
+  probedUrl?: string;
+}
+
+/**
+ * The backend a live remote chat session is actually talking to. Captured when
+ * the completion engine is built and never repointed, unlike the ServerConfig
+ * it was built from — editing a server url leaves the session on the old
+ * backend until the model is re-selected. Owned by ModelStore, not persisted.
+ */
+export interface RemoteSessionBinding {
+  modelId: string; // `${serverId}/${remoteModelId}`
+  serverId: string;
+  remoteModelId: string;
+  url: string;
+  serverType?: string;
 }
 
 export enum ModelType {


### PR DESCRIPTION
## Summary

Fixes #828.

The llama.cpp `GET /props` capability probe asked the server for its properties without naming a model. A single-model `llama-server` answers with the loaded model, so this worked. A multi-model router answers the bare form with a placeholder (`model_path: "none"`, `n_ctx: 0`, no `modalities`), so every discovered capability came back empty: image attach stayed disabled for a vision-capable model, and the context banners lost their real window.

Capabilities are per model, so they are now probed and stored per model, resolved against the backend the live session is actually bound to, and answered through a single selector shared by every consumer.

`/props` can only answer for a model the server has **loaded**, though — and on a swap router `?model=` *loads* it, so browsing 47 models cannot mean starting 47 of them. The `GET /v1/models` body the app already fetches turns out to state the same facts per row, so it now feeds the declared axis as a second, non-probing source: the model card and the add sheet can say what a remote model supports **before** anything is activated, with no extra request.

## Changes

### Per-model capability discovery

- `src/api/openai.ts` — `fetchServerProps` takes an optional model id and scopes the request to `?model=<id>` (URL-encoded). It returns per-model caps and only ever sets a field from a body that describes an actually loaded model: `contextLength` only for a finite `n_ctx > 0`, `supportsVision` only when the body names a real model. A router placeholder yields nothing. The probe's default bound is the props timeout rather than the 30 s connection default.
- `src/store/ServerStore.ts` — new `remoteCaps` map keyed by the full model id (`<serverId>/<remoteModelId>`), persisted alongside `remoteReasoning`, with `fetchRemoteModelCaps` as its only writer. It merges field-wise, so a partial answer never blanks a known field, and a probe that resolves nothing writes nothing. At most two requests: the scoped probe, plus a bare retry only when the server is provably serving that one model — on a multi-model server the bare form describes whichever model is resident, so it is never issued there. `removeServer` prunes caps by server prefix.
- `src/store/ModelStore.ts` — the probe fires on remote-model activation, detached, instead of once per server after the models list is fetched. That also removes the race where a foreground refresh could clobber a good per-model result.

### Binding capabilities to the session's backend

- A capability entry records the url it was probed against. An entry that describes a different backend than the live session is bound to resolves to unknown rather than being trusted, which fails closed: editing a server's url or type drops the stale entries instead of reporting another server's answers, and the cached model list is dropped when a server is repointed.
- Unknown capabilities are re-probed when the app returns to the foreground.

### One resolver for every capability question

- `src/utils/modelCaps.ts` (new) — `resolveModelCaps(model, env)`, pure and synchronous, is now the only place `model.origin` is branched on to answer a capability question. It reports two independent axes: what the model declares (`vision`, `contextLength`), and what the session that exists right now can do (`visionActive`, `effectiveContextLength`). Session facts apply only to the active model on **both** origin legs, so a card can never borrow another model's load state. Both length fields are `> 0` or absent, so callers do not re-check.
- `src/store/ModelStore.ts` — assembles the resolver input in one private place and exposes `activeModelCaps` and `capsFor(model)`. No component builds that input or reads `remoteCaps` itself.
- `ModelStore.isMultimodalEnabled` is **deleted**. It was an async method that could repair `isMultimodalActive` from a reader, which made the flag a self-correcting cache that no writer had to keep complete. With it gone the flag has only its two transition writers and is a maintained observable; no reader performs a native re-verify. The attach affordance and the send-path image gate now read the same field of the same call, so they cannot disagree by ordering.
- `ChatScreen` drops the `useState`/`useEffect` pair that resolved local vision asynchronously; the value is read in the `observer` render body, so a capability landing from the detached probe or a model load re-enables attach with no further user action. `useChatSession`, `VideoPalScreen` and `BannerRow` read the same selector.

### The models list as a second, non-probing capability source

- `src/utils/listCaps.ts` (new) — `deriveListCaps(row, serverType)` is the only interpreter of a `/v1/models` row: pure, synchronous, and yielding at most `supportsVision` and `contextLength`. Vision from `architecture.input_modalities` containing `image` — the array always carries `text`, so a missing `image` is the server answering "no", not failing to answer — else, only if that key was absent, from `capabilities` containing `multimodal`. Context from `meta.n_ctx`, else the last `--ctx-size`/`-c` in `status.args` in either the space or `=` form, admitted only as an integer `> 0`. No other argument is read, and every failure lands on an absent field rather than a default (`--ctx-size 0` means "the model's trained window", which is unknown, not `0`). The `serverType === 'llama.cpp'` gate lives inside the function, because it has two callers with two different sources for that type. `status.args` can carry filesystem paths, so this is the only thing permitted to read it: nothing logs, persists or serialises a raw row.
- `src/api/openai.ts` — a single-model `llama-server` describes its model twice, and only the sibling `models[]` array carries `capabilities`; the fetch joins that entry onto its `data[]` row by `name ?? model`, so a direct server needs no extra request either. Servers emitting no `models[]` are unaffected.
- `src/store/ServerStore.ts` — `listCaps` is a **computed** with no writer and no persistence. `serverModels`'s lifecycle is already the right invalidation: replaced by each fetch, dropped when a server's url or type changes, dropped with the server. It therefore needs no probed-url check — a list cannot outlive the url it came from.
- Precedence is field-wise, probe first, and the list reaches the **declared** axis only. `visionActive` and `effectiveContextLength` are computed from the probe result before the list is consulted, so no derived value can gate attach, the send-path image gate, the video-pal camera start or a context banner. That holds structurally rather than by convention: there is no write path from the list into `remoteCaps`, and the two types carry a literal `tier` discriminant making them mutually non-assignable.

### Capabilities on the model card and the add sheet

- `src/screens/ModelsScreen/ModelCard/ModelCard.tsx` — remote cards gain the expand affordance they never had, so the details block is reachable for the first time. The expanded block is server-sourced only: the full model name, the discovered context window when known, and a vision indicator that states `Supported` / `Not supported` / `Unknown` explicitly — unknown is never expressed as absence. The header glyph is sourced from the same resolver as the cell, so the two cannot contradict each other. Two rows that would otherwise render device claims about someone else's hardware are suppressed for remote: the memory estimate (which reads "0 B" with no local file) and the Author cell (which holds the server name, already shown in the header chip). Local cards are unchanged in every state.
- `src/components/RemoteModelSheet/RemoteModelSheet.tsx` — against a llama.cpp server each row carries a **three-state** vision slot: the eye glyph, the text-chat glyph, or a muted em-dash for "this build does not say", with an accessibility label on all three. Without the third state "no vision" and "cannot tell" would collide, and a screen reader would hear nothing for either. Any other server type renders no slot at all. The slot reads the persisted type of the selected server, not the type the sheet detected, since pressing a known-server chip never sets that state.
- Card roots fall back to the model id when there is no filename, and the new cells and rows carry per-model testIDs, so cards and rows are individually addressable.
- Three new English strings; other locales are owned by Weblate.

## Verification

- Lint (0 errors), typecheck, and the full jest suite green: **265 suites, 4096 tests**, coverage 76.2% overall; the capability resolvers at 100% (`modelCaps`, `remoteCaps`) and 95% (`listCaps`).
- New unit coverage: scoped/encoded request URL, placeholder rejection, `n_ctx` zero/negative/non-numeric, vision decided only from a model-describing body, timeout fallback; store-side field-wise merge, sibling models not inheriting each other's caps, the single-model gate matrix, prefix prune, stale-binding invalidation; the resolver's tri-state, precedence and active-model-only rules; the list parser against verbatim captured router and direct-server bodies, including both argument forms, the short flag, last-occurrence-wins, and every documented parse failure; the join and its degenerate one-row case; card and add-sheet scenarios for pre-activation state, the three slot states being mutually distinct, the non-llama.cpp no-op, and cold-start fill-in with no user action.
- Mutation-checked: replacing the shared test store's capability resolution with a fixed answer fails 22 tests across the chat, banner and card suites; removing the type discriminant fails typecheck; reverting the header-glyph source or ungating the vision label each red their own cases. The suites are gates, not decoration.
- Live verification against a multi-model llama.cpp router (47 models) and a direct single-model `llama-server`, on **both** platforms: five models are marked as vision-capable in the list and on the cards before anything is activated, an expanded never-activated card states its context window and vision support, activating a vision model enables attach and its text-only sibling on the same server disables it, and a server of another type produces byte-identical screens to before.
- Visual evidence for the chat surface, the model card, and the pre-activation list-sourced surfaces is posted as PR comments.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
