### PR TITLE
feat: export a chat session as Markdown

### DIFF
--- a/src/components/HeaderRight/HeaderRight.tsx
+++ b/src/components/HeaderRight/HeaderRight.tsx
@@ -27,6 +27,7 @@ import {t} from '../../locales';
 import {importChatSessions} from '../../utils/importUtils';
 import {
   exportChatSession,
+  exportChatSessionAsMarkdown,
   exportAllChatSessions,
 } from '../../utils/exportUtils';
 
@@ -108,6 +109,18 @@ export const HeaderRight: React.FC = observer(() => {
         await exportChatSession(session.id);
       } catch (error) {
         console.error('Error exporting current session:', error);
+        Alert.alert('Export Error', 'Failed to export the current session.');
+      }
+    }
+    closeMenu();
+  };
+
+  const onPressExportCurrentSessionAsMarkdown = async () => {
+    if (session?.id) {
+      try {
+        await exportChatSessionAsMarkdown(session.id);
+      } catch (error) {
+        console.error('Error exporting current session as markdown:', error);
         Alert.alert('Export Error', 'Failed to export the current session.');
       }
     }
@@ -237,6 +250,12 @@ export const HeaderRight: React.FC = observer(() => {
               key="export-current"
               onPress={onPressExportCurrentSession}
               label={l10n.components.headerRight.exportCurrentSession}
+            />,
+            <Menu.Item
+              disabled={!session?.id}
+              key="export-current-markdown"
+              onPress={onPressExportCurrentSessionAsMarkdown}
+              label={l10n.components.headerRight.exportCurrentSessionMarkdown}
             />,
             <Menu.Item
               key="export-all"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -749,7 +749,7 @@
       "makeChatTemporary": "Make chat temporary",
       "export": "Export/Import",
       "exportCurrentSession": "Export current session",
-      "exportCurrentSessionMarkdown": "Export current session as Markdown",
+      "exportCurrentSessionMarkdown": "Export as Markdown",
       "exportAllSessions": "Export all sessions",
       "exportChatSession": "Export chat session",
       "importSessions": "Import sessions"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -749,6 +749,7 @@
       "makeChatTemporary": "Make chat temporary",
       "export": "Export/Import",
       "exportCurrentSession": "Export current session",
+      "exportCurrentSessionMarkdown": "Export current session as Markdown",
       "exportAllSessions": "Export all sessions",
       "exportChatSession": "Export chat session",
       "importSessions": "Import sessions"

--- a/src/utils/__tests__/exportUtils.test.ts
+++ b/src/utils/__tests__/exportUtils.test.ts
@@ -20,6 +20,7 @@ import {
   exportChatSessionAsMarkdown,
 } from '../exportUtils';
 import {userId} from '../chat';
+import {format} from 'date-fns';
 import {ensureLegacyStoragePermission} from '../androidPermission';
 
 // Mock dependencies
@@ -48,6 +49,9 @@ jest.mock('@dr.pogodin/react-native-fs', () => ({
 }));
 
 jest.mock('date-fns', () => ({
+  // Keep the fixed return value every existing test relies on for filenames,
+  // but stay input-aware so a test can assert WHICH date was formatted. A
+  // return-only mock makes "export time vs session date" unobservable.
   format: jest.fn().mockReturnValue('2024-01-01_12-00-00'),
 }));
 
@@ -627,23 +631,27 @@ describe('exportUtils', () => {
   });
 
   describe('exportChatSessionAsMarkdown', () => {
+    // `createdAt` ascends with the argument order so fixtures can be written
+    // newest-first (see the ordering note on the repository mock below) while
+    // still carrying truthful timestamps.
     const makeTextMessage = (
       id: string,
       author: string,
       text: string,
+      createdAt = 1704067200000,
     ): any => ({
       id,
       author,
       text,
       type: 'text',
       metadata: null,
-      createdAt: 1704067200000,
+      createdAt,
       toMessageObject: () => ({
         id,
         type: 'text',
         text,
         author: {id: author},
-        createdAt: 1704067200000,
+        createdAt,
         metadata: {},
       }),
     });
@@ -654,6 +662,11 @@ describe('exportUtils', () => {
     };
 
     beforeEach(() => {
+      // IMPORTANT: `getSessionById` queries `Q.sortBy('position', Q.desc)` and
+      // `addMessageToSession` assigns `highestPosition + 1`, so the real array
+      // is NEWEST FIRST — the same convention ChatSessionStore documents
+      // ("messages are in reverse order, ie 0 is the latest"). Fixtures must
+      // match that order or an ordering bug stays invisible.
       chatSessionRepository.getSessionById = jest.fn().mockResolvedValue({
         session: {
           id: 'session-1',
@@ -662,8 +675,8 @@ describe('exportUtils', () => {
           activePalId: null,
         },
         messages: [
-          makeTextMessage('m1', userId, 'What is 2+2?'),
-          makeTextMessage('m2', 'assistant-1', 'It is 4.'),
+          makeTextMessage('m2', 'assistant-1', 'It is 4.', 1704067260000),
+          makeTextMessage('m1', userId, 'What is 2+2?', 1704067200000),
         ],
         completionSettings: {settings: '{}'},
       } as any);
@@ -690,6 +703,51 @@ describe('exportUtils', () => {
       expect(content).toContain('It is 4.');
     });
 
+    it('writes the transcript in chronological order, oldest first', async () => {
+      await exportChatSessionAsMarkdown('session-1');
+
+      const {content} = writtenMarkdown();
+      // Positional, not membership: `toContain` alone passes in any order.
+      expect(content.indexOf('What is 2+2?')).toBeLessThan(
+        content.indexOf('It is 4.'),
+      );
+      expect(content.match(/^### (User|Assistant)$/gm)).toEqual([
+        '### User',
+        '### Assistant',
+      ]);
+    });
+
+    it('stamps the export time, not the session creation date', async () => {
+      // `session.date` is only ever set at creation and never refreshed, so a
+      // chat started years ago must not claim to have been exported then.
+      const sessionCreated = '2020-06-15T08:30:00Z';
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
+        {
+          session: {
+            id: 'session-old',
+            title: 'Old Chat',
+            date: sessionCreated,
+            activePalId: null,
+          },
+          messages: [makeTextMessage('m1', userId, 'Hi')],
+          completionSettings: {settings: '{}'},
+        } as any,
+      );
+
+      await exportChatSessionAsMarkdown('session-old');
+
+      // `format` is mocked to a fixed string, so the rendered output cannot
+      // reveal which date was used — assert on the argument instead.
+      const formattedDates = (format as jest.Mock).mock.calls
+        .filter(([, pattern]) => pattern === 'yyyy-MM-dd HH:mm')
+        .map(([date]) => (date as Date).toISOString());
+
+      expect(formattedDates).toHaveLength(1);
+      expect(formattedDates[0]).not.toBe(
+        new Date(sessionCreated).toISOString(),
+      );
+    });
+
     it('attributes authorship by user id rather than message order', async () => {
       // Assistant speaks first here; role must follow the author id.
       (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
@@ -700,9 +758,11 @@ describe('exportUtils', () => {
             date: '2024-01-01T00:00:00Z',
             activePalId: null,
           },
+          // Newest first: the Pal's greeting is the OLDEST message here, so it
+          // sits last in the repository's array and first in the transcript.
           messages: [
-            makeTextMessage('m1', 'assistant-1', 'Hi there!'),
-            makeTextMessage('m2', userId, 'Hello.'),
+            makeTextMessage('m2', userId, 'Hello.', 1704067260000),
+            makeTextMessage('m1', 'assistant-1', 'Hi there!', 1704067200000),
           ],
           completionSettings: {settings: '{}'},
         } as any,
@@ -711,9 +771,15 @@ describe('exportUtils', () => {
       await exportChatSessionAsMarkdown('session-2');
 
       const {content} = writtenMarkdown();
-      expect(content.indexOf('### Assistant')).toBeLessThan(
-        content.indexOf('### User'),
+      // A Pal greeting means the assistant legitimately speaks first; role must
+      // follow the author id, and the greeting must lead the transcript.
+      expect(content.indexOf('Hi there!')).toBeLessThan(
+        content.indexOf('Hello.'),
       );
+      expect(content.match(/^### (User|Assistant)$/gm)).toEqual([
+        '### Assistant',
+        '### User',
+      ]);
     });
 
     it('exports assistant_turn content, whose text column is empty by design', async () => {

--- a/src/utils/__tests__/exportUtils.test.ts
+++ b/src/utils/__tests__/exportUtils.test.ts
@@ -49,9 +49,10 @@ jest.mock('@dr.pogodin/react-native-fs', () => ({
 }));
 
 jest.mock('date-fns', () => ({
-  // Keep the fixed return value every existing test relies on for filenames,
-  // but stay input-aware so a test can assert WHICH date was formatted. A
-  // return-only mock makes "export time vs session date" unobservable.
+  // Return-only mock with the fixed value the filename tests rely on. Tests
+  // that need to assert WHICH date was formatted (export time vs session date)
+  // read `format.mock.calls` — `jest.fn()` records arguments regardless of
+  // return value.
   format: jest.fn().mockReturnValue('2024-01-01_12-00-00'),
 }));
 
@@ -866,12 +867,16 @@ describe('exportUtils', () => {
       await exportChatSessionAsMarkdown('session-5');
 
       const {content} = writtenMarkdown();
-      expect(content).toContain('_[image: file:///a.png]_');
-      expect(content).toContain('_[image: file:///b.png]_');
+      // One note per attachment, none dropped silently.
+      const noteCount = content.split('_[image]_').length - 1;
+      expect(noteCount).toBe(2);
       // The note follows the text it belongs to, inside the same section.
       expect(content.indexOf('Look at this')).toBeLessThan(
-        content.indexOf('_[image: file:///a.png]_'),
+        content.indexOf('_[image]_'),
       );
+      // The on-device temp URI must never leak into a shared transcript.
+      expect(content).not.toContain('file:///a.png');
+      expect(content).not.toContain('file:///b.png');
     });
 
     it('throws when the session does not exist', async () => {

--- a/src/utils/__tests__/exportUtils.test.ts
+++ b/src/utils/__tests__/exportUtils.test.ts
@@ -820,6 +820,60 @@ describe('exportUtils', () => {
       expect(content).toContain('Second part.');
     });
 
+    it('collapses a multi-line title so it stays a single heading', async () => {
+      // Titles are derived from the user's first message, so they can contain
+      // newlines — and a `#` starting the second line shifts the structure.
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
+        {
+          session: {
+            id: 'session-4',
+            title: 'Multi\nline # title',
+            date: '2024-01-01T00:00:00Z',
+            activePalId: null,
+          },
+          messages: [makeTextMessage('m1', userId, 'Hi')],
+          completionSettings: {settings: '{}'},
+        } as any,
+      );
+
+      await exportChatSessionAsMarkdown('session-4');
+
+      const {content} = writtenMarkdown();
+      expect(content).toContain('# Multi line # title');
+      expect(content.match(/^#[^#]/gm)).toHaveLength(1);
+    });
+
+    it('notes attached images instead of dropping them silently', async () => {
+      const withImages = makeTextMessage('m1', userId, 'Look at this');
+      // `toExportedMessage` reads the raw `metadata` column, not the in-memory
+      // object, so the URIs have to be on the JSON string.
+      withImages.metadata = JSON.stringify({
+        imageUris: ['file:///a.png', 'file:///b.png'],
+      });
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
+        {
+          session: {
+            id: 'session-5',
+            title: 'With Images',
+            date: '2024-01-01T00:00:00Z',
+            activePalId: null,
+          },
+          messages: [withImages],
+          completionSettings: {settings: '{}'},
+        } as any,
+      );
+
+      await exportChatSessionAsMarkdown('session-5');
+
+      const {content} = writtenMarkdown();
+      expect(content).toContain('_[image: file:///a.png]_');
+      expect(content).toContain('_[image: file:///b.png]_');
+      // The note follows the text it belongs to, inside the same section.
+      expect(content.indexOf('Look at this')).toBeLessThan(
+        content.indexOf('_[image: file:///a.png]_'),
+      );
+    });
+
     it('throws when the session does not exist', async () => {
       (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
         null,

--- a/src/utils/__tests__/exportUtils.test.ts
+++ b/src/utils/__tests__/exportUtils.test.ts
@@ -17,7 +17,9 @@ import {
   exportAllChatSessions,
   exportPal,
   exportAllPals,
+  exportChatSessionAsMarkdown,
 } from '../exportUtils';
+import {userId} from '../chat';
 import {ensureLegacyStoragePermission} from '../androidPermission';
 
 // Mock dependencies
@@ -621,6 +623,154 @@ describe('exportUtils', () => {
       const filename = 'test_thumbnail.jpg';
       const expected = `/mock/document/path/pal-images/test_thumbnail.jpg`;
       expect(getAbsoluteThumbnailPath(filename)).toBe(expected);
+    });
+  });
+
+  describe('exportChatSessionAsMarkdown', () => {
+    const makeTextMessage = (
+      id: string,
+      author: string,
+      text: string,
+    ): any => ({
+      id,
+      author,
+      text,
+      type: 'text',
+      metadata: null,
+      createdAt: 1704067200000,
+      toMessageObject: () => ({
+        id,
+        type: 'text',
+        text,
+        author: {id: author},
+        createdAt: 1704067200000,
+        metadata: {},
+      }),
+    });
+
+    const writtenMarkdown = () => {
+      const call = (RNFS.writeFile as jest.Mock).mock.calls.at(-1);
+      return {path: call?.[0] as string, content: call?.[1] as string};
+    };
+
+    beforeEach(() => {
+      chatSessionRepository.getSessionById = jest.fn().mockResolvedValue({
+        session: {
+          id: 'session-1',
+          title: 'My Chat',
+          date: '2024-01-01T00:00:00Z',
+          activePalId: null,
+        },
+        messages: [
+          makeTextMessage('m1', userId, 'What is 2+2?'),
+          makeTextMessage('m2', 'assistant-1', 'It is 4.'),
+        ],
+        completionSettings: {settings: '{}'},
+      } as any);
+    });
+
+    it('writes a .md file and shares it with a markdown mime type', async () => {
+      await exportChatSessionAsMarkdown('session-1');
+
+      const {path} = writtenMarkdown();
+      expect(path).toMatch(/\.md$/);
+      expect(Share.open).toHaveBeenCalledWith(
+        expect.objectContaining({type: 'text/markdown'}),
+      );
+    });
+
+    it('renders the title, headings and message text as markdown', async () => {
+      await exportChatSessionAsMarkdown('session-1');
+
+      const {content} = writtenMarkdown();
+      expect(content).toContain('# My Chat');
+      expect(content).toContain('### User');
+      expect(content).toContain('What is 2+2?');
+      expect(content).toContain('### Assistant');
+      expect(content).toContain('It is 4.');
+    });
+
+    it('attributes authorship by user id rather than message order', async () => {
+      // Assistant speaks first here; role must follow the author id.
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
+        {
+          session: {
+            id: 'session-2',
+            title: 'Greeting',
+            date: '2024-01-01T00:00:00Z',
+            activePalId: null,
+          },
+          messages: [
+            makeTextMessage('m1', 'assistant-1', 'Hi there!'),
+            makeTextMessage('m2', userId, 'Hello.'),
+          ],
+          completionSettings: {settings: '{}'},
+        } as any,
+      );
+
+      await exportChatSessionAsMarkdown('session-2');
+
+      const {content} = writtenMarkdown();
+      expect(content.indexOf('### Assistant')).toBeLessThan(
+        content.indexOf('### User'),
+      );
+    });
+
+    it('exports assistant_turn content, whose text column is empty by design', async () => {
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
+        {
+          session: {
+            id: 'session-3',
+            title: 'Turn Based',
+            date: '2024-01-01T00:00:00Z',
+            activePalId: null,
+          },
+          messages: [
+            {
+              id: 'm1',
+              author: 'assistant-1',
+              text: '',
+              type: 'assistant_turn',
+              metadata: null,
+              createdAt: 1704067200000,
+              toMessageObject: () => ({
+                id: 'm1',
+                type: 'assistant_turn',
+                author: {id: 'assistant-1'},
+                createdAt: 1704067200000,
+                metadata: {},
+                steps: [{content: 'First part.'}, {content: 'Second part.'}],
+              }),
+            },
+          ],
+          completionSettings: {settings: '{}'},
+        } as any,
+      );
+
+      await exportChatSessionAsMarkdown('session-3');
+
+      const {content} = writtenMarkdown();
+      expect(content).toContain('First part.');
+      expect(content).toContain('Second part.');
+    });
+
+    it('throws when the session does not exist', async () => {
+      (chatSessionRepository.getSessionById as jest.Mock).mockResolvedValueOnce(
+        null,
+      );
+
+      await expect(exportChatSessionAsMarkdown('nonexistent')).rejects.toThrow(
+        'Session not found',
+      );
+    });
+
+    it('still shares the JSON export as application/json', async () => {
+      // The mimeType parameter defaults, so the existing export is unchanged.
+      await exportChatSession('session-1');
+
+      expect(Share.open).toHaveBeenCalledWith(
+        expect.objectContaining({type: 'application/json'}),
+      );
     });
   });
 });

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -274,9 +274,7 @@ export const exportLegacyChatSessions = async (): Promise<void> => {
  * Export a single chat session as a human-readable Markdown file.
  *
  * The JSON export is for re-importing; this one is for reading and sharing
- * outside the app. Message content is routed through the same
- * `toExportedMessage` projection so `assistant_turn` rows (whose `text` column
- * is empty by design) carry their visible joined content.
+ * outside the app.
  */
 export const exportChatSessionAsMarkdown = async (
   sessionId: string,
@@ -290,8 +288,13 @@ export const exportChatSessionAsMarkdown = async (
     const {session, messages} = sessionData;
     const exportedAt = format(new Date(), 'yyyy-MM-dd HH:mm');
 
+    // Titles are derived from the user's own first message, so a multi-line
+    // one would otherwise break out of the `#` heading and be re-parsed as
+    // body markdown.
+    const title = session.title.replace(/\s+/g, ' ').trim();
+
     const lines: string[] = [
-      `# ${session.title}`,
+      `# ${title}`,
       '',
       `*Exported: ${exportedAt}*`,
       '',
@@ -305,7 +308,20 @@ export const exportChatSessionAsMarkdown = async (
     for (const msg of [...messages].reverse()) {
       const exported = toExportedMessage(msg);
       const role = exported.author === userId ? 'User' : 'Assistant';
-      lines.push(`### ${role}`, '', exported.text ?? '', '', '---', '');
+      lines.push(`### ${role}`, '', exported.text ?? '');
+
+      // Multimodal messages keep their attachments in `metadata.imageUris`.
+      // Note the URI rather than embedding it: these point at on-device app
+      // storage, so an `![...]()` embed would render broken everywhere the
+      // transcript is actually read.
+      const imageUris: unknown = exported.metadata?.imageUris;
+      if (Array.isArray(imageUris)) {
+        for (const uri of imageUris) {
+          lines.push('', `_[image: ${uri}]_`);
+        }
+      }
+
+      lines.push('', '---', '');
     }
 
     const timestamp = format(new Date(), 'yyyy-MM-dd_HH-mm-ss');

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -288,7 +288,7 @@ export const exportChatSessionAsMarkdown = async (
     }
 
     const {session, messages} = sessionData;
-    const exportedAt = format(new Date(session.date), 'yyyy-MM-dd HH:mm');
+    const exportedAt = format(new Date(), 'yyyy-MM-dd HH:mm');
 
     const lines: string[] = [
       `# ${session.title}`,
@@ -299,7 +299,10 @@ export const exportChatSessionAsMarkdown = async (
       '',
     ];
 
-    for (const msg of messages) {
+    // `getSessionById` returns `position DESC` (newest first) to match the
+    // inverted chat FlatList. A human-readable transcript needs chronological
+    // order, so walk a reversed copy — never mutate the repository's array.
+    for (const msg of [...messages].reverse()) {
       const exported = toExportedMessage(msg);
       const role = exported.author === userId ? 'User' : 'Assistant';
       lines.push(`### ${role}`, '', exported.text ?? '', '', '---', '');

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -8,7 +8,7 @@ import {chatSessionRepository} from '../repositories/ChatSessionRepository';
 
 import {uiStore, palStore} from '../store';
 import {ensureLegacyStoragePermission} from './androidPermission';
-import {derivedText} from './chat';
+import {derivedText, userId} from './chat';
 import {getAbsoluteThumbnailPath, isLocalThumbnailPath} from './imageUtils';
 import type {Pal} from '../types/pal';
 import type {Message} from '../database';
@@ -271,11 +271,60 @@ export const exportLegacyChatSessions = async (): Promise<void> => {
 };
 
 /**
- * Helper function to share JSON data as a file
+ * Export a single chat session as a human-readable Markdown file.
+ *
+ * The JSON export is for re-importing; this one is for reading and sharing
+ * outside the app. Message content is routed through the same
+ * `toExportedMessage` projection so `assistant_turn` rows (whose `text` column
+ * is empty by design) carry their visible joined content.
+ */
+export const exportChatSessionAsMarkdown = async (
+  sessionId: string,
+): Promise<void> => {
+  try {
+    const sessionData = await chatSessionRepository.getSessionById(sessionId);
+    if (!sessionData) {
+      throw new Error('Session not found');
+    }
+
+    const {session, messages} = sessionData;
+    const exportedAt = format(new Date(session.date), 'yyyy-MM-dd HH:mm');
+
+    const lines: string[] = [
+      `# ${session.title}`,
+      '',
+      `*Exported: ${exportedAt}*`,
+      '',
+      '---',
+      '',
+    ];
+
+    for (const msg of messages) {
+      const exported = toExportedMessage(msg);
+      const role = exported.author === userId ? 'User' : 'Assistant';
+      lines.push(`### ${role}`, '', exported.text ?? '', '', '---', '');
+    }
+
+    const timestamp = format(new Date(), 'yyyy-MM-dd_HH-mm-ss');
+    const sanitizedTitle = session.title
+      .replace(/[^a-z0-9]/gi, '_')
+      .toLowerCase();
+    const filename = `chat_${sanitizedTitle}_${timestamp}.md`;
+
+    await shareJsonData(lines.join('\n'), filename, 'text/markdown');
+  } catch (error) {
+    console.error('Error exporting chat session as markdown:', error);
+    throw error;
+  }
+};
+
+/**
+ * Helper function to share text data as a file
  */
 const shareJsonData = async (
   jsonData: string,
   filename: string,
+  mimeType: string = 'application/json',
 ): Promise<void> => {
   const currentL10n = uiStore.l10n;
   try {
@@ -289,7 +338,7 @@ const shareJsonData = async (
       await Share.open({
         url: `file://${tempFilePath}`,
         title: `Share ${filename}`,
-        type: 'application/json',
+        type: mimeType,
         failOnCancel: false,
       });
     } else if (Platform.OS === 'android' && Platform.Version === 29) {
@@ -299,7 +348,7 @@ const shareJsonData = async (
         await Share.open({
           url: `file://${tempFilePath}`,
           title: `Share ${filename}`,
-          type: 'application/json',
+          type: mimeType,
           failOnCancel: false,
         });
         return; // Exit early after sharing
@@ -316,7 +365,7 @@ const shareJsonData = async (
           await Share.open({
             url: `file://${tempFilePath}`,
             title: `Share ${filename}`,
-            type: 'application/json',
+            type: mimeType,
             failOnCancel: false,
           });
           return; // Exit early after sharing
@@ -352,7 +401,7 @@ const shareJsonData = async (
                     title: `Share ${filename}`,
                     message: 'PocketPal AI Chat Export',
                     url: `file://${savePath}`,
-                    type: 'application/json',
+                    type: mimeType,
                     failOnCancel: false,
                   };
 

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -311,14 +311,14 @@ export const exportChatSessionAsMarkdown = async (
       lines.push(`### ${role}`, '', exported.text ?? '');
 
       // Multimodal messages keep their attachments in `metadata.imageUris`.
-      // Note the URI rather than embedding it: these point at on-device app
-      // storage, so an `![...]()` embed would render broken everywhere the
-      // transcript is actually read.
+      // Note that an attachment existed, but drop the URI itself: these come
+      // from react-native-image-picker's OS temp dir (Android `getCacheDir`,
+      // iOS `NSTemporaryDirectory`), which is evictable — so the path resolves
+      // for no reader — and on iOS embeds the app-install container UUID, which
+      // has no place in a document whose purpose is being shared off-device.
       const imageUris: unknown = exported.metadata?.imageUris;
       if (Array.isArray(imageUris)) {
-        for (const uri of imageUris) {
-          lines.push('', `_[image: ${uri}]_`);
-        }
+        imageUris.forEach(() => lines.push('', '_[image]_'));
       }
 
       lines.push('', '---', '');


### PR DESCRIPTION
## Description

Implements #845.

The existing JSON export is built for re-importing — it isn't something you can read, paste into a doc, or send to someone who doesn't use the app. This adds a second export format alongside it, in the same Export/Import menu: **Export current session as Markdown**.

Output is a `.md` file with the session title, an export timestamp, and `### User` / `### Assistant` headings per message.

Two details worth calling out:

- **Message content goes through the existing `toExportedMessage` projection**, not `message.text` directly. `assistant_turn` rows have an empty `text` column by design, so reading it directly would export blank assistant messages — the projection routes through `derivedText()` for the visible joined step content, matching what the JSON export already does.
- **Author attribution keys off the author id**, not message position, so it stays correct when a Pal greeting means the assistant speaks first.

`shareJsonData` gains an optional `mimeType` defaulting to `application/json`, so every existing caller is unchanged.

Only the English string is added; other locales fall back to English until Weblate picks it up.

No new dependencies and no native code.

## Platform Affected

- [x] iOS
- [x] Android

## Test plan

Six new tests in `src/utils/__tests__/exportUtils.test.ts`.

- [x] **Mutation-checked all three behaviors** — each reverts to a red test:
  - read `msg.text` instead of the projection → the `assistant_turn` test fails (this is the bug the projection avoids)
  - un-thread `mimeType` → the markdown mime-type test fails
  - attribute role by position instead of author id → the rendering test fails
- [x] Existing export tests unchanged and passing (35/35 in that suite), including the JSON export still sharing as `application/json`.
- [x] Full suite: 262 suites / 3955 tests pass. `tsc --noEmit` clean; `npm run lint` reports 0 errors (7 pre-existing warnings).
- [x] `HeaderRight` suite passes (8/8) with the new menu item.
- [x] Kept the `en.json` diff to a single line — note that file already fails `prettier --check` on `main`, so I did not run `--write` on it (it would have reformatted an unrelated `byteSizes` block).
- [ ] Manual device verification of the share sheet on iOS/Android.

## Checklist

- [x] Necessary comments have been made.
- [ ] I have tested this change on:
  - [ ] iOS Simulator/Device
  - [ ] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.