### PR TITLE
chore(deps): upgrade llama.rn to 0.13.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Versions are pinned in [`package.json`](package.json); the highlights:
 | UI | React Native Paper `5.14.5`, React Navigation |
 | State | MobX `6` (`mobx`, `mobx-react`, `mobx-persist-store`) |
 | Persistence | WatermelonDB (chat history), AsyncStorage (settings), Keychain (secrets) |
-| LLM | `llama.rn` `0.12.4` → llama.cpp · GGUF |
+| LLM | `llama.rn` `0.13.0-rc.0` → llama.cpp · GGUF |
 | TTS | `react-native-speech` `2.3.1` + `onnxruntime-react-native` `1.23.2` · ONNX |
 | Tooling | Yarn 1 (Classic), ESLint, Prettier, Jest, Husky + Commitlint |
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.12.7):
+  - llama-rn (0.13.0-rc.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3751,7 +3751,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: 98cb15ad698ad6264e4e9e7064500f8b66f88d05
+  llama-rn: e1b526654aa8c618ac793bf2bdf71447723f0386
   onnxruntime-c: 4a1a1a81da2087869dc9b6357f182952db2df29c
   onnxruntime-react-native: 4451eff6b1aa60589186c6a8422d436fba6a9192
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
     "expr-eval": "^2.0.2",
-    "llama.rn": "0.12.7",
+    "llama.rn": "0.13.0-rc.0",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6520,10 +6520,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.12.7:
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.12.7.tgz#20f90bebb3c4f1d26594948a088fec3e32efd416"
-  integrity sha512-n18BLz9g2OuxIyZ9p2Y4ml8C1e0c8xrvNGPL3DIK9pKDp56sZtDSWLOzDMUWfsyVYSVRnbCMmQvGkIX/8YV6Og==
+llama.rn@0.13.0-rc.0:
+  version "0.13.0-rc.0"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.13.0-rc.0.tgz#5381c6cb874afe49d84ac5083e77f485a12f59f8"
+  integrity sha512-6VWkmFzcPBX+Xv2gqKm+o0kWpa4gPhNJ74EM89iL2zaxruxmu/eApTHDjGRzX3dMPHhDJWyloJ+d00xhg+9FeA==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

Upgrade the `llama.rn` native dependency from `0.12.7` to `0.13.0-rc.0` (current npm `latest`), picking up the skipped `0.12.8` and `0.12.9` patch releases. Three files: `package.json`, `yarn.lock`, `ios/Podfile.lock`.

Upstream changes carried in:
- llama.cpp sync b10054 -> b10335 (via b10156, b10256)
- parallel-decoding state files valid and resumable for multimodal models (0.12.8)
- cancelled parallel completions now settle (0.12.9)
- TTS fixes: grammar enforcement, OuteTTS prompt/sampling, codec.cpp vocoder (experimental)

The pin is exact (no `^`) — a caret would resolve `<0.14.0` and could silently pull `0.13.0` final with different prebuilt binaries than anything verified here.

## Risk and verification

The one substantive risk was whether llama.rn still times the blocking completion path with its own wall clock, since the displayed generation rate depends on it and a pre-`0.12.7` regression made speculative turns read `0.00 tokens/sec`. Confirmed intact both statically and at runtime:

- `predicted_per_second = n_decoded / t_token_generation` in `cpp/rn-slot.cpp`, fed by `lm_ggml_time_us()` in `cpp/rn-completion.cpp`; `llama_perf_context` appears only as `_reset`, never as a rate source.
- Two speculative runs on the iOS simulator reported real rates with draft engagement: 48.39 tok/s and 43.84 tok/s. Never near zero.

Other checks:
- Both error-string couplings to native throws survive verbatim (`context is full`, `failed to create MTP draft context` — all three throw sites).
- The TTS breaking changes cannot reach the app: `initVocoder` / `getFormattedAudioCompletion` / `decodeAudioTokens` / `releaseVocoder` have zero call sites in `src/` (positive-controlled — the symbols are present in the typings and `llama.rn` imports do exist in `src/`). PocketPal's TTS is `rn-speech`/Supertonic.
- `n_parallel` stays pinned to 1 and there are no app call sites for llama.rn `loadSession`/`saveSession`, so the multimodal state-file fix is inert.
- Prebuilt slices intact: both iOS xcframework slices carry `rnllama.framework`; the Android `arm64-v8a` variant set is not reduced.

## Test plan

- `yarn lint` (0 errors), `yarn typecheck` (clean), `yarn test` — 270 suites / 4301 tests pass, 76.8% line coverage
- `pod install` in sync (`Podfile.lock` matches `Pods/Manifest.lock`), iOS Release build and Android release build both succeed
- iOS `quick-smoke` pass; Android `quick-smoke` pass
- iOS `speculative.spec.ts` 3/3 — engagement (draft tokens > 0 with a real generation rate), off-safety (non-MTP model resolves to off, no draft footer), crash-safety (width-mismatched draft does not abort the process)
- Cancellation: stop mid-generation settles, partial text retained, and the following turn completes — covering the 0.12.9 cancel fix

Visual evidence in a follow-up comment.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
