### PR TITLE
fix: stop local models disappearing when the app container path changes

### DIFF
--- a/ios/PocketPal/AppIntents/PalDataProvider.swift
+++ b/ios/PocketPal/AppIntents/PalDataProvider.swift
@@ -197,6 +197,27 @@ class PalDataProvider {
                 print("[PalDataProvider] Error: Full path is undefined for local model")
                 return nil
             }
+            if fileManager.fileExists(atPath: fullPath) {
+                return fullPath
+            }
+            // The stored path is absolute and captured at import time; the app
+            // container UUID can change (OS upgrade, backup/restore), leaving it
+            // stale while the file still exists under the current container.
+            // Imported models are copied into Documents/models/local, so
+            // re-anchor that stable suffix onto the current documents path.
+            // Mirrors resolveLocalModelPath() in src/store/ModelStore.ts.
+            // Use upperBound and re-add the known prefix so the appended
+            // component never begins with "/".
+            if let markerRange = fullPath.range(of: "/models/local/") {
+                let relativePath = "models/local/" + String(fullPath[markerRange.upperBound...])
+                let recoveredPath = documentsPath
+                    .appendingPathComponent(relativePath)
+                    .path
+                if recoveredPath != fullPath, fileManager.fileExists(atPath: recoveredPath) {
+                    print("[PalDataProvider] Recovered local model path: \(recoveredPath)")
+                    return recoveredPath
+                }
+            }
             return fullPath
         }
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -545,7 +545,7 @@ class ModelStore {
     const presets = await this.resolvePresets();
 
     if (storedVersion < MODEL_LIST_VERSION) {
-      this.mergeModelLists(presets);
+      await this.mergeModelLists(presets);
       // Only finalize the one-time migration once presets actually resolved.
       // An empty result signals a transient resolve failure (e.g. the RAM read
       // rejected); leave the version unbumped so the migration retries next
@@ -818,7 +818,9 @@ class ModelStore {
 
     this.reconcilePresets(presets);
 
-    this.initializeDownloadStatus();
+    // Returned (not awaited) so callers inside runInAction can stay sync while
+    // initializeStore can still await settlement before pruning local models.
+    return this.initializeDownloadStatus();
   };
 
   setupAppStateListener = () => {
@@ -970,7 +972,7 @@ class ModelStore {
       if (!model.fullPath) {
         throw new Error('Full path is undefined for local model');
       }
-      return model.fullPath;
+      return this.resolveLocalModelPath(model);
     }
 
     if (!model.filename) {
@@ -1048,6 +1050,51 @@ class ModelStore {
     return `${RNFS.DocumentDirectoryPath}/${model.filename}`;
   };
 
+  /**
+   * Re-anchors a LOCAL model's stored absolute path onto the current app
+   * container.
+   *
+   * `fullPath` is persisted verbatim when the file is imported. On iOS the app
+   * container UUID can change (OS upgrade, backup/restore, reinstall), which
+   * invalidates every stored absolute path even though the file is still on
+   * disk under the new container. Imported models are copied into
+   * `<DocumentDirectoryPath>/models/local`, so the segment from `models/local`
+   * onward is stable and can be re-joined to the *current* documents path.
+   *
+   * Returns the recovered path (and persists it) when the original is missing
+   * but the re-anchored one exists; otherwise returns the stored path unchanged
+   * so existing not-found handling still applies.
+   */
+  resolveLocalModelPath = async (model: Model): Promise<string> => {
+    const storedPath = model.fullPath!;
+
+    if (await RNFS.exists(storedPath)) {
+      return storedPath;
+    }
+
+    const marker = '/models/local/';
+    const markerIndex = storedPath.indexOf(marker);
+    if (markerIndex === -1) {
+      return storedPath;
+    }
+
+    const recoveredPath = `${RNFS.DocumentDirectoryPath}${storedPath.slice(
+      markerIndex,
+    )}`;
+    if (recoveredPath === storedPath || !(await RNFS.exists(recoveredPath))) {
+      return storedPath;
+    }
+
+    console.log(
+      '[ModelStore] Recovered local model path after container change:',
+      {modelId: model.id, from: storedPath, to: recoveredPath},
+    );
+    runInAction(() => {
+      model.fullPath = recoveredPath;
+    });
+    return recoveredPath;
+  };
+
   async checkFileExists(model: Model) {
     const filePath = await this.getModelFullPath(model);
     const exists = await RNFS.exists(filePath);
@@ -1071,9 +1118,25 @@ class ModelStore {
   }
 
   refreshDownloadStatuses = async () => {
-    this.models.forEach(model => {
-      this.checkFileExists(model);
-    });
+    // Await every check: callers (notably initializeStore, which then runs
+    // removeInvalidLocalModels) depend on isDownloaded being settled. A bare
+    // forEach resolved immediately and left the checks in flight.
+    //
+    // Each check is isolated: a single failure (e.g. an RNFS error, or a local
+    // model with no fullPath) must not abort the others, and must leave
+    // isDownloaded untouched rather than defaulting it to false — an
+    // indeterminate result is not evidence the file is gone.
+    await Promise.all(
+      this.models.map(model =>
+        this.checkFileExists(model).catch(error => {
+          console.warn(
+            '[ModelStore] Could not determine file status for model:',
+            model.id,
+            error,
+          );
+        }),
+      ),
+    );
   };
 
   initializeDownloadStatus = async () => {
@@ -1082,14 +1145,26 @@ class ModelStore {
 
   removeInvalidLocalModels = () => {
     runInAction(() => {
-      this.models = this.models.filter(
-        model =>
-          // Keep all non-local models (preset and HF)
-          !(model.isLocal || model.origin === ModelOrigin.LOCAL) ||
-          // This condition ensures that we keep models that are downloaded.
-          // For local models, isDownloaded==true means the file exists, otherwise it's invalid.
-          model.isDownloaded,
-      );
+      this.models = this.models.filter(model => {
+        // Keep all non-local models (preset and HF)
+        if (!(model.isLocal || model.origin === ModelOrigin.LOCAL)) {
+          return true;
+        }
+        // For local models, isDownloaded==true means the file exists, otherwise
+        // it's invalid. Callers must let refreshDownloadStatuses settle first —
+        // it re-anchors stale container paths (resolveLocalModelPath) so a
+        // recoverable model is not treated as missing here.
+        if (model.isDownloaded) {
+          return true;
+        }
+        // Dropping a local model is unrecoverable (there is no download URL to
+        // re-fetch from), so make it visible rather than silent.
+        console.warn(
+          '[ModelStore] Removing local model whose file is no longer present:',
+          {modelId: model.id, name: model.name, fullPath: model.fullPath},
+        );
+        return false;
+      });
     });
   };
 

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -1079,7 +1079,7 @@ class ModelStore {
    * existing not-found handling still applies.
    *
    * IMPORTANT: this re-anchoring is duplicated in native Swift for iOS
-   * Shortcuts — see the LOCAL branch of resolveModelPath() in
+   * Shortcuts — see the LOCAL branch of parseModelPath() in
    * ios/PocketPal/AppIntents/PalDataProvider.swift. Keep the two in sync; the
    * shared '/models/local/' marker must match on both sides.
    */
@@ -1108,10 +1108,6 @@ class ModelStore {
       return storedPath;
     }
 
-    // Imported models are copied under <Documents>/models/local, so the segment
-    // from that marker onward is stable across container-UUID churn (iOS OS
-    // upgrade, backup/restore, reinstall) and can be re-joined to the current
-    // documents path.
     const marker = '/models/local/';
     const markerIndex = storedPath.indexOf(marker);
     if (markerIndex === -1) {

--- a/src/store/ModelStore.ts
+++ b/src/store/ModelStore.ts
@@ -197,6 +197,13 @@ class ModelStore {
   // Last requested model ID - enables "last one wins" during rapid switching
   private pendingModelId: string | null = null;
 
+  // Recovered local-model paths awaiting persistence. resolveLocalModelPath
+  // collects (model -> re-anchored path) here instead of writing each one in
+  // its own runInAction; a container change invalidates every local path at
+  // once, so the batch flush turns N full store serializations into one.
+  // Not in the persist list, so it is never serialized itself.
+  private pendingLocalPathRecoveries: Map<Model, string> = new Map();
+
   // When true, the e2e benchmark runner owns the native context lifecycle.
   // Other callers (ChatView auto-load, selectModel, initContext) must defer
   // to keep the matrix's per-cell devices/n_gpu_layers from being shadowed
@@ -546,6 +553,11 @@ class ModelStore {
 
     if (storedVersion < MODEL_LIST_VERSION) {
       await this.mergeModelLists(presets);
+      // mergeModelLists awaits the download-status checks (which re-anchor stale
+      // container paths), so pruning here — as the non-migration branch does —
+      // is now safe: a recoverable local model has already been settled and will
+      // not be dropped as missing.
+      this.removeInvalidLocalModels();
       // Only finalize the one-time migration once presets actually resolved.
       // An empty result signals a transient resolve failure (e.g. the RAM read
       // rejected); leave the version unbumped so the migration retries next
@@ -1061,17 +1073,45 @@ class ModelStore {
    * `<DocumentDirectoryPath>/models/local`, so the segment from `models/local`
    * onward is stable and can be re-joined to the *current* documents path.
    *
-   * Returns the recovered path (and persists it) when the original is missing
-   * but the re-anchored one exists; otherwise returns the stored path unchanged
-   * so existing not-found handling still applies.
+   * Returns the recovered path (persistence is batched via
+   * flushPendingLocalPathRecoveries) when the original is missing but the
+   * re-anchored one exists; otherwise returns the stored path unchanged so
+   * existing not-found handling still applies.
+   *
+   * IMPORTANT: this re-anchoring is duplicated in native Swift for iOS
+   * Shortcuts — see the LOCAL branch of resolveModelPath() in
+   * ios/PocketPal/AppIntents/PalDataProvider.swift. Keep the two in sync; the
+   * shared '/models/local/' marker must match on both sides.
    */
   resolveLocalModelPath = async (model: Model): Promise<string> => {
     const storedPath = model.fullPath!;
 
-    if (await RNFS.exists(storedPath)) {
+    // A rejected exists() must not escape: getModelFullPath is treated as
+    // non-throwing by every consumer, and deleteModel awaits it *outside* its
+    // try (a throw would abort the delete before the unlink). An indeterminate
+    // check is degraded to "not present" — recovery is attempted, and if it is
+    // also indeterminate we fall through to the stored path so the existing
+    // not-found handling still applies.
+    const pathExists = async (path: string): Promise<boolean> => {
+      try {
+        return await RNFS.exists(path);
+      } catch (err) {
+        console.warn(
+          '[ModelStore] exists() check failed while resolving local path:',
+          {modelId: model.id, path, err},
+        );
+        return false;
+      }
+    };
+
+    if (await pathExists(storedPath)) {
       return storedPath;
     }
 
+    // Imported models are copied under <Documents>/models/local, so the segment
+    // from that marker onward is stable across container-UUID churn (iOS OS
+    // upgrade, backup/restore, reinstall) and can be re-joined to the current
+    // documents path.
     const marker = '/models/local/';
     const markerIndex = storedPath.indexOf(marker);
     if (markerIndex === -1) {
@@ -1081,7 +1121,7 @@ class ModelStore {
     const recoveredPath = `${RNFS.DocumentDirectoryPath}${storedPath.slice(
       markerIndex,
     )}`;
-    if (recoveredPath === storedPath || !(await RNFS.exists(recoveredPath))) {
+    if (recoveredPath === storedPath || !(await pathExists(recoveredPath))) {
       return storedPath;
     }
 
@@ -1089,10 +1129,32 @@ class ModelStore {
       '[ModelStore] Recovered local model path after container change:',
       {modelId: model.id, from: storedPath, to: recoveredPath},
     );
-    runInAction(() => {
-      model.fullPath = recoveredPath;
-    });
+    // Defer the write: flushPendingLocalPathRecoveries applies every recovery
+    // from a refresh pass in a single runInAction. Callers use the returned
+    // path immediately, so deferring persistence changes nothing they observe.
+    this.pendingLocalPathRecoveries.set(model, recoveredPath);
     return recoveredPath;
+  };
+
+  /**
+   * Applies every path recovered since the last flush in one runInAction, so a
+   * container change that invalidates N local paths persists once rather than N
+   * times. Called after refreshDownloadStatuses settles; entries for models no
+   * longer in the store are dropped.
+   */
+  private flushPendingLocalPathRecoveries = () => {
+    if (this.pendingLocalPathRecoveries.size === 0) {
+      return;
+    }
+    const recoveries = Array.from(this.pendingLocalPathRecoveries.entries());
+    this.pendingLocalPathRecoveries.clear();
+    runInAction(() => {
+      for (const [model, recoveredPath] of recoveries) {
+        if (this.models.includes(model)) {
+          model.fullPath = recoveredPath;
+        }
+      }
+    });
   };
 
   async checkFileExists(model: Model) {
@@ -1119,8 +1181,8 @@ class ModelStore {
 
   refreshDownloadStatuses = async () => {
     // Await every check: callers (notably initializeStore, which then runs
-    // removeInvalidLocalModels) depend on isDownloaded being settled. A bare
-    // forEach resolved immediately and left the checks in flight.
+    // removeInvalidLocalModels) depend on isDownloaded being settled before they
+    // prune.
     //
     // Each check is isolated: a single failure (e.g. an RNFS error, or a local
     // model with no fullPath) must not abort the others, and must leave
@@ -1137,6 +1199,8 @@ class ModelStore {
         }),
       ),
     );
+    // Persist every path re-anchored during the pass in a single write.
+    this.flushPendingLocalPathRecoveries();
   };
 
   initializeDownloadStatus = async () => {

--- a/src/store/__tests__/ModelStore.localModelPath.test.ts
+++ b/src/store/__tests__/ModelStore.localModelPath.test.ts
@@ -1,0 +1,240 @@
+jest.unmock('../../store');
+import {runInAction} from 'mobx';
+
+import {Model, ModelOrigin} from '../../utils/types';
+import {createModel} from '../../../jest/fixtures/models';
+import * as RNFS from '@dr.pogodin/react-native-fs';
+
+import {modelStore} from '..';
+
+// Mock the download manager: checkFileExists consults isDownloading before
+// marking a model as present.
+jest.mock('../../services/downloads', () => {
+  class MockDownloadCancelledError extends Error {
+    modelId: string;
+    constructor(modelId: string) {
+      super(`Download cancelled for ${modelId}`);
+      this.name = 'DownloadCancelledError';
+      this.modelId = modelId;
+    }
+  }
+  return {
+    DownloadCancelledError: MockDownloadCancelledError,
+    downloadManager: {
+      isDownloading: jest.fn().mockReturnValue(false),
+      startDownload: jest.fn(),
+      cancelDownload: jest.fn(),
+      setCallbacks: jest.fn(),
+      syncWithActiveDownloads: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+// Keep the device-rules network boundary and signal read deterministic, matching
+// the main ModelStore suite.
+jest.mock('../../services/deviceRules/rules', () => ({
+  fetchRules: jest.fn().mockResolvedValue(null),
+}));
+jest.mock('../../services/deviceRules/signals', () => ({
+  readDeviceSignals: jest
+    .fn()
+    .mockResolvedValue({ramBytes: 8 * 1e9, socModel: 'SM8850'}),
+}));
+
+const DOCS = '/path/to/documents';
+
+const createLocalModel = (fullPath: string): Model =>
+  createModel({
+    id: 'local-1',
+    name: 'my-local-model.gguf',
+    filename: 'my-local-model.gguf',
+    origin: ModelOrigin.LOCAL,
+    isLocal: true,
+    isDownloaded: true,
+    downloadUrl: '',
+    fullPath,
+  }) as Model;
+
+describe('ModelStore local model path handling (#684)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (RNFS as any).__resetMockState?.();
+    modelStore.models = [];
+  });
+
+  describe('resolveLocalModelPath', () => {
+    it('returns the stored path unchanged when the file is present', async () => {
+      const storedPath = `${DOCS}/models/local/my-local-model.gguf`;
+      const model = createLocalModel(storedPath);
+      (RNFS.exists as jest.Mock).mockResolvedValue(true);
+
+      const resolved = await modelStore.resolveLocalModelPath(model);
+
+      expect(resolved).toBe(storedPath);
+      expect(model.fullPath).toBe(storedPath);
+    });
+
+    it('re-anchors a stale iOS container path onto the current documents path', async () => {
+      // Path captured under a previous app container UUID.
+      const stalePath =
+        '/var/mobile/Containers/Data/Application/OLD-UUID/Documents/models/local/my-local-model.gguf';
+      const recoveredPath = `${DOCS}/models/local/my-local-model.gguf`;
+      const model = createLocalModel(stalePath);
+
+      (RNFS.exists as jest.Mock).mockImplementation((path: string) =>
+        Promise.resolve(path === recoveredPath),
+      );
+
+      const resolved = await modelStore.resolveLocalModelPath(model);
+
+      expect(resolved).toBe(recoveredPath);
+      // The recovered path is persisted so later launches skip the recovery.
+      expect(model.fullPath).toBe(recoveredPath);
+    });
+
+    it('returns the stored path when the file is absent at both locations', async () => {
+      const stalePath =
+        '/var/mobile/Containers/Data/Application/OLD-UUID/Documents/models/local/gone.gguf';
+      const model = createLocalModel(stalePath);
+      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+
+      const resolved = await modelStore.resolveLocalModelPath(model);
+
+      expect(resolved).toBe(stalePath);
+      expect(model.fullPath).toBe(stalePath);
+    });
+
+    it('leaves paths outside the managed local directory untouched', async () => {
+      // Imported models live under models/local; anything else has no stable
+      // suffix to re-anchor, so it must not be rewritten.
+      const outsidePath = '/some/other/place/my-local-model.gguf';
+      const model = createLocalModel(outsidePath);
+      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+
+      const resolved = await modelStore.resolveLocalModelPath(model);
+
+      expect(resolved).toBe(outsidePath);
+      expect(model.fullPath).toBe(outsidePath);
+    });
+  });
+
+  describe('refreshDownloadStatuses', () => {
+    it('awaits every check so isDownloaded is settled when it resolves', async () => {
+      const model = createLocalModel(`${DOCS}/models/local/a.gguf`);
+      runInAction(() => {
+        modelStore.models = [{...model, isDownloaded: false} as Model];
+      });
+      (RNFS.exists as jest.Mock).mockResolvedValue(true);
+
+      await modelStore.refreshDownloadStatuses();
+
+      // Would still be false if the per-model checks were left in flight.
+      expect(modelStore.models[0].isDownloaded).toBe(true);
+    });
+
+    it('mergeModelLists returns a promise that settles the status checks', async () => {
+      // initializeStore awaits mergeModelLists before finalizing the migration,
+      // so the status work must be reachable through its return value rather
+      // than left as a floating promise.
+      runInAction(() => {
+        modelStore.models = [
+          {
+            ...createLocalModel(`${DOCS}/models/local/merged.gguf`),
+            isDownloaded: false,
+          } as Model,
+        ];
+      });
+      (RNFS.exists as jest.Mock).mockResolvedValue(true);
+
+      await modelStore.mergeModelLists();
+
+      expect(modelStore.models[0].isDownloaded).toBe(true);
+    });
+
+    it('isolates a failing check so other models are still evaluated', async () => {
+      const broken = createLocalModel(`${DOCS}/models/local/broken.gguf`);
+      const healthyPath = `${DOCS}/models/local/healthy.gguf`;
+      const healthy = createLocalModel(healthyPath);
+      healthy.id = 'local-2';
+
+      runInAction(() => {
+        modelStore.models = [
+          {...broken, isDownloaded: false} as Model,
+          {...healthy, isDownloaded: false} as Model,
+        ];
+      });
+
+      (RNFS.exists as jest.Mock).mockImplementation((path: string) => {
+        if (path.includes('broken')) {
+          return Promise.reject(new Error('RNFS blew up'));
+        }
+        return Promise.resolve(path === healthyPath);
+      });
+
+      await expect(
+        modelStore.refreshDownloadStatuses(),
+      ).resolves.toBeUndefined();
+
+      expect(modelStore.models[1].isDownloaded).toBe(true);
+    });
+  });
+
+  describe('removeInvalidLocalModels', () => {
+    it('keeps a local model whose stale path was recovered', async () => {
+      const stalePath =
+        '/var/mobile/Containers/Data/Application/OLD-UUID/Documents/models/local/my-local-model.gguf';
+      const recoveredPath = `${DOCS}/models/local/my-local-model.gguf`;
+
+      runInAction(() => {
+        modelStore.models = [
+          {...createLocalModel(stalePath), isDownloaded: false} as Model,
+        ];
+      });
+
+      (RNFS.exists as jest.Mock).mockImplementation((path: string) =>
+        Promise.resolve(path === recoveredPath),
+      );
+
+      // The real startup order: settle statuses (which recovers the path),
+      // then prune.
+      await modelStore.refreshDownloadStatuses();
+      modelStore.removeInvalidLocalModels();
+
+      expect(modelStore.models).toHaveLength(1);
+      expect(modelStore.models[0].fullPath).toBe(recoveredPath);
+    });
+
+    it('still removes a local model whose file is genuinely gone', async () => {
+      runInAction(() => {
+        modelStore.models = [
+          {
+            ...createLocalModel(`${DOCS}/models/local/gone.gguf`),
+            isDownloaded: false,
+          } as Model,
+        ];
+      });
+      (RNFS.exists as jest.Mock).mockResolvedValue(false);
+
+      await modelStore.refreshDownloadStatuses();
+      modelStore.removeInvalidLocalModels();
+
+      expect(modelStore.models).toHaveLength(0);
+    });
+
+    it('never removes non-local models regardless of download state', () => {
+      const hfModel = createModel({
+        id: 'hf-1',
+        origin: ModelOrigin.HF,
+        isLocal: false,
+        isDownloaded: false,
+      }) as Model;
+      runInAction(() => {
+        modelStore.models = [hfModel];
+      });
+
+      modelStore.removeInvalidLocalModels();
+
+      expect(modelStore.models).toHaveLength(1);
+    });
+  });
+});

--- a/src/store/__tests__/ModelStore.localModelPath.test.ts
+++ b/src/store/__tests__/ModelStore.localModelPath.test.ts
@@ -88,8 +88,10 @@ describe('ModelStore local model path handling (#684)', () => {
       const resolved = await modelStore.resolveLocalModelPath(model);
 
       expect(resolved).toBe(recoveredPath);
-      // The recovered path is persisted so later launches skip the recovery.
-      expect(model.fullPath).toBe(recoveredPath);
+      // Persistence is batched and flushed by refreshDownloadStatuses, so the
+      // resolve call itself does not rewrite the stored path (the "survives a
+      // reload" persistence is proven through refreshDownloadStatuses below).
+      expect(model.fullPath).toBe(stalePath);
     });
 
     it('returns the stored path when the file is absent at both locations', async () => {
@@ -151,7 +153,11 @@ describe('ModelStore local model path handling (#684)', () => {
       expect(modelStore.models[0].isDownloaded).toBe(true);
     });
 
-    it('isolates a failing check so other models are still evaluated', async () => {
+    it('leaves isDownloaded untouched when a check throws, and still evaluates the rest', async () => {
+      // The broken model starts present. A rejected exists() is indeterminate,
+      // not proof the file is gone, so isDownloaded must survive the failure —
+      // flipping it to false in the catch (the exact regression this guards)
+      // would make this go red.
       const broken = createLocalModel(`${DOCS}/models/local/broken.gguf`);
       const healthyPath = `${DOCS}/models/local/healthy.gguf`;
       const healthy = createLocalModel(healthyPath);
@@ -159,7 +165,7 @@ describe('ModelStore local model path handling (#684)', () => {
 
       runInAction(() => {
         modelStore.models = [
-          {...broken, isDownloaded: false} as Model,
+          {...broken, isDownloaded: true} as Model,
           {...healthy, isDownloaded: false} as Model,
         ];
       });
@@ -175,6 +181,8 @@ describe('ModelStore local model path handling (#684)', () => {
         modelStore.refreshDownloadStatuses(),
       ).resolves.toBeUndefined();
 
+      // Indeterminate check → left as seeded; the healthy check still ran.
+      expect(modelStore.models[0].isDownloaded).toBe(true);
       expect(modelStore.models[1].isDownloaded).toBe(true);
     });
   });
@@ -202,6 +210,23 @@ describe('ModelStore local model path handling (#684)', () => {
 
       expect(modelStore.models).toHaveLength(1);
       expect(modelStore.models[0].fullPath).toBe(recoveredPath);
+    });
+
+    it('keeps a local model whose file check could not be determined', async () => {
+      // An RNFS failure is indeterminate, not absence: the model stays
+      // downloaded and must not be pruned as if the file were gone. If the
+      // failing check flipped isDownloaded to false, this model would be
+      // dropped here and the length assertion would fail.
+      const model = createLocalModel(`${DOCS}/models/local/indeterminate.gguf`);
+      runInAction(() => {
+        modelStore.models = [{...model, isDownloaded: true} as Model];
+      });
+      (RNFS.exists as jest.Mock).mockRejectedValue(new Error('RNFS blew up'));
+
+      await modelStore.refreshDownloadStatuses();
+      modelStore.removeInvalidLocalModels();
+
+      expect(modelStore.models).toHaveLength(1);
     });
 
     it('still removes a local model whose file is genuinely gone', async () => {

--- a/src/store/__tests__/ModelStore.localModelPath.test.ts
+++ b/src/store/__tests__/ModelStore.localModelPath.test.ts
@@ -6,6 +6,7 @@ import {createModel} from '../../../jest/fixtures/models';
 import * as RNFS from '@dr.pogodin/react-native-fs';
 
 import {modelStore} from '..';
+import {MODEL_LIST_VERSION} from '../ModelStore';
 
 // Mock the download manager: checkFileExists consults isDownloading before
 // marking a model as present.
@@ -260,6 +261,47 @@ describe('ModelStore local model path handling (#684)', () => {
       modelStore.removeInvalidLocalModels();
 
       expect(modelStore.models).toHaveLength(1);
+    });
+  });
+
+  describe('initializeStore steady-state launch', () => {
+    afterEach(async () => {
+      // initializeStore fires several un-awaited background tasks; let them
+      // settle so they cannot bleed into the next test.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      runInAction(() => {
+        modelStore.models = [];
+        modelStore.version = undefined;
+      });
+    });
+
+    it('settles the status checks before pruning, so a recoverable local model survives a launch', async () => {
+      // The branch every launch after the one-time migration takes. The tests
+      // above drive refreshDownloadStatuses and removeInvalidLocalModels by
+      // hand, which proves they compose — not that initializeStore calls them
+      // in that order. Pruning before the checks settle is exactly the reported
+      // bug, so assert the ordering where production actually performs it.
+      const stalePath =
+        '/var/mobile/Containers/Data/Application/OLD-UUID/Documents/models/local/my-local-model.gguf';
+      const recoveredPath = `${DOCS}/models/local/my-local-model.gguf`;
+
+      runInAction(() => {
+        modelStore.version = MODEL_LIST_VERSION;
+        modelStore.availableMemoryCeiling = 1;
+        modelStore.models = [
+          {...createLocalModel(stalePath), isDownloaded: false} as Model,
+        ];
+      });
+
+      (RNFS.exists as jest.Mock).mockImplementation((path: string) =>
+        Promise.resolve(path === recoveredPath),
+      );
+
+      await modelStore.initializeStore();
+
+      const local = modelStore.models.find(m => m.id === 'local-1');
+      expect(local).toBeDefined();
+      expect(local?.fullPath).toBe(recoveredPath);
     });
   });
 });


### PR DESCRIPTION
## Description

Imported local models are the only kind with no recovery path — there is no download URL to re-fetch from — yet they were the easiest to lose.

`fullPath` is persisted as an absolute path at import time. On iOS the app container UUID can change (OS upgrade, backup/restore, reinstall), which invalidates that path even though the file is still on disk under the new container. The stale path then failed its existence check, the model was marked not-downloaded, and `removeInvalidLocalModels` deleted the entry outright.

Three separate defects contributed:

1. **`refreshDownloadStatuses` never awaited its per-model checks.** It used `forEach` over an async function, so it resolved immediately with every check still in flight. Callers that depend on `isDownloaded` being settled — notably `initializeStore`, which calls `removeInvalidLocalModels` on the very next line — raced them. Each check is now awaited *and* isolated, so one failure neither aborts the others nor records an indeterminate result as "file is gone".
2. **`mergeModelLists` dropped the promise** from `initializeDownloadStatus`, so even the `await`ed migration path did not actually wait for it. It now returns that promise (kept sync-callable, since `resetModels` invokes it inside `runInAction`).
3. **Nothing attempted to recover a stale path.** Imported models are copied into `Documents/models/local` (see `handleAddLocalModel`), so that suffix is stable and can be re-anchored onto the *current* documents path. When the file is found there, the entry is repaired and the corrected path persisted so later launches skip the recovery.

Removing a local model is now logged rather than silent.

The iOS Shortcuts resolver (`PalDataProvider.swift:parseModelPath`) duplicates this logic — as the note on `getModelFullPath` requires — and had the identical staleness bug, so it gets the matching recovery.

Refs #684

### Scope note

I could not get the reporter on #684 to confirm model type or platform, so I am **not** claiming this is definitively their bug — the report is consistent with it but unconfirmed. Defects 1 and 2 are order-of-operations bugs that stand on their own regardless. Behavior when the file is genuinely gone is unchanged: the model is still removed.

### Blast radius (recovery)

- **iOS-only in effect.** Android's `DocumentDirectoryPath` is `filesDir`, which is stable across upgrades/reinstalls, so no local path goes stale there. Defects 1–2 still affect both platforms; the re-anchoring only ever fires on iOS.
- **Pre-`8244a688` (Nov 2024) imports** predate the `models/local` destination, carry no marker, and are intentionally left unrecovered (`markerIndex === -1` returns them unchanged) — they're still pruned if their file is gone.
- The `/models/local/` marker is now a behavioural invariant shared with the Swift resolver; both sides carry a sync warning.

### Review follow-up (commit `4b913ea`)

Addresses maintainer review:

- **`resolveLocalModelPath` no longer lets an FS rejection escape.** Both `exists()` checks are wrapped and degrade to "not present", keeping `getModelFullPath` total for `deleteModel` (which awaits it outside its `try`) and its other call sites.
- **The migration branch now prunes too.** `removeInvalidLocalModels()` runs after the awaited `mergeModelLists`, making the "settle then prune" comment honest; safe because the status checks are settled first.
- **Recovered paths are batched.** One `runInAction` flushed after the refresh pass replaces one full store serialization per recovered model.
- **Guard tests strengthened.** The failing-check test now seeds `isDownloaded: true` and asserts survival, plus a pruning-survival case (12 tests total). Mutation-verified — injecting the forbidden `isDownloaded = false` into the refresh `catch` turns both red.

## Platform Affected

- [x] iOS
- [x] Android

(Defects 1–2 affect both; the container-path staleness and the Swift change are iOS-specific.)

## Test plan

New suite `src/store/__tests__/ModelStore.localModelPath.test.ts` (10 tests) covering path recovery, the await contract, and pruning.

- [x] **Mutation-checked every fix** — each reverts to a red test:
  - revert `resolveLocalModelPath` call site → "keeps a local model whose stale path was recovered" fails
  - restore the `forEach` → unhandled rejection crashes the run (exit 1); with the fix, exit 0
  - drop the `return` in `mergeModelLists` → "returns a promise that settles the status checks" fails
- [x] **Suite fails on base, passes with the fix** — on `4f1ba9b` the new file is the only failing suite (262/263 pass); with the change 263/263.
- [x] Full suite: 263 suites / 3959 tests pass. `tsc --noEmit`, eslint, prettier clean.
- [x] Verified path re-anchoring against nested subdirectories and non-`models/local` paths (left untouched).
- [x] Confirmed the pre-existing "worker process failed to exit gracefully" warning also occurs on base — not introduced here.
- [x] **Swift change compiles** — confirmed by the maintainer in review (`pod install` + iOS/Android builds pass, `PalDataProvider.o` in the main target). A Shortcuts smoke test on a real recovered path is still outstanding. I avoided `appendingPathComponent` on a leading-`/` component.
- [ ] Manual device verification of the container-change scenario (needs a real backup/restore or reinstall).

## Checklist

- [x] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.