### PR TITLE
fix: make markdown link color theme-aware (#753)

### DIFF
--- a/src/components/MarkdownView/__tests__/MarkdownView.test.tsx
+++ b/src/components/MarkdownView/__tests__/MarkdownView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ScrollView} from 'react-native';
+import {ScrollView, StyleSheet} from 'react-native';
 
 // Use the project's custom render which mounts MarkdownProvider — required
 // because MarkdownView now relies on the ambient TRenderEngineProvider
@@ -110,6 +110,33 @@ describe('MarkdownView Component', () => {
     );
 
     expect(getByText(/console\.log/)).toBeTruthy();
+  });
+
+  describe('Link Rendering', () => {
+    // Light theme secondary color (see src/theme/tokens/colors.ts).
+    const LINK_COLOR = '#1E4DF6';
+
+    it('renders link text from a markdown link', () => {
+      const markdownText = '[Example](https://example.com)';
+      const {getByText} = render(
+        <MarkdownView markdownText={markdownText} maxMessageWidth={300} />,
+      );
+
+      expect(getByText('Example')).toBeTruthy();
+    });
+
+    it('styles links with a distinct color and underline', () => {
+      const markdownText = '[Example](https://example.com)';
+      const {getByText} = render(
+        <MarkdownView markdownText={markdownText} maxMessageWidth={300} />,
+      );
+
+      const linkNode = getByText('Example');
+      const flattened = StyleSheet.flatten(linkNode.props.style) || {};
+
+      expect(flattened.color).toBe(LINK_COLOR);
+      expect(flattened.textDecorationLine).toBe('underline');
+    });
   });
 
   describe('Table Rendering', () => {

--- a/src/components/MarkdownView/__tests__/MarkdownView.test.tsx
+++ b/src/components/MarkdownView/__tests__/MarkdownView.test.tsx
@@ -5,6 +5,8 @@ import {ScrollView, StyleSheet} from 'react-native';
 // because MarkdownView now relies on the ambient TRenderEngineProvider
 // instead of building its own engine per instance.
 import {render, fireEvent} from '../../../../jest/test-utils';
+import {themeFixtures} from '../../../../jest/fixtures/theme';
+import {useTheme} from '../../../hooks';
 
 import {MarkdownView} from '../MarkdownView';
 
@@ -113,8 +115,8 @@ describe('MarkdownView Component', () => {
   });
 
   describe('Link Rendering', () => {
-    // Light theme secondary color (see src/theme/tokens/colors.ts).
-    const LINK_COLOR = '#1E4DF6';
+    const lightLink = themeFixtures.lightTheme.colors.secondary;
+    const darkLink = themeFixtures.darkTheme.colors.secondary;
 
     it('renders link text from a markdown link', () => {
       const markdownText = '[Example](https://example.com)';
@@ -134,8 +136,26 @@ describe('MarkdownView Component', () => {
       const linkNode = getByText('Example');
       const flattened = StyleSheet.flatten(linkNode.props.style) || {};
 
-      expect(flattened.color).toBe(LINK_COLOR);
+      expect(flattened.color).toBe(lightLink);
       expect(flattened.textDecorationLine).toBe('underline');
+    });
+
+    it('uses the dark theme link color in dark mode', () => {
+      (useTheme as jest.Mock).mockReturnValue(themeFixtures.darkTheme);
+      try {
+        const {getByText} = render(
+          <MarkdownView
+            markdownText="[Example](https://example.com)"
+            maxMessageWidth={300}
+          />,
+        );
+        const flattened =
+          StyleSheet.flatten(getByText('Example').props.style) || {};
+
+        expect(flattened.color).toBe(darkLink);
+      } finally {
+        (useTheme as jest.Mock).mockReturnValue(themeFixtures.lightTheme);
+      }
     });
   });
 

--- a/src/components/MarkdownView/styles.ts
+++ b/src/components/MarkdownView/styles.ts
@@ -21,14 +21,9 @@ export const createTagsStyles = (theme: Theme) => ({
     backgroundColor: 'transparent',
     // display: 'inline-block',
   },
-  // The `body` color above takes precedence over the render engine's UA anchor
-  // styles, so without an explicit rule links inherit the body text color and
-  // render indistinguishably from surrounding prose. Bind them to the theme's
-  // secondary color (plus an underline) so they read as links in both themes.
   a: {
     color: theme.colors.secondary,
     textDecorationLine: 'underline' as const,
-    textDecorationColor: theme.colors.secondary,
   },
   code: {
     fontFamily: 'Courier', // Change the font for code snippets

--- a/src/components/MarkdownView/styles.ts
+++ b/src/components/MarkdownView/styles.ts
@@ -21,6 +21,15 @@ export const createTagsStyles = (theme: Theme) => ({
     backgroundColor: 'transparent',
     // display: 'inline-block',
   },
+  // The `body` color above takes precedence over the render engine's UA anchor
+  // styles, so without an explicit rule links inherit the body text color and
+  // render indistinguishably from surrounding prose. Bind them to the theme's
+  // secondary color (plus an underline) so they read as links in both themes.
+  a: {
+    color: theme.colors.secondary,
+    textDecorationLine: 'underline' as const,
+    textDecorationColor: theme.colors.secondary,
+  },
   code: {
     fontFamily: 'Courier', // Change the font for code snippets
     backgroundColor: theme.colors.surface, // Custom background for code blocks


### PR DESCRIPTION
## Description

Links in model responses were indistinguishable from surrounding text — as reported in #753 ("rendered exactly the same as other text on the screen").

No user-agent tag style applies in this app (see the root cause below), so anchors get no link styling of their own and simply inherit the colour `MarkdownView` sets via `tagsStyles.body.color` (the theme's `text` token) — rendering as plain prose with no link affordance. Removing the `a` rule yields `#111111` in light and `#ffffff` in dark, the body text colour in both cases.

This binds the `<a>` tag style to the app's `secondary` theme token and adds an underline:

- Light: `#1E4DF6`
- Dark: `#95ABE6`

`marked` already autolinks bare URLs, `www.` URLs, and emails into `<a>` tags, so this covers every link form — not just explicit `[text](url)` markdown.

Fixes #753

### Correction to an earlier version of this description

This description has stated the mechanism wrongly **twice**, so both are recorded here rather than quietly edited out:

1. *"The renderer applies a hardcoded UA anchor colour of `#245dc1` and removing the `a` rule falls back to it."* Wrong — `UA_ANCHOR_COL` exists in `transient-render-engine` but never applies here, so it caused no part of the user-visible bug.
2. *"`body.color` takes precedence over the render engine's UA anchor styles."* Also wrong, and this is the wording still in commit `871dccb`. Measured, varying each axis independently (flattened style on the `<a>` node):

```
UA=off  body.color=on    {"color":"#111111"}                                    <- what users saw
UA=off  body.color=off   {}
UA=on   body.color=on    {"fontSize":14,"color":"#245dc1","textDecorationLine":"underline"}
UA=on   body.color=off   {"fontSize":14,"color":"#245dc1","textDecorationLine":"underline"}
```

With UA styles on, `#245dc1` wins *over* `body.color` — the reverse of the claim. There was never a precedence contest: no UA style was applying at all. Each of those two claims was written as a *correction* to the one before it, without being executed; correcting is not verifying.

Per @a-ghorbani's review, the underlying cause is broader than this PR: RNRH passes `enableUserAgentStyles: true` via `TRenderEngineProvider.defaultProps`, which React 19 ignores on function components, so **no** UA tag styles apply anywhere in the app — bold, italic, headings and lists all render as plain text too. This change is still wanted (the UA anchor colour isn't theme-aware), but it addresses links specifically rather than that root cause, which is being tracked separately.

## Platform Affected

- [x] iOS
- [x] Android

## Test plan

- [x] `Link Rendering` tests in `MarkdownView.test.tsx`: link text renders, links carry the theme secondary colour + underline, and a dark-mode case asserts the dark token.
- [x] Tests assert the theme token rather than a hex literal, so a palette retune doesn't fail on a bare colour.
- [x] **Mutation-checked** — removing the `a` rule turns both styling tests red (`#111111` light, `#ffffff` dark), confirming they guard the fix.
- [x] Verified `marked` autolinks all four forms (`https://…`, `www.…`, `a@b.com`, `[t](url)`) into `<a>` tags.
- [x] Full `MarkdownView` suite 21/21; full project suite 262 suites / 3952 tests. `tsc --noEmit` and eslint clean.
- [x] Rebased onto current `main`.
- [x] Dropped `textDecorationColor` (iOS-only, duplicated `color`) per review.
- [ ] Manual verification on a physical device — the reviewer captured before/after on an iOS simulator in both themes.

## Checklist

- [x] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [x] Unit tests pass locally.