### PR TITLE
Restore the Hexagon backend in Android builds and gate the payload

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,11 @@ module.exports = {
   },
   overrides: [
     {
+      // Build/CI tooling: Node CommonJS, not React Native.
+      files: ['scripts/**/*.js'],
+      env: {node: true, es2021: true},
+    },
+    {
       // Nothing inside src/ (outside src/__automation__/) may import from
       // the automation bridge. The bridge only ships in the E2E flavor and
       // any stray import could drag it into the prod bundle, defeating DCE.

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -1,0 +1,42 @@
+name: Set up ccache
+description: >-
+  Install ccache if absent, restore its cache, and export its configuration.
+  llama.rn's CMake picks ccache up on its own if the binary is on PATH.
+
+# Kept in one place because the settings below are not tuning knobs — the NDK
+# is reinstalled on every run and `yarn install` rewrites mtimes under
+# node_modules, so at ccache's defaults nearly every object misses. A copy of
+# this that silently lost `compiler_check=content` would still be green, just
+# slow, and would read as a cold cache rather than as a misconfigured one.
+inputs:
+  max-size:
+    description: Maximum ccache size
+    required: false
+    default: 2G
+
+runs:
+  using: composite
+  steps:
+    - name: Cache ccache
+      uses: actions/cache@v4
+      with:
+        path: ~/.ccache
+        key: ccache-android-${{ github.sha }}
+        restore-keys: ccache-android-
+
+    - name: Install and configure ccache
+      shell: bash
+      env:
+        CCACHE_MAX_SIZE: ${{ inputs.max-size }}
+      run: |
+        set -euo pipefail
+        if ! command -v ccache >/dev/null 2>&1; then
+          sudo apt-get update && sudo apt-get install -y ccache
+        fi
+        {
+          echo "CCACHE_DIR=$HOME/.ccache"
+          echo "CCACHE_MAXSIZE=$CCACHE_MAX_SIZE"
+          echo "CCACHE_COMPILERCHECK=content"
+          echo "CCACHE_SLOPPINESS=time_macros,include_file_mtime,include_file_ctime"
+        } >> "$GITHUB_ENV"
+        CCACHE_DIR="$HOME/.ccache" ccache --zero-stats

--- a/.github/actions/setup-hexagon-sdk/action.yml
+++ b/.github/actions/setup-hexagon-sdk/action.yml
@@ -66,12 +66,32 @@ runs:
         SDK_ROOT="$HOME/.hexagon-sdk/$HEXAGON_SDK_VERSION"
         TOOLS_ROOT="$SDK_ROOT/tools/HEXAGON_Tools/$HEXAGON_TOOLS_VERSION"
 
-        if [ ! -d "$SDK_ROOT" ]; then
+        # Consumed by the Android build: the include roots CMake adds and the
+        # library it links. Everything else in the ~3 GB tree is unused.
+        #
+        # CMake also adds ${HEXAGON_SDK_ROOT}/utils/examples as an include
+        # directory, but this repackaging does not ship it — a compiler ignores
+        # a missing include dir, so nothing is consumed from it and listing it
+        # here would only make `find` return non-zero.
+        CONSUMED_PATHS="incs ipc/fastrpc/rpcmem/inc ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so"
+
+        # Every stage announces itself. An earlier version of this step could
+        # exit non-zero with no output at all, which is the one thing a
+        # provisioning check must never do.
+        if [ -d "$SDK_ROOT" ]; then
+          echo "Hexagon SDK restored from cache at $SDK_ROOT"
+        else
           STAGE=$(mktemp -d)
-          curl -fsSL -o "$STAGE/sdk.tar.xz" \
+          echo "Downloading Hexagon SDK $HEXAGON_SDK_VERSION"
+          if ! curl -fsSL -o "$STAGE/sdk.tar.xz" \
             "https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v${HEXAGON_SDK_VERSION}/hexagon-sdk-v${HEXAGON_SDK_VERSION}-amd64-lnx.tar.xz"
+          then
+            echo "::error::Could not download the Hexagon SDK tarball."
+            exit 1
+          fi
 
           ACTUAL=$(sha256sum "$STAGE/sdk.tar.xz" | cut -d' ' -f1)
+          echo "Tarball sha256: $ACTUAL"
           if [ "$ACTUAL" != "$EXPECTED_SDK_SHA256" ]; then
             echo "::error::Hexagon SDK tarball digest mismatch. Expected $EXPECTED_SDK_SHA256, got $ACTUAL."
             echo "The release asset is mutable and this publisher is not Qualcomm, so a changed digest"
@@ -80,8 +100,12 @@ runs:
             exit 1
           fi
 
+          echo "Extracting"
           mkdir -p "$STAGE/unpacked"
-          tar --use-compress-program='xz -T0 -d' -xf "$STAGE/sdk.tar.xz" -C "$STAGE/unpacked"
+          if ! tar --use-compress-program='xz -T0 -d' -xf "$STAGE/sdk.tar.xz" -C "$STAGE/unpacked"; then
+            echo "::error::Could not extract the Hexagon SDK tarball."
+            exit 1
+          fi
           rm -f "$STAGE/sdk.tar.xz"
 
           # The archive wraps everything in a single <version> directory.
@@ -89,13 +113,15 @@ runs:
           if [ -d "$STAGE/unpacked/incs" ]; then
             mv "$STAGE/unpacked" "$SDK_ROOT"
           else
-            INNER=$(find "$STAGE/unpacked" -maxdepth 1 -mindepth 1 -type d)
+            INNER=$(find "$STAGE/unpacked" -maxdepth 1 -mindepth 1 -type d || true)
             if [ "$(printf '%s\n' "$INNER" | wc -l)" -ne 1 ] || [ ! -d "$INNER/incs" ]; then
-              echo "::error::Unexpected Hexagon SDK archive layout; could not find the SDK root."
+              echo "::error::Unexpected Hexagon SDK archive layout. Top level:"
+              ls -la "$STAGE/unpacked" || true
               exit 1
             fi
             mv "$INNER" "$SDK_ROOT"
           fi
+          echo "Installed to $SDK_ROOT"
         fi
 
         # A partially present SDK is the failure this action exists to prevent:
@@ -111,19 +137,27 @@ runs:
           fi
         done
 
-        # Runs on every job, cache hit or miss: the digest above only witnesses
-        # a fresh download, and a restored tree is never otherwise re-checked.
-        # Scoped to what the build reads and links — well under 1 MB of a ~3 GB
-        # tree, so this is cheap enough to do unconditionally.
-        # LC_ALL=C so the sort order is byte order everywhere, and the file
-        # list is fed to one sha256sum invocation so its output — hashes and
-        # relative paths — is the same stream on any host.
-        CONSUMED=$( cd "$SDK_ROOT" && LC_ALL=C find \
-            incs \
-            ipc/fastrpc/rpcmem/inc \
-            utils/examples \
-            ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so \
-            -type f 2>/dev/null | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1 )
+        MISSING=""
+        for consumed in $CONSUMED_PATHS; do
+          [ -e "$SDK_ROOT/$consumed" ] || MISSING="$MISSING $consumed"
+        done
+        if [ -n "$MISSING" ]; then
+          echo "::error::Hexagon SDK is missing paths the build consumes:$MISSING"
+          exit 1
+        fi
+
+        # Runs on every job, cache hit or miss: the tarball digest only
+        # witnesses a fresh download, and a restored tree is never otherwise
+        # re-checked. Scoped to what the build reads and links — well under
+        # 1 MB of a ~3 GB tree, so this is cheap enough to do unconditionally.
+        # LC_ALL=C so sort order is byte order on any host, and the list is fed
+        # to one sha256sum so its output stream is host-independent.
+        CONSUMED=$(
+          cd "$SDK_ROOT" || exit 1
+          # shellcheck disable=SC2086
+          LC_ALL=C find $CONSUMED_PATHS -type f | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1
+        )
+        echo "Consumed-subset sha256: $CONSUMED"
         if [ "$CONSUMED" != "$EXPECTED_CONSUMED_SHA256" ]; then
           echo "::error::The Hexagon SDK files this build consumes do not match the expected digest."
           echo "Expected $EXPECTED_CONSUMED_SHA256, got $CONSUMED."

--- a/.github/actions/setup-hexagon-sdk/action.yml
+++ b/.github/actions/setup-hexagon-sdk/action.yml
@@ -155,7 +155,11 @@ runs:
         CONSUMED=$(
           cd "$SDK_ROOT" || exit 1
           # shellcheck disable=SC2086
-          LC_ALL=C find $CONSUMED_PATHS -type f | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1
+          # `! -type d` rather than `-type f`: a symlink added under incs/
+          # would be followed by the compiler and could shadow an NDK header,
+          # so it must be inside the digest. Today the set holds no
+          # non-regular entries, and this predicate yields the same value.
+          LC_ALL=C find $CONSUMED_PATHS ! -type d | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1
         )
         echo "Consumed-subset sha256: $CONSUMED"
         if [ "$CONSUMED" != "$EXPECTED_CONSUMED_SHA256" ]; then

--- a/.github/actions/setup-hexagon-sdk/action.yml
+++ b/.github/actions/setup-hexagon-sdk/action.yml
@@ -1,0 +1,137 @@
+name: Set up the Hexagon SDK
+description: >-
+  Provision, verify and cache the Hexagon SDK, and export HEXAGON_SDK_ROOT and
+  HEXAGON_TOOLS_ROOT for later steps. The SDK is what decides whether the NPU
+  backend is compiled in at all; without it the Android build succeeds and
+  ships without it.
+
+# The versions and digests live here and nowhere else. Both publishing
+# workflows call this action, and a version bumped in only one of them would
+# have them build against different SDKs with both runs green — the payload
+# gate asserts that the backend symbols are present, not which SDK produced
+# them, so that drift is invisible to it by design.
+#
+# WHAT THIS SDK IS, AND WHY IT IS PINNED BY CONTENT.
+# `snapdragon-toolchain/hexagon-sdk` is NOT Qualcomm. It is a third-party
+# organisation redistributing the Hexagon SDK Community Edition "trimmed and
+# repackaged for GitHub Actions", published without checksums. A release tag
+# names a mutable asset, so pinning the tag pins nothing. The NDK compiles this
+# SDK's headers into librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so and links
+# its libcdsprpc.so, so its contents become shipped native code — in a job that
+# also holds the release keystore and Play credentials. Hence: verify the
+# tarball by digest, and re-verify the files the build actually reads on every
+# run, cache hit included.
+inputs:
+  sdk-version:
+    description: Hexagon SDK version
+    required: false
+    default: 6.4.0.2
+  tools-version:
+    description: Hexagon Tools version inside the SDK
+    required: false
+    default: 19.0.04
+  sdk-sha256:
+    description: >-
+      SHA-256 of the release tarball. Bumping the version means bumping this in
+      the same reviewed diff.
+    required: false
+    default: b4a57a774795cf12da19a777a5d306e970905bf9758a4c4765e5e4593428ae0b
+  consumed-sha256:
+    description: >-
+      Digest over only the SDK files the Android build reads or links. Checked
+      on every run so a restored cache is verified, not just a fresh download.
+    required: false
+    default: f56685ec2513933ab6465c44e40e8ce0263bc40751961aa2468da9cbcdfe7409
+
+runs:
+  using: composite
+  steps:
+    # The digest is part of the key, so a cache entry written under a different
+    # tarball can never be restored under this one.
+    - name: Cache Hexagon SDK
+      uses: actions/cache@v4
+      with:
+        path: ~/.hexagon-sdk
+        key: hexagon-sdk-${{ inputs.sdk-version }}-${{ inputs.sdk-sha256 }}
+
+    - name: Provision and verify the Hexagon SDK
+      shell: bash
+      env:
+        HEXAGON_SDK_VERSION: ${{ inputs.sdk-version }}
+        HEXAGON_TOOLS_VERSION: ${{ inputs.tools-version }}
+        EXPECTED_SDK_SHA256: ${{ inputs.sdk-sha256 }}
+        EXPECTED_CONSUMED_SHA256: ${{ inputs.consumed-sha256 }}
+      run: |
+        set -euo pipefail
+        SDK_ROOT="$HOME/.hexagon-sdk/$HEXAGON_SDK_VERSION"
+        TOOLS_ROOT="$SDK_ROOT/tools/HEXAGON_Tools/$HEXAGON_TOOLS_VERSION"
+
+        if [ ! -d "$SDK_ROOT" ]; then
+          STAGE=$(mktemp -d)
+          curl -fsSL -o "$STAGE/sdk.tar.xz" \
+            "https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v${HEXAGON_SDK_VERSION}/hexagon-sdk-v${HEXAGON_SDK_VERSION}-amd64-lnx.tar.xz"
+
+          ACTUAL=$(sha256sum "$STAGE/sdk.tar.xz" | cut -d' ' -f1)
+          if [ "$ACTUAL" != "$EXPECTED_SDK_SHA256" ]; then
+            echo "::error::Hexagon SDK tarball digest mismatch. Expected $EXPECTED_SDK_SHA256, got $ACTUAL."
+            echo "The release asset is mutable and this publisher is not Qualcomm, so a changed digest"
+            echo "means the artifact changed under a fixed tag. Do not update the expected value without"
+            echo "establishing what changed."
+            exit 1
+          fi
+
+          mkdir -p "$STAGE/unpacked"
+          tar --use-compress-program='xz -T0 -d' -xf "$STAGE/sdk.tar.xz" -C "$STAGE/unpacked"
+          rm -f "$STAGE/sdk.tar.xz"
+
+          # The archive wraps everything in a single <version> directory.
+          mkdir -p "$HOME/.hexagon-sdk"
+          if [ -d "$STAGE/unpacked/incs" ]; then
+            mv "$STAGE/unpacked" "$SDK_ROOT"
+          else
+            INNER=$(find "$STAGE/unpacked" -maxdepth 1 -mindepth 1 -type d)
+            if [ "$(printf '%s\n' "$INNER" | wc -l)" -ne 1 ] || [ ! -d "$INNER/incs" ]; then
+              echo "::error::Unexpected Hexagon SDK archive layout; could not find the SDK root."
+              exit 1
+            fi
+            mv "$INNER" "$SDK_ROOT"
+          fi
+        fi
+
+        # A partially present SDK is the failure this action exists to prevent:
+        # gradle and CMake both downgrade a missing Hexagon SDK to a warning.
+        for required in \
+          "$SDK_ROOT/incs" \
+          "$TOOLS_ROOT" \
+          "$SDK_ROOT/ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so"
+        do
+          if [ ! -e "$required" ]; then
+            echo "::error::Hexagon SDK is incomplete: $required is missing, so the build would omit the NPU backend."
+            exit 1
+          fi
+        done
+
+        # Runs on every job, cache hit or miss: the digest above only witnesses
+        # a fresh download, and a restored tree is never otherwise re-checked.
+        # Scoped to what the build reads and links — well under 1 MB of a ~3 GB
+        # tree, so this is cheap enough to do unconditionally.
+        # LC_ALL=C so the sort order is byte order everywhere, and the file
+        # list is fed to one sha256sum invocation so its output — hashes and
+        # relative paths — is the same stream on any host.
+        CONSUMED=$( cd "$SDK_ROOT" && LC_ALL=C find \
+            incs \
+            ipc/fastrpc/rpcmem/inc \
+            utils/examples \
+            ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so \
+            -type f 2>/dev/null | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1 )
+        if [ "$CONSUMED" != "$EXPECTED_CONSUMED_SHA256" ]; then
+          echo "::error::The Hexagon SDK files this build consumes do not match the expected digest."
+          echo "Expected $EXPECTED_CONSUMED_SHA256, got $CONSUMED."
+          echo "These headers are compiled into the shipped library. If the SDK version was bumped,"
+          echo "update both digests in this action in the same reviewed diff; otherwise the cached or"
+          echo "downloaded tree is not what we verified."
+          exit 1
+        fi
+
+        echo "HEXAGON_SDK_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+        echo "HEXAGON_TOOLS_ROOT=$TOOLS_ROOT" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,22 @@ jobs:
           fi
           echo "OK: llama.rn built exactly the declared variants."
 
+      - name: Verify the Android payload
+        run: |
+          node scripts/verify-android-payload.js \
+            --apk android/app/build/outputs/apk/prod/release/app-prod-release.apk \
+            --report payload-report.txt
+
+      # The report is evidence about the artifact, not the artifact, so it
+      # uploads whether or not the check passed. The APK below does not.
+      - name: Upload payload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: payload-report
+          path: payload-report.txt
+          if-no-files-found: ignore
+
       - name: Verify prod APK has no automation-bridge code (DCE sanity check)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-test, detect-changes]
     if: needs.detect-changes.outputs.translation_only != 'true'
+    env:
+      # Declared here rather than in android/gradle.properties: llama.rn's own
+      # android/gradle.properties sets rnllamaBuildFromSource, and a subproject's
+      # value beats the root project's, so only an environment property or -P wins.
+      ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -128,6 +133,13 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
+
+      - name: Derive the rnllama variant allowlist from the payload manifest
+        run: |
+          set -euo pipefail
+          VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
+          echo "Declared allowlist: $VARIANTS"
+          echo "ORG_GRADLE_PROJECT_rnllamaVariants=$VARIANTS" >> "$GITHUB_ENV"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -202,7 +214,26 @@ jobs:
         env:
           APP_RELEASE_STORE_PASSWORD: dummy-ci-password
           APP_RELEASE_KEY_PASSWORD: dummy-ci-password
-        run: ./gradlew assembleProdRelease
+        run: |
+          set -euo pipefail
+          if [ -z "${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-}" ]; then
+            echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is not set, so the build mode would be whatever llama.rn happens to ship."
+            exit 1
+          fi
+          ./gradlew assembleProdRelease 2>&1 | tee android-build.log
+
+      - name: Verify the variant allowlist reached the llama.rn build
+        run: |
+          set -euo pipefail
+          VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
+          if ! grep -qF "Building rnllama variants: $VARIANTS" android/android-build.log; then
+            echo "::error::llama.rn did not report building the declared variant set."
+            echo "Expected: $VARIANTS"
+            echo "In the build log:"
+            grep -F "rnllama variants" android/android-build.log || echo "  (no variant line at all — ORG_GRADLE_PROJECT_rnllamaVariants never reached the subproject)"
+            exit 1
+          fi
+          echo "OK: llama.rn built exactly the declared variants."
 
       - name: Verify prod APK has no automation-bridge code (DCE sanity check)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,25 @@ jobs:
       # android/gradle.properties sets rnllamaBuildFromSource, and a subproject's
       # value beats the root project's, so only an environment property or -P wins.
       ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
+      HEXAGON_SDK_VERSION: 6.4.0.2
+      HEXAGON_TOOLS_VERSION: 19.0.04
+      CCACHE_MAXSIZE: 2G
+      # The NDK is reinstalled on every run, so hash the compiler rather than
+      # stat it, and do not let regenerated mtimes under node_modules count as
+      # a change. Left at the defaults, nearly every object would miss.
+      CCACHE_COMPILERCHECK: content
+      CCACHE_SLOPPINESS: time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      # Must precede setup-node and setup-java: /opt/hostedtoolcache is where
+      # those install. The Hexagon SDK adds ~3.1 GB on top of a from-source build.
+      - name: Maximize build space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache
+          df -h /
 
       # Set up Node.js environment
       - name: Set up Node.js
@@ -141,12 +157,86 @@ jobs:
           echo "Declared allowlist: $VARIANTS"
           echo "ORG_GRADLE_PROJECT_rnllamaVariants=$VARIANTS" >> "$GITHUB_ENV"
 
+      # Keyed on the manifest as well as yarn.lock: the manifest decides the
+      # variant set, so changing it must invalidate the configured build tree.
+      - name: Cache llama.rn native build tree
+        uses: actions/cache@v4
+        with:
+          path: node_modules/llama.rn/android/.cxx
+          key: ${{ runner.os }}-cxx-${{ hashFiles('yarn.lock', 'scripts/android-payload-manifest.json') }}
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
+
+      - name: Cache Hexagon SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.hexagon-sdk
+          key: hexagon-sdk-${{ env.HEXAGON_SDK_VERSION }}
+
+      - name: Provision the Hexagon SDK
+        run: |
+          set -euo pipefail
+          SDK_ROOT="$HOME/.hexagon-sdk/$HEXAGON_SDK_VERSION"
+          TOOLS_ROOT="$SDK_ROOT/tools/HEXAGON_Tools/$HEXAGON_TOOLS_VERSION"
+
+          if [ ! -d "$SDK_ROOT" ]; then
+            STAGE=$(mktemp -d)
+            curl -fsSL -o "$STAGE/sdk.tar.xz" \
+              "https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v${HEXAGON_SDK_VERSION}/hexagon-sdk-v${HEXAGON_SDK_VERSION}-amd64-lnx.tar.xz"
+            mkdir -p "$STAGE/unpacked"
+            tar --use-compress-program='xz -T0 -d' -xf "$STAGE/sdk.tar.xz" -C "$STAGE/unpacked"
+            rm -f "$STAGE/sdk.tar.xz"
+
+            mkdir -p "$HOME/.hexagon-sdk"
+            if [ -d "$STAGE/unpacked/incs" ]; then
+              mv "$STAGE/unpacked" "$SDK_ROOT"
+            else
+              INNER=$(find "$STAGE/unpacked" -maxdepth 1 -mindepth 1 -type d)
+              if [ "$(printf '%s\n' "$INNER" | wc -l)" -ne 1 ] || [ ! -d "$INNER/incs" ]; then
+                echo "::error::Unexpected Hexagon SDK archive layout; could not find the SDK root."
+                exit 1
+              fi
+              mv "$INNER" "$SDK_ROOT"
+            fi
+          fi
+
+          # A partially present SDK is the failure this job exists to prevent:
+          # gradle and CMake both downgrade a missing Hexagon SDK to a warning.
+          for required in \
+            "$SDK_ROOT/incs" \
+            "$TOOLS_ROOT" \
+            "$SDK_ROOT/ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so"
+          do
+            if [ ! -e "$required" ]; then
+              echo "::error::Hexagon SDK is incomplete: $required is missing, so the build would omit the NPU backend."
+              exit 1
+            fi
+          done
+
+          echo "HEXAGON_SDK_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "HEXAGON_TOOLS_ROOT=$TOOLS_ROOT" >> "$GITHUB_ENV"
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-android-${{ github.sha }}
+          restore-keys: ccache-android-
+
+      # llama.rn's CMake picks ccache up on its own if the binary is on PATH.
+      - name: Set up ccache
+        run: |
+          set -euo pipefail
+          if ! command -v ccache >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y ccache
+          fi
+          echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
+          CCACHE_DIR="$HOME/.ccache" ccache --zero-stats
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -221,6 +311,10 @@ jobs:
             exit 1
           fi
           ./gradlew assembleProdRelease 2>&1 | tee android-build.log
+
+      - name: ccache statistics
+        if: always()
+        run: ccache --show-stats || echo "ccache unavailable (its setup step did not complete)"
 
       - name: Verify the variant allowlist reached the llama.rn build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
             grep -F "rnllama variants" android/android-build.log || echo "  (no variant line at all — ORG_GRADLE_PROJECT_rnllamaVariants never reached the subproject)"
             exit 1
           fi
-          echo "OK: llama.rn built exactly the declared variants."
+          echo "OK: llama.rn reported the declared variant list (extras, if any, are permitted and are reported by the payload check)."
 
       - name: Verify the Android payload
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,6 @@ jobs:
       # android/gradle.properties sets rnllamaBuildFromSource, and a subproject's
       # value beats the root project's, so only an environment property or -P wins.
       ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
-      HEXAGON_SDK_VERSION: 6.4.0.2
-      HEXAGON_TOOLS_VERSION: 19.0.04
-      CCACHE_MAXSIZE: 2G
-      # The NDK is reinstalled on every run, so hash the compiler rather than
-      # stat it, and do not let regenerated mtimes under node_modules count as
-      # a change. Left at the defaults, nearly every object would miss.
-      CCACHE_COMPILERCHECK: content
-      CCACHE_SLOPPINESS: time_macros,include_file_mtime,include_file_ctime
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -172,71 +164,11 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Cache Hexagon SDK
-        uses: actions/cache@v4
-        with:
-          path: ~/.hexagon-sdk
-          key: hexagon-sdk-${{ env.HEXAGON_SDK_VERSION }}
+      - name: Set up the Hexagon SDK
+        uses: ./.github/actions/setup-hexagon-sdk
 
-      - name: Provision the Hexagon SDK
-        run: |
-          set -euo pipefail
-          SDK_ROOT="$HOME/.hexagon-sdk/$HEXAGON_SDK_VERSION"
-          TOOLS_ROOT="$SDK_ROOT/tools/HEXAGON_Tools/$HEXAGON_TOOLS_VERSION"
-
-          if [ ! -d "$SDK_ROOT" ]; then
-            STAGE=$(mktemp -d)
-            curl -fsSL -o "$STAGE/sdk.tar.xz" \
-              "https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v${HEXAGON_SDK_VERSION}/hexagon-sdk-v${HEXAGON_SDK_VERSION}-amd64-lnx.tar.xz"
-            mkdir -p "$STAGE/unpacked"
-            tar --use-compress-program='xz -T0 -d' -xf "$STAGE/sdk.tar.xz" -C "$STAGE/unpacked"
-            rm -f "$STAGE/sdk.tar.xz"
-
-            mkdir -p "$HOME/.hexagon-sdk"
-            if [ -d "$STAGE/unpacked/incs" ]; then
-              mv "$STAGE/unpacked" "$SDK_ROOT"
-            else
-              INNER=$(find "$STAGE/unpacked" -maxdepth 1 -mindepth 1 -type d)
-              if [ "$(printf '%s\n' "$INNER" | wc -l)" -ne 1 ] || [ ! -d "$INNER/incs" ]; then
-                echo "::error::Unexpected Hexagon SDK archive layout; could not find the SDK root."
-                exit 1
-              fi
-              mv "$INNER" "$SDK_ROOT"
-            fi
-          fi
-
-          # A partially present SDK is the failure this job exists to prevent:
-          # gradle and CMake both downgrade a missing Hexagon SDK to a warning.
-          for required in \
-            "$SDK_ROOT/incs" \
-            "$TOOLS_ROOT" \
-            "$SDK_ROOT/ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so"
-          do
-            if [ ! -e "$required" ]; then
-              echo "::error::Hexagon SDK is incomplete: $required is missing, so the build would omit the NPU backend."
-              exit 1
-            fi
-          done
-
-          echo "HEXAGON_SDK_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
-          echo "HEXAGON_TOOLS_ROOT=$TOOLS_ROOT" >> "$GITHUB_ENV"
-
-      - name: Cache ccache
-        uses: actions/cache@v4
-        with:
-          path: ~/.ccache
-          key: ccache-android-${{ github.sha }}
-          restore-keys: ccache-android-
-
-      # llama.rn's CMake picks ccache up on its own if the binary is on PATH.
       - name: Set up ccache
-        run: |
-          set -euo pipefail
-          if ! command -v ccache >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y ccache
-          fi
-          echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
-          CCACHE_DIR="$HOME/.ccache" ccache --zero-stats
+        uses: ./.github/actions/setup-ccache
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -306,8 +238,12 @@ jobs:
           APP_RELEASE_KEY_PASSWORD: dummy-ci-password
         run: |
           set -euo pipefail
-          if [ -z "${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-}" ]; then
-            echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is not set, so the build mode would be whatever llama.rn happens to ship."
+          # Compared against "true" rather than merely checked for emptiness:
+          # the payload gate cannot tell the modes apart (upstream's prebuilt
+          # exports the same symbols), so this guard is the only thing holding
+          # the declaration.
+          if [ "${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-}" != "true" ]; then
+            echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is '${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-<unset>}', expected 'true'. Building from prebuilts is the documented escape hatch, but it must be a deliberate edit to this workflow."
             exit 1
           fi
           ./gradlew assembleProdRelease 2>&1 | tee android-build.log
@@ -316,6 +252,11 @@ jobs:
         if: always()
         run: ccache --show-stats || echo "ccache unavailable (its setup step did not complete)"
 
+      # COUPLING: the string grepped for below is upstream's, printed by
+      # node_modules/llama.rn/android/build.gradle next to its rnllamaVariants
+      # lookup. A llama.rn upgrade that rewords it fails this step. That is the
+      # intended direction — it is the only live proof the environment reaches
+      # gradle — but the fix is to update the literal, not to delete the check.
       - name: Verify the variant allowlist reached the llama.rn build
         run: |
           set -euo pipefail
@@ -324,7 +265,12 @@ jobs:
             echo "::error::llama.rn did not report building the declared variant set."
             echo "Expected: $VARIANTS"
             echo "In the build log:"
-            grep -F "rnllama variants" android/android-build.log || echo "  (no variant line at all — ORG_GRADLE_PROJECT_rnllamaVariants never reached the subproject)"
+            grep -F "rnllama variants" android/android-build.log || echo "  (no such line at all)"
+            echo ""
+            echo "Two different causes look identical here. Either ORG_GRADLE_PROJECT_rnllamaVariants"
+            echo "did not reach the llama.rn subproject, or upstream changed the wording of the line"
+            echo "this step greps for (android/build.gradle, the println next to rnllamaVariants)."
+            echo "Check the wording first — a llama.rn upgrade is the more common reason."
             exit 1
           fi
           echo "OK: llama.rn reported the declared variant list (extras, if any, are permitted and are reported by the payload check)."

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,14 @@ env:
 jobs:
   build-android:
     runs-on: ubuntu-latest
+    env:
+      # Declared here rather than in android/gradle.properties: llama.rn's own
+      # android/gradle.properties sets rnllamaBuildFromSource, and a subproject's
+      # value beats the root project's, so only an environment property or -P wins.
+      #
+      # This APK is never published and emulators have no DSP, so this job takes
+      # the variant allowlist but provisions no Hexagon SDK and runs no payload gate.
+      ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,6 +44,13 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Derive the rnllama variant allowlist from the payload manifest
+        run: |
+          set -euo pipefail
+          VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
+          echo "Declared allowlist: $VARIANTS"
+          echo "ORG_GRADLE_PROJECT_rnllamaVariants=$VARIANTS" >> "$GITHUB_ENV"
 
       - name: Create dummy google-services.json for CI
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,6 +24,11 @@ jobs:
       # This APK is never published and emulators have no DSP, so this job takes
       # the variant allowlist but provisions no Hexagon SDK and runs no payload gate.
       ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
+      # This job caches no node_modules, so llama.rn's postinstall runs every
+      # time and downloads ~100 MB of prebuilt jniLibs plus the iOS xcframework.
+      # A from-source Android build uses neither. The DSP libraries under bin/
+      # are tarball content and arrive regardless.
+      RNLLAMA_SKIP_POSTINSTALL: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,9 +20,6 @@ jobs:
       # Declared here rather than in android/gradle.properties: llama.rn's own
       # android/gradle.properties sets rnllamaBuildFromSource, and a subproject's
       # value beats the root project's, so only an environment property or -P wins.
-      #
-      # This APK is never published and emulators have no DSP, so this job takes
-      # the variant allowlist but provisions no Hexagon SDK and runs no payload gate.
       ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
       # This job caches no node_modules, so llama.rn's postinstall runs every
       # time and downloads ~100 MB of prebuilt jniLibs plus the iOS xcframework.
@@ -56,6 +53,9 @@ jobs:
           VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
           echo "Declared allowlist: $VARIANTS"
           echo "ORG_GRADLE_PROJECT_rnllamaVariants=$VARIANTS" >> "$GITHUB_ENV"
+
+      - name: Set up the Hexagon SDK
+        uses: ./.github/actions/setup-hexagon-sdk
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -123,12 +123,59 @@ jobs:
             -dname "CN=CI Build, OU=CI, O=PocketPal, L=CI, S=CI, C=US"
 
       - name: Build Android E2E APK
+        working-directory: android
         env:
           APP_RELEASE_STORE_PASSWORD: dummy-ci-password
           APP_RELEASE_KEY_PASSWORD: dummy-ci-password
         run: |
-          cd android
-          E2E_BUILD=true ./gradlew assembleE2eReleaseE2e
+          set -euo pipefail
+          if [ "${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-}" != "true" ]; then
+            echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is '${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-<unset>}', expected 'true'."
+            exit 1
+          fi
+          E2E_BUILD=true ./gradlew assembleE2eReleaseE2e 2>&1 | tee android-build.log
+
+      # COUPLING: the string grepped for below is upstream's, printed by
+      # node_modules/llama.rn/android/build.gradle next to its rnllamaVariants
+      # lookup. A llama.rn upgrade that rewords it fails this step. The fix is
+      # to update the literal, not to delete the check.
+      - name: Verify the variant allowlist reached the llama.rn build
+        run: |
+          set -euo pipefail
+          VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
+          if ! grep -qF "Building rnllama variants: $VARIANTS" android/android-build.log; then
+            echo "::error::llama.rn did not report building the declared variant set."
+            echo "Expected: $VARIANTS"
+            echo "In the build log:"
+            grep -F "rnllama variants" android/android-build.log || echo "  (no such line at all)"
+            echo ""
+            echo "Two different causes look identical here. Either ORG_GRADLE_PROJECT_rnllamaVariants"
+            echo "did not reach the llama.rn subproject, or upstream changed the wording of the line"
+            echo "this step greps for (android/build.gradle, the println next to rnllamaVariants)."
+            echo "Check the wording first — a llama.rn upgrade is the more common reason."
+            exit 1
+          fi
+          echo "OK: llama.rn reported the declared variant list (extras, if any, are permitted and are reported by the payload check)."
+
+      # This build may ADD test scaffolding — different flavor, automation
+      # bridge, debuggable, dummy signing — but it must not SUBTRACT production
+      # capability, which is what this asserts. The manifest describes only the
+      # native payload, and that does not vary by flavor, so it applies here
+      # unchanged. The mirror of this is ci.yml's DCE check, which asserts the
+      # prod artifact carries none of the test code this one is allowed to add.
+      - name: Verify the Android payload
+        run: |
+          node scripts/verify-android-payload.js \
+            --apk android/app/build/outputs/apk/e2e/releaseE2e/app-e2e-releaseE2e.apk \
+            --report payload-report.txt
+
+      - name: Upload payload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: payload-report
+          path: payload-report.txt
+          if-no-files-found: ignore
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
     permissions:
       contents: 'write' # Allows workflow to checkout repository code
       id-token: 'write' # Required for Google Cloud Workload Identity Federation authentication (OIDC token generation)
+    env:
+      # Declared here rather than in android/gradle.properties: llama.rn's own
+      # android/gradle.properties sets rnllamaBuildFromSource, and a subproject's
+      # value beats the root project's, so only an environment property or -P wins.
+      ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
 
     steps:
       # Step 1: Checkout the code
@@ -56,6 +61,15 @@ jobs:
       # Step 4: Install dependencies using Yarn
       - name: Install dependencies
         run: yarn install
+
+      # Step 4b: The manifest that the payload gate enforces also decides which
+      # rnllama variants are worth compiling — one declaration, both uses.
+      - name: Derive the rnllama variant allowlist from the payload manifest
+        run: |
+          set -euo pipefail
+          VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
+          echo "Declared allowlist: $VARIANTS"
+          echo "ORG_GRADLE_PROJECT_rnllamaVariants=$VARIANTS" >> "$GITHUB_ENV"
 
       # Step 5: Set up Ruby and Bundler
       - name: Set up Ruby
@@ -133,8 +147,26 @@ jobs:
           PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
+          set -euo pipefail
+          if [ -z "${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-}" ]; then
+            echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is not set, so the build mode would be whatever llama.rn happens to ship."
+            exit 1
+          fi
           echo "$PLAY_STORE_JSON_KEY" > play-store-key.json
-          bundle exec fastlane release_android_alpha
+          bundle exec fastlane release_android_alpha 2>&1 | tee android-build.log
+
+      - name: Verify the variant allowlist reached the llama.rn build
+        run: |
+          set -euo pipefail
+          VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
+          if ! grep -qF "Building rnllama variants: $VARIANTS" android/android-build.log; then
+            echo "::error::llama.rn did not report building the declared variant set."
+            echo "Expected: $VARIANTS"
+            echo "In the build log:"
+            grep -F "rnllama variants" android/android-build.log || echo "  (no variant line at all — ORG_GRADLE_PROJECT_rnllamaVariants never reached the subproject)"
+            exit 1
+          fi
+          echo "OK: llama.rn built exactly the declared variants."
 
       # Step 11: Create GitHub Release with APK
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,16 +135,16 @@ jobs:
           GOOGLE_WEB_CLIENT_ID=${{ vars.GOOGLE_WEB_CLIENT_ID }}
           EOL
 
-      # Step 10: Build and upload Android app to Alpha track (includes building APK and Bundle)
-      - name: Build and upload Android app
+      # Step 10a: Build the Android APK and Bundle. Building and uploading are
+      # separate steps so the payload check below sits between them in the
+      # workflow graph and the upload cannot outrun it.
+      - name: Build Android app
         working-directory: android
         env:
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           GRADLE_USER_HOME: ${{ runner.temp }}/.gradle
-          #  GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }} # This is not supported by fastlane, we need to replace it with PLAY_STORE_JSON_KEY in the future.
-          PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           set -euo pipefail
@@ -152,8 +152,7 @@ jobs:
             echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is not set, so the build mode would be whatever llama.rn happens to ship."
             exit 1
           fi
-          echo "$PLAY_STORE_JSON_KEY" > play-store-key.json
-          bundle exec fastlane release_android_alpha 2>&1 | tee android-build.log
+          bundle exec fastlane build_android_release 2>&1 | tee android-build.log
 
       - name: Verify the variant allowlist reached the llama.rn build
         run: |
@@ -167,6 +166,34 @@ jobs:
             exit 1
           fi
           echo "OK: llama.rn built exactly the declared variants."
+
+      # Step 10b: Both shipped forms are checked — the APK goes to the GitHub
+      # Release, the AAB goes to Play, and they are packaged separately.
+      - name: Verify the Android payload
+        run: |
+          node scripts/verify-android-payload.js \
+            --apk android/app/build/outputs/apk/prod/release/app-prod-release.apk \
+            --aab android/app/build/outputs/bundle/prodRelease/app-prod-release.aab \
+            --report payload-report.txt
+
+      - name: Upload payload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: payload-report
+          path: payload-report.txt
+          if-no-files-found: ignore
+
+      # Step 10c: Upload the checked bundle to the Alpha track
+      - name: Upload Android app to Alpha track
+        working-directory: android
+        env:
+          #  GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }} # This is not supported by fastlane, we need to replace it with PLAY_STORE_JSON_KEY in the future.
+          PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          echo "$PLAY_STORE_JSON_KEY" > play-store-key.json
+          bundle exec fastlane upload_android_alpha
 
       # Step 11: Create GitHub Release with APK
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,14 +39,6 @@ jobs:
       # builds no iOS target, so the postinstall download has nothing to supply.
       # The DSP libraries under bin/ are tarball content and arrive regardless.
       RNLLAMA_SKIP_POSTINSTALL: '1'
-      HEXAGON_SDK_VERSION: 6.4.0.2
-      HEXAGON_TOOLS_VERSION: 19.0.04
-      CCACHE_MAXSIZE: 2G
-      # The NDK is reinstalled on every run, so hash the compiler rather than
-      # stat it, and do not let regenerated mtimes under node_modules count as
-      # a change. Left at the defaults, nearly every object would miss.
-      CCACHE_COMPILERCHECK: content
-      CCACHE_SLOPPINESS: time_macros,include_file_mtime,include_file_ctime
 
     steps:
       # Step 1: Checkout the code
@@ -93,71 +85,11 @@ jobs:
 
       # Step 4c: The Hexagon SDK is what decides whether the NPU backend is
       # compiled in at all. Without it the build succeeds and ships without it.
-      - name: Cache Hexagon SDK
-        uses: actions/cache@v4
-        with:
-          path: ~/.hexagon-sdk
-          key: hexagon-sdk-${{ env.HEXAGON_SDK_VERSION }}
+      - name: Set up the Hexagon SDK
+        uses: ./.github/actions/setup-hexagon-sdk
 
-      - name: Provision the Hexagon SDK
-        run: |
-          set -euo pipefail
-          SDK_ROOT="$HOME/.hexagon-sdk/$HEXAGON_SDK_VERSION"
-          TOOLS_ROOT="$SDK_ROOT/tools/HEXAGON_Tools/$HEXAGON_TOOLS_VERSION"
-
-          if [ ! -d "$SDK_ROOT" ]; then
-            STAGE=$(mktemp -d)
-            curl -fsSL -o "$STAGE/sdk.tar.xz" \
-              "https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v${HEXAGON_SDK_VERSION}/hexagon-sdk-v${HEXAGON_SDK_VERSION}-amd64-lnx.tar.xz"
-            mkdir -p "$STAGE/unpacked"
-            tar --use-compress-program='xz -T0 -d' -xf "$STAGE/sdk.tar.xz" -C "$STAGE/unpacked"
-            rm -f "$STAGE/sdk.tar.xz"
-
-            mkdir -p "$HOME/.hexagon-sdk"
-            if [ -d "$STAGE/unpacked/incs" ]; then
-              mv "$STAGE/unpacked" "$SDK_ROOT"
-            else
-              INNER=$(find "$STAGE/unpacked" -maxdepth 1 -mindepth 1 -type d)
-              if [ "$(printf '%s\n' "$INNER" | wc -l)" -ne 1 ] || [ ! -d "$INNER/incs" ]; then
-                echo "::error::Unexpected Hexagon SDK archive layout; could not find the SDK root."
-                exit 1
-              fi
-              mv "$INNER" "$SDK_ROOT"
-            fi
-          fi
-
-          # A partially present SDK is the failure this job exists to prevent:
-          # gradle and CMake both downgrade a missing Hexagon SDK to a warning.
-          for required in \
-            "$SDK_ROOT/incs" \
-            "$TOOLS_ROOT" \
-            "$SDK_ROOT/ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so"
-          do
-            if [ ! -e "$required" ]; then
-              echo "::error::Hexagon SDK is incomplete: $required is missing, so the build would omit the NPU backend."
-              exit 1
-            fi
-          done
-
-          echo "HEXAGON_SDK_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
-          echo "HEXAGON_TOOLS_ROOT=$TOOLS_ROOT" >> "$GITHUB_ENV"
-
-      - name: Cache ccache
-        uses: actions/cache@v4
-        with:
-          path: ~/.ccache
-          key: ccache-android-${{ github.sha }}
-          restore-keys: ccache-android-
-
-      # llama.rn's CMake picks ccache up on its own if the binary is on PATH.
       - name: Set up ccache
-        run: |
-          set -euo pipefail
-          if ! command -v ccache >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y ccache
-          fi
-          echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
-          CCACHE_DIR="$HOME/.ccache" ccache --zero-stats
+        uses: ./.github/actions/setup-ccache
 
       # Step 5: Set up Ruby and Bundler
       - name: Set up Ruby
@@ -237,8 +169,12 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           set -euo pipefail
-          if [ -z "${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-}" ]; then
-            echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is not set, so the build mode would be whatever llama.rn happens to ship."
+          # Compared against "true" rather than merely checked for emptiness:
+          # the payload gate cannot tell the modes apart (upstream's prebuilt
+          # exports the same symbols), so this guard is the only thing holding
+          # the declaration.
+          if [ "${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-}" != "true" ]; then
+            echo "::error::ORG_GRADLE_PROJECT_rnllamaBuildFromSource is '${ORG_GRADLE_PROJECT_rnllamaBuildFromSource:-<unset>}', expected 'true'. Building from prebuilts is the documented escape hatch, but it must be a deliberate edit to this workflow."
             exit 1
           fi
           bundle exec fastlane build_android_release 2>&1 | tee android-build.log
@@ -247,6 +183,11 @@ jobs:
         if: always()
         run: ccache --show-stats || echo "ccache unavailable (its setup step did not complete)"
 
+      # COUPLING: the string grepped for below is upstream's, printed by
+      # node_modules/llama.rn/android/build.gradle next to its rnllamaVariants
+      # lookup. A llama.rn upgrade that rewords it fails this step. That is the
+      # intended direction — it is the only live proof the environment reaches
+      # gradle — but the fix is to update the literal, not to delete the check.
       - name: Verify the variant allowlist reached the llama.rn build
         run: |
           set -euo pipefail
@@ -255,7 +196,12 @@ jobs:
             echo "::error::llama.rn did not report building the declared variant set."
             echo "Expected: $VARIANTS"
             echo "In the build log:"
-            grep -F "rnllama variants" android/android-build.log || echo "  (no variant line at all — ORG_GRADLE_PROJECT_rnllamaVariants never reached the subproject)"
+            grep -F "rnllama variants" android/android-build.log || echo "  (no such line at all)"
+            echo ""
+            echo "Two different causes look identical here. Either ORG_GRADLE_PROJECT_rnllamaVariants"
+            echo "did not reach the llama.rn subproject, or upstream changed the wording of the line"
+            echo "this step greps for (android/build.gradle, the println next to rnllamaVariants)."
+            echo "Check the wording first — a llama.rn upgrade is the more common reason."
             exit 1
           fi
           echo "OK: llama.rn reported the declared variant list (extras, if any, are permitted and are reported by the payload check)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,18 @@ jobs:
       # android/gradle.properties sets rnllamaBuildFromSource, and a subproject's
       # value beats the root project's, so only an environment property or -P wins.
       ORG_GRADLE_PROJECT_rnllamaBuildFromSource: 'true'
+      # From-source builds ignore llama.rn's downloaded jniLibs, and this job
+      # builds no iOS target, so the postinstall download has nothing to supply.
+      # The DSP libraries under bin/ are tarball content and arrive regardless.
+      RNLLAMA_SKIP_POSTINSTALL: '1'
+      HEXAGON_SDK_VERSION: 6.4.0.2
+      HEXAGON_TOOLS_VERSION: 19.0.04
+      CCACHE_MAXSIZE: 2G
+      # The NDK is reinstalled on every run, so hash the compiler rather than
+      # stat it, and do not let regenerated mtimes under node_modules count as
+      # a change. Left at the defaults, nearly every object would miss.
+      CCACHE_COMPILERCHECK: content
+      CCACHE_SLOPPINESS: time_macros,include_file_mtime,include_file_ctime
 
     steps:
       # Step 1: Checkout the code
@@ -43,6 +55,14 @@ jobs:
         with:
           fetch-depth: 0  # Important for git history
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      # Must precede setup-java and setup-node: /opt/hostedtoolcache is where
+      # those install. The Hexagon SDK adds ~3.1 GB on top of a from-source build.
+      - name: Maximize build space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache
+          df -h /
 
       # Step 2: Set up JDK 17
       - name: Set up JDK 17
@@ -70,6 +90,74 @@ jobs:
           VARIANTS=$(node scripts/verify-android-payload.js --print-variants)
           echo "Declared allowlist: $VARIANTS"
           echo "ORG_GRADLE_PROJECT_rnllamaVariants=$VARIANTS" >> "$GITHUB_ENV"
+
+      # Step 4c: The Hexagon SDK is what decides whether the NPU backend is
+      # compiled in at all. Without it the build succeeds and ships without it.
+      - name: Cache Hexagon SDK
+        uses: actions/cache@v4
+        with:
+          path: ~/.hexagon-sdk
+          key: hexagon-sdk-${{ env.HEXAGON_SDK_VERSION }}
+
+      - name: Provision the Hexagon SDK
+        run: |
+          set -euo pipefail
+          SDK_ROOT="$HOME/.hexagon-sdk/$HEXAGON_SDK_VERSION"
+          TOOLS_ROOT="$SDK_ROOT/tools/HEXAGON_Tools/$HEXAGON_TOOLS_VERSION"
+
+          if [ ! -d "$SDK_ROOT" ]; then
+            STAGE=$(mktemp -d)
+            curl -fsSL -o "$STAGE/sdk.tar.xz" \
+              "https://github.com/snapdragon-toolchain/hexagon-sdk/releases/download/v${HEXAGON_SDK_VERSION}/hexagon-sdk-v${HEXAGON_SDK_VERSION}-amd64-lnx.tar.xz"
+            mkdir -p "$STAGE/unpacked"
+            tar --use-compress-program='xz -T0 -d' -xf "$STAGE/sdk.tar.xz" -C "$STAGE/unpacked"
+            rm -f "$STAGE/sdk.tar.xz"
+
+            mkdir -p "$HOME/.hexagon-sdk"
+            if [ -d "$STAGE/unpacked/incs" ]; then
+              mv "$STAGE/unpacked" "$SDK_ROOT"
+            else
+              INNER=$(find "$STAGE/unpacked" -maxdepth 1 -mindepth 1 -type d)
+              if [ "$(printf '%s\n' "$INNER" | wc -l)" -ne 1 ] || [ ! -d "$INNER/incs" ]; then
+                echo "::error::Unexpected Hexagon SDK archive layout; could not find the SDK root."
+                exit 1
+              fi
+              mv "$INNER" "$SDK_ROOT"
+            fi
+          fi
+
+          # A partially present SDK is the failure this job exists to prevent:
+          # gradle and CMake both downgrade a missing Hexagon SDK to a warning.
+          for required in \
+            "$SDK_ROOT/incs" \
+            "$TOOLS_ROOT" \
+            "$SDK_ROOT/ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so"
+          do
+            if [ ! -e "$required" ]; then
+              echo "::error::Hexagon SDK is incomplete: $required is missing, so the build would omit the NPU backend."
+              exit 1
+            fi
+          done
+
+          echo "HEXAGON_SDK_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "HEXAGON_TOOLS_ROOT=$TOOLS_ROOT" >> "$GITHUB_ENV"
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-android-${{ github.sha }}
+          restore-keys: ccache-android-
+
+      # llama.rn's CMake picks ccache up on its own if the binary is on PATH.
+      - name: Set up ccache
+        run: |
+          set -euo pipefail
+          if ! command -v ccache >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y ccache
+          fi
+          echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
+          CCACHE_DIR="$HOME/.ccache" ccache --zero-stats
 
       # Step 5: Set up Ruby and Bundler
       - name: Set up Ruby
@@ -154,6 +242,10 @@ jobs:
             exit 1
           fi
           bundle exec fastlane build_android_release 2>&1 | tee android-build.log
+
+      - name: ccache statistics
+        if: always()
+        run: ccache --show-stats || echo "ccache unavailable (its setup step did not complete)"
 
       - name: Verify the variant allowlist reached the llama.rn build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,12 @@ jobs:
       - name: Set up the Hexagon SDK
         uses: ./.github/actions/setup-hexagon-sdk
 
-      - name: Set up ccache
-        uses: ./.github/actions/setup-ccache
+      # No ccache on the release path, deliberately. Its key is the commit
+      # SHA, and a release builds a fresh version-bump commit, so the only way
+      # it could ever hit is the `ccache-android-` prefix restore — which would
+      # link objects of unreviewed provenance into the artifact that ships.
+      # Keeping it would cost the shipped binary's provenance to save build
+      # minutes on the least frequent workflow we run.
 
       # Step 5: Set up Ruby and Bundler
       - name: Set up Ruby
@@ -178,10 +182,6 @@ jobs:
             exit 1
           fi
           bundle exec fastlane build_android_release 2>&1 | tee android-build.log
-
-      - name: ccache statistics
-        if: always()
-        run: ccache --show-stats || echo "ccache unavailable (its setup step did not complete)"
 
       # COUPLING: the string grepped for below is upstream's, printed by
       # node_modules/llama.rn/android/build.gradle next to its rnllamaVariants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,9 @@ jobs:
           git add .version package.json android/app/build.gradle ios/PocketPal.xcodeproj/project.pbxproj
           git commit -m "chore(release): bump version to $VERSION"
           git push
+          # Created here so it points at the bump commit, but pushed only once
+          # the payload check has passed — see "Push the release tag" below.
           git tag "v$VERSION"
-          git push origin "v$VERSION"
 
       # Step 8: Set up Android Keystore
       - name: Set up Android Keystore
@@ -194,6 +195,11 @@ jobs:
           set -euo pipefail
           echo "$PLAY_STORE_JSON_KEY" > play-store-key.json
           bundle exec fastlane upload_android_alpha
+
+      # Step 10d: A failed payload check now leaves no release tag on the
+      # remote, so a re-run does not have to reuse or delete one.
+      - name: Push the release tag
+        run: git push origin "v$VERSION"
 
       # Step 11: Create GitHub Release with APK
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
             grep -F "rnllama variants" android/android-build.log || echo "  (no variant line at all — ORG_GRADLE_PROJECT_rnllamaVariants never reached the subproject)"
             exit 1
           fi
-          echo "OK: llama.rn built exactly the declared variants."
+          echo "OK: llama.rn reported the declared variant list (extras, if any, are permitted and are reported by the payload check)."
 
       # Step 10b: Both shipped forms are checked — the APK goes to the GitHub
       # Release, the AAB goes to Play, and they are packaged separately.

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,11 @@ e2e/dist/
 # with the worktree.
 e2e/specs/visual-capture/TASK-*.spec.ts
 
+# Android build log and payload-check report, written by the release path
+# and reproducible locally.
+android/android-build.log
+payload-report.txt
+
 # Dev-team workflow control-plane artefacts (story docs, designer asks,
 # screenshot inventories). Live in the dev-team repo and are sometimes
 # synced into the worktree for local reference; never committed here.

--- a/.gitignore
+++ b/.gitignore
@@ -101,10 +101,11 @@ e2e/dist/
 # with the worktree.
 e2e/specs/visual-capture/TASK-*.spec.ts
 
-# Android build log and payload-check report, written by the release path
-# and reproducible locally.
+# Android build log and payload-check report, written by both the CI and
+# release workflows and reproducible locally. The build log can contain the
+# gradle command line, so it is never committed.
 android/android-build.log
-payload-report.txt
+/payload-report.txt
 
 # Dev-team workflow control-plane artefacts (story docs, designer asks,
 # screenshot inventories). Live in the dev-team repo and are sometimes

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,16 +1,16 @@
 default_platform :android
 
 platform :android do
-  desc "Release Android app to Alpha track"
-  lane :release_android_alpha do
+  desc "Build the Android release APK and AAB"
+  lane :build_android_release do
     android_dir = File.expand_path('..', Dir.pwd)
-    
+
     # Create google-services.json from GitHub secret
     File.write(
       File.join(android_dir, "app/google-services.json"),
       ENV["GOOGLE_SERVICES_JSON"]
     )
-    
+
     # Build APK for GitHub Release.
     # flavor: "prod" is MANDATORY — task: "assemble" is a gradle meta-task
     # that, post-flavor, would build both prodRelease AND e2eRelease
@@ -41,10 +41,22 @@ platform :android do
         "android.injected.signing.key.password" => ENV["KEY_PASSWORD"]
       }
     )
+  end
+
+  desc "Upload the built Android bundle to the Alpha track"
+  lane :upload_android_alpha do
+    android_dir = File.expand_path('..', Dir.pwd)
 
     upload_to_play_store(
       track: "alpha",
       package_name: "com.pocketpalai",
+      # Passed explicitly, and must stay that way. supply otherwise takes the
+      # bundle from lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH], which
+      # only exists in the process that ran `gradle(task: "bundle")` — a
+      # separate one from this lane's. Its fallback globs do not match this
+      # project's flavored output path, so an absent value uploads the
+      # metadata, no binary, and reports success.
+      aab: File.join(android_dir, "app/build/outputs/bundle/prodRelease/app-prod-release.aab"),
       skip_upload_metadata: false,
       skip_upload_images: true,
       skip_upload_screenshots: true,

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -21,6 +21,11 @@ platform :android do
       task: "assemble",
       flavor: "prod",
       build_type: "Release",
+      # The properties below are rendered into the command line fastlane echoes
+      # before running it, and that echo is what put the signing passwords in
+      # plaintext into android-build.log. Output stays on — the payload check's
+      # allowlist assertion reads gradle's stdout.
+      print_command: false,
       properties: {
         "android.injected.signing.store.file" => File.join(android_dir, "app/pocketpal-release-key.keystore"),
         "android.injected.signing.store.password" => ENV["KEYSTORE_PASSWORD"],
@@ -34,6 +39,11 @@ platform :android do
       task: "bundle",
       flavor: "prod",
       build_type: "Release",
+      # The properties below are rendered into the command line fastlane echoes
+      # before running it, and that echo is what put the signing passwords in
+      # plaintext into android-build.log. Output stays on — the payload check's
+      # allowlist assertion reads gradle's stdout.
+      print_command: false,
       properties: {
         "android.injected.signing.store.file" => File.join(android_dir, "app/pocketpal-release-key.keystore"),
         "android.injected.signing.store.password" => ENV["KEYSTORE_PASSWORD"],

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -37,6 +37,3 @@ newArchEnabled=true
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
-
-# Use this to enable building llama.rn from source. 
-# rnllamaBuildFromSource=true

--- a/scripts/__tests__/android-ladder-coverage.test.js
+++ b/scripts/__tests__/android-ladder-coverage.test.js
@@ -16,6 +16,13 @@ const LLAMA_RN_ANDROID = path.join(
   'main',
 );
 const LIBRARY_CMAKE = path.join(LLAMA_RN_ANDROID, 'rnllama', 'CMakeLists.txt');
+const RNLLAMA_JAVA = path.join(
+  LLAMA_RN_ANDROID,
+  'java',
+  'com',
+  'rnllama',
+  'RNLlama.java',
+);
 const JNI_CMAKE = path.join(LLAMA_RN_ANDROID, 'CMakeLists.txt');
 
 const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8'));
@@ -198,5 +205,39 @@ describe('the ladder loads JNI wrappers, so their call sites must track the libr
         );
       }
     }
+  });
+});
+
+describe('the DSP asset list tracks the runtime loader', () => {
+  // The manifest hand-mirrors RNLlama.java's HTP_LIBS. Nothing else notices if
+  // upstream adds or removes one: a new library ships un-gated, and a later
+  // upgrade that drops it kills the backend outright, because the loader
+  // returns false on the first asset it cannot open.
+  const source = fs.readFileSync(RNLLAMA_JAVA, 'utf-8');
+
+  function parseHtpLibs() {
+    const block = source.match(/String\[\]\s+HTP_LIBS\s*=\s*\{([^}]*)\}/);
+    if (!block) {
+      return null;
+    }
+    return [...block[1].matchAll(/"([^"]+)"/g)].map(match => match[1]);
+  }
+
+  const assetDir = source.match(/getAssets\(\)\.open\("([^"]*?)"\s*\+/);
+  const htpLibs = parseHtpLibs();
+
+  it('parses the loader, rather than passing because it matched nothing', () => {
+    expect(htpLibs).not.toBeNull();
+    expect(htpLibs.length).toBeGreaterThan(0);
+    expect(assetDir).not.toBeNull();
+  });
+
+  it('declares exactly the assets the loader extracts, at the path it reads', () => {
+    const declared = manifest.abis
+      .flatMap(abi => abi.requiredAssets || [])
+      .sort();
+    const expected = htpLibs.map(lib => `assets/${assetDir[1]}${lib}`).sort();
+
+    expect(declared).toEqual(expected);
   });
 });

--- a/scripts/__tests__/android-ladder-coverage.test.js
+++ b/scripts/__tests__/android-ladder-coverage.test.js
@@ -1,0 +1,202 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const MANIFEST_PATH = path.join(
+  __dirname,
+  '..',
+  'android-payload-manifest.json',
+);
+const LLAMA_RN_ANDROID = path.join(
+  ROOT,
+  'node_modules',
+  'llama.rn',
+  'android',
+  'src',
+  'main',
+);
+const LIBRARY_CMAKE = path.join(LLAMA_RN_ANDROID, 'rnllama', 'CMakeLists.txt');
+const JNI_CMAKE = path.join(LLAMA_RN_ANDROID, 'CMakeLists.txt');
+
+const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8'));
+
+/**
+ * The rungs the runtime ladder can select but the allowlist does not build,
+ * each with the rung a matching device falls to instead. FEAT_I8MM and
+ * FEAT_DotProd are independently optional from Armv8.2, so this is an
+ * empirical claim about shipping silicon, not an architectural one.
+ */
+const NAMED_BETS = {
+  rnllama_v8_2_i8mm:
+    'rnllama_v8_2, or rnllama_v8 on a device that also lacks fp16',
+};
+
+/**
+ * `build_rnllama_*` call sites, each attributed to the ABI whose
+ * `if (ANDROID_ABI STREQUAL ...)` branch encloses it. Sites outside every
+ * branch are built for all ABIs.
+ */
+function parseCallSites(cmakePath, fnName, argNames) {
+  const pattern = new RegExp(
+    `${fnName}\\(\\s*${argNames.map(() => '"([^"]*)"').join('\\s+')}\\s*\\)`,
+  );
+  const abiBranch = /^\s*(?:else)?if\s*\(.*ANDROID_ABI\s+STREQUAL\s+"([^"]+)"/;
+  const sites = [];
+  let abi = null;
+
+  for (const line of fs.readFileSync(cmakePath, 'utf-8').split('\n')) {
+    if (/^\s*#/.test(line)) {
+      continue;
+    }
+    const branch = line.match(abiBranch);
+    if (branch) {
+      abi = branch[1];
+      continue;
+    }
+    if (/^\s*(?:else\s*\(|endif)/.test(line)) {
+      abi = null;
+      continue;
+    }
+    const call = line.match(pattern);
+    if (call) {
+      const site = {abi};
+      argNames.forEach((argName, i) => {
+        site[argName] = call[i + 1];
+      });
+      sites.push(site);
+    }
+  }
+  return sites;
+}
+
+/**
+ * What a variant is actually compiled as. `arch` and `cpu_flags` are not
+ * enough: `build_rnllama_library` derives extra sources and `-D` macros from
+ * the target *name*, so the hexagon variant and the plain dotprod+i8mm one
+ * share both literal arguments while differing in the backend they carry.
+ */
+function buildSignature({name, arch, flags}) {
+  return JSON.stringify({
+    arch,
+    flags,
+    hexagon: /_hexagon/.test(name),
+    opencl: /_opencl$/.test(name),
+    genericSources: arch === 'generic',
+  });
+}
+
+function abisFor(site) {
+  return site.abi ? [site.abi] : manifest.abis.map(entry => entry.abi);
+}
+
+function requiredLibsFor(abi) {
+  const entry = manifest.abis.find(candidate => candidate.abi === abi);
+  return entry ? entry.requiredLibs : [];
+}
+
+function isRetained(site, abi) {
+  return requiredLibsFor(abi).includes(`lib${site.name}.so`);
+}
+
+const librarySites = parseCallSites(LIBRARY_CMAKE, 'build_rnllama_library', [
+  'name',
+  'arch',
+  'flags',
+]);
+const jniSites = parseCallSites(JNI_CMAKE, 'build_rnllama_jni', [
+  'jniName',
+  'name',
+  'arch',
+  'flags',
+]);
+
+describe('the parse itself', () => {
+  // Without these, an upstream reformat that matches zero call sites would
+  // make every for-each below pass vacuously and CI would stay green.
+  it.each([
+    ['library', librarySites],
+    ['JNI wrapper', jniSites],
+  ])('finds the expected %s call sites', (_label, sites) => {
+    expect(sites).toHaveLength(8);
+    expect(sites.filter(site => site.abi === null)).toHaveLength(1);
+    expect(sites.filter(site => site.abi === 'arm64-v8a')).toHaveLength(6);
+    expect(sites.filter(site => site.abi === 'x86_64')).toHaveLength(1);
+  });
+});
+
+describe('ladder coverage', () => {
+  it('builds every variant the runtime ladder can select', () => {
+    const unexplained = [];
+
+    for (const site of librarySites) {
+      for (const abi of abisFor(site)) {
+        if (isRetained(site, abi)) {
+          continue;
+        }
+        if (NAMED_BETS[site.name]) {
+          continue;
+        }
+        const equivalent = librarySites
+          .filter(
+            other => abisFor(other).includes(abi) && isRetained(other, abi),
+          )
+          .some(other => buildSignature(other) === buildSignature(site));
+        if (!equivalent) {
+          unexplained.push(`${abi}/${site.name}`);
+        }
+      }
+    }
+
+    expect(unexplained).toEqual([]);
+  });
+
+  it('states the fall-through rung for every variant it drops', () => {
+    const dropped = librarySites
+      .filter(site => abisFor(site).some(abi => !isRetained(site, abi)))
+      .map(site => site.name);
+
+    expect(dropped).toEqual(Object.keys(NAMED_BETS));
+  });
+
+  it('does not treat the hexagon variant as covered by its dotprod+i8mm twin', () => {
+    const hexagon = librarySites.find(site => /_hexagon/.test(site.name));
+    const twin = librarySites.find(
+      site => site.name === 'rnllama_v8_2_dotprod_i8mm',
+    );
+
+    expect(hexagon.arch).toBe(twin.arch);
+    expect(hexagon.flags).toBe(twin.flags);
+    expect(buildSignature(hexagon)).not.toBe(buildSignature(twin));
+  });
+
+  it('does not treat the portable-C fallback as covered by the armv8-a rung', () => {
+    const generic = librarySites.find(site => site.name === 'rnllama');
+    const armv8 = librarySites.find(site => site.name === 'rnllama_v8');
+
+    expect(buildSignature(generic)).not.toBe(buildSignature(armv8));
+  });
+});
+
+describe('the ladder loads JNI wrappers, so their call sites must track the libraries', () => {
+  it('pairs one wrapper with each library, on the same arch and flags', () => {
+    const key = site => `${site.abi}/${site.name}/${site.arch}/${site.flags}`;
+
+    expect(jniSites.map(key).sort()).toEqual(librarySites.map(key).sort());
+    for (const site of jniSites) {
+      expect(site.jniName).toBe(site.name.replace('rnllama', 'rnllama_jni'));
+    }
+  });
+
+  it('requires a wrapper in the manifest for every required library', () => {
+    for (const abi of manifest.abis) {
+      const libs = abi.requiredLibs.filter(
+        lib => !lib.startsWith('librnllama_jni'),
+      );
+      for (const lib of libs) {
+        expect(abi.requiredLibs).toContain(
+          lib.replace('librnllama', 'librnllama_jni'),
+        );
+      }
+    }
+  });
+});

--- a/scripts/__tests__/hexagon-sdk-coverage.test.js
+++ b/scripts/__tests__/hexagon-sdk-coverage.test.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const ACTION = path.join(
+  ROOT,
+  '.github',
+  'actions',
+  'setup-hexagon-sdk',
+  'action.yml',
+);
+const LLAMA_RN_CMAKE = [
+  path.join(
+    ROOT,
+    'node_modules/llama.rn/android/src/main/rnllama/CMakeLists.txt',
+  ),
+  path.join(ROOT, 'node_modules/llama.rn/android/src/main/CMakeLists.txt'),
+];
+
+/**
+ * The provisioning action verifies a digest over a narrow subset of the ~3 GB
+ * SDK — the parts the Android build reads or links. That subset is only sound
+ * while it still covers what llama.rn's CMake actually references. A widened
+ * include set would otherwise leave the digest green over a stale, narrower
+ * set, and on a cache hit the tarball digest is not there to catch it.
+ *
+ * Paths llama.rn references that this repackaging does not ship. A compiler
+ * ignores a missing include directory, so nothing is consumed from them.
+ */
+const NOT_SHIPPED = {
+  'utils/examples': 'absent from the snapdragon-toolchain repackaging',
+};
+
+const cmakeSources = LLAMA_RN_CMAKE.map(file =>
+  fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '',
+).join('\n');
+
+const referenced = [
+  ...new Set(
+    [...cmakeSources.matchAll(/\$\{HEXAGON_SDK_ROOT\}\/([^\s")]+)/g)].map(
+      match => match[1],
+    ),
+  ),
+].sort();
+
+const consumedPaths = (() => {
+  const match = fs
+    .readFileSync(ACTION, 'utf-8')
+    .match(/^\s*CONSUMED_PATHS="([^"]*)"/m);
+  return match ? match[1].trim().split(/\s+/).filter(Boolean) : null;
+})();
+
+describe('the parse itself', () => {
+  // Without these, a rename on either side makes every assertion below pass
+  // over an empty set.
+  it('finds the SDK paths llama.rn references', () => {
+    expect(referenced.length).toBe(5);
+  });
+
+  it('finds the paths the provisioning action digests', () => {
+    expect(consumedPaths).not.toBeNull();
+    expect(consumedPaths.length).toBeGreaterThan(0);
+  });
+});
+
+describe('the verified subset covers what the build consumes', () => {
+  const covers = (consumed, ref) =>
+    ref === consumed || ref.startsWith(`${consumed}/`);
+
+  it.each(referenced)('%s', ref => {
+    if (NOT_SHIPPED[ref]) {
+      return;
+    }
+    expect(consumedPaths.some(consumed => covers(consumed, ref))).toBe(true);
+  });
+
+  it('digests nothing that llama.rn does not reference', () => {
+    const unreferenced = consumedPaths.filter(
+      consumed => !referenced.some(ref => covers(consumed, ref)),
+    );
+    expect(unreferenced).toEqual([]);
+  });
+
+  it('states why each referenced path it skips is not shipped', () => {
+    const skipped = referenced.filter(
+      ref => !consumedPaths.some(consumed => covers(consumed, ref)),
+    );
+    expect(skipped).toEqual(Object.keys(NOT_SHIPPED));
+  });
+});

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -525,6 +525,72 @@ describe('a check that cannot run', () => {
     expect(output).toContain('its backend would not be checked');
   });
 
+  // Every list in the manifest needs a floor. An emptied list is the cheapest
+  // edit that unblocks a build, and it degrades silently: the rule simply
+  // stops being checked and nothing else covers it.
+  it.each([
+    [
+      'an accelerator ABI with no required assets',
+      abis => {
+        abis[0].requiredAssets = [];
+      },
+      'no required assets',
+    ],
+    [
+      'an accelerator ABI whose requiredAssets is absent',
+      abis => {
+        delete abis[0].requiredAssets;
+      },
+      'no required assets',
+    ],
+    [
+      'an accelerator ABI with no symbol rule, even when another ABI has one',
+      abis => {
+        abis[0].requiredSymbols = [];
+        abis[1].requiredSymbols = [
+          {
+            lib: 'librnllama_x86_64.so',
+            mustExport: ['lm_ggml_backend_reg_count'],
+          },
+        ];
+      },
+      'no symbol rule',
+    ],
+  ])('fails on %s', (_label, weaken, fragment) => {
+    const weakened = path.join(workspace, 'weakened-abi.json');
+    const edited = JSON.parse(JSON.stringify(manifest));
+    weaken(edited.abis);
+    fs.writeFileSync(weakened, JSON.stringify(edited));
+
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain(fragment);
+  });
+
+  it('reports the assets row even when none are declared', () => {
+    // The summary claims assets were checked, so a manifest declaring none
+    // must be visible in the report rather than simply omitting the line.
+    const weakened = path.join(workspace, 'no-accelerator.json');
+    const edited = JSON.parse(JSON.stringify(manifest));
+    // x86_64 only: no accelerator, so no assets are required — but it still
+    // carries a symbol rule, which is a legitimate shape.
+    edited.abis = [edited.abis[1]];
+    edited.abis[0].requiredSymbols = [
+      {lib: 'librnllama_x86_64.so', mustExport: ['lm_ggml_backend_reg_count']},
+    ];
+    fs.writeFileSync(weakened, JSON.stringify(edited));
+
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {output} = runGate(['--apk', archive, '--manifest', weakened]);
+    expect(output).toContain('assets: 0/0 present');
+  });
+
   it('refuses a manifest that yields an empty variant allowlist', () => {
     const weakened = path.join(workspace, 'wrappers-only.json');
     const edited = JSON.parse(JSON.stringify(manifest));

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -364,6 +364,13 @@ describe('a check that cannot run', () => {
     expect(runGate([]).status).toBe(1);
   });
 
+  it('refuses --print-variants alongside an artifact rather than skipping the check', () => {
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {status, output} = runGate(['--print-variants', '--apk', archive]);
+    expect(status).toBe(1);
+    expect(output).toContain('does not check an artifact');
+  });
+
   it('fails when the manifest declares no ABIs', () => {
     const emptyManifest = path.join(workspace, 'empty-manifest.json');
     fs.writeFileSync(emptyManifest, JSON.stringify({abis: []}));

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -481,6 +481,29 @@ describe('a check that cannot run', () => {
       },
     ],
     ['a rule naming no library', rule => delete rule.lib],
+    // count: 0 does not merely assert nothing, it asserts the backend is
+    // ABSENT — so the incident build satisfies it exactly.
+    [
+      'a rule whose only demand is a count of zero',
+      rule => {
+        rule.mustExport = [];
+        rule.expectedMatchCount = {pattern: 'hexagon', count: 0};
+      },
+    ],
+    [
+      'a rule whose expectedMatchCount has no pattern',
+      rule => {
+        rule.mustExport = [];
+        rule.expectedMatchCount = {count: 16};
+      },
+    ],
+    [
+      'a rule whose expectedMatchCount is an empty object',
+      rule => {
+        rule.mustExport = [];
+        rule.expectedMatchCount = {};
+      },
+    ],
   ])('fails on %s', (_label, weaken) => {
     const weakened = path.join(workspace, 'weakened.json');
     const edited = JSON.parse(JSON.stringify(manifest));
@@ -499,7 +522,28 @@ describe('a check that cannot run', () => {
       weakened,
     ]);
     expect(status).toBe(1);
-    expect(output).toContain('asserts nothing');
+    expect(output).toContain('its backend would not be checked');
+  });
+
+  it('refuses a manifest that yields an empty variant allowlist', () => {
+    const weakened = path.join(workspace, 'wrappers-only.json');
+    const edited = JSON.parse(JSON.stringify(manifest));
+    for (const abi of edited.abis) {
+      abi.requiredLibs = abi.requiredLibs.filter(lib =>
+        lib.startsWith('librnllama_jni'),
+      );
+    }
+    fs.writeFileSync(weakened, JSON.stringify(edited));
+
+    // An empty allowlist would be exported as ORG_GRADLE_PROJECT_rnllamaVariants=
+    // and the build-log assertion would then grep for a bare prefix.
+    const {status, output} = runGate([
+      '--print-variants',
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('empty variant allowlist');
   });
 
   it('refuses a repeated --apk rather than checking only the last one', () => {

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -120,6 +120,22 @@ function hexagonDynsym(matchCount, {withRequired = true} = {}) {
   return buildElf(symbols);
 }
 
+/**
+ * A DSP library as far as the check is concerned: ELF32, little-endian, and
+ * targeting EM_QDSP6. The real ones are 650-730 KB of Hexagon code; only the
+ * header is asserted, so only the header is built.
+ */
+function buildDspStub(machine = 164) {
+  const out = Buffer.alloc(52);
+  out.writeUInt32BE(0x7f454c46, 0);
+  out.writeUInt8(1, 4); // ELFCLASS32
+  out.writeUInt8(1, 5); // ELFDATA2LSB
+  out.writeUInt8(1, 6);
+  out.writeUInt16LE(3, 16); // ET_DYN
+  out.writeUInt16LE(machine, 18);
+  return out;
+}
+
 const PLAIN_ELF = buildElf([
   {name: 'lm_ggml_backend_reg_count', defined: true},
   {name: 'malloc', defined: false},
@@ -133,7 +149,7 @@ function conformingEntries(prefix = '') {
       entries[`${prefix}lib/${abi.abi}/${lib}`] = PLAIN_ELF;
     }
     for (const asset of abi.requiredAssets) {
-      entries[`${prefix}${asset}`] = Buffer.from('dsp');
+      entries[`${prefix}${asset}`] = buildDspStub();
     }
     for (const rule of abi.requiredSymbols) {
       entries[`${prefix}lib/${abi.abi}/${rule.lib}`] = hexagonDynsym(
@@ -558,6 +574,25 @@ describe('a check that cannot run', () => {
       'no symbol rule examining it',
     ],
     [
+      "an accelerator ABI whose only rule examines the accelerator's JNI wrapper",
+      abis => {
+        abis[0].requiredSymbols = [
+          {
+            lib: 'librnllama_jni_v8_2_dotprod_i8mm_hexagon_opencl.so',
+            mustExport: ['Java_com_rnllama_RNLlama_nativeSetLoadedLibrary'],
+          },
+        ];
+      },
+      'no symbol rule examining it',
+    ],
+    [
+      'an accelerator ABI declaring assets with no machine to check them against',
+      abis => {
+        delete abis[0].requiredAssetElfMachine;
+      },
+      'no requiredAssetElfMachine',
+    ],
+    [
       'an accelerator ABI with no symbol rule, even when another ABI has one',
       abis => {
         abis[0].requiredSymbols = [];
@@ -590,22 +625,91 @@ describe('a check that cannot run', () => {
   it('reports the assets row even when none are declared', () => {
     // The summary claims assets were checked, so a manifest declaring none
     // must be visible in the report rather than simply omitting the line.
-    const weakened = path.join(workspace, 'no-accelerator.json');
-    const edited = JSON.parse(JSON.stringify(manifest));
-    // x86_64 only: no accelerator, so no assets are required — but it still
-    // carries a symbol rule, which is a legitimate shape.
-    edited.abis = [edited.abis[1]];
-    edited.abis[0].requiredSymbols = [
-      {lib: 'librnllama_x86_64.so', mustExport: ['lm_ggml_backend_reg_count']},
-    ];
-    fs.writeFileSync(weakened, JSON.stringify(edited));
-
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
-    const {output} = runGate(['--apk', archive, '--manifest', weakened]);
+    // x86_64 declares no assets, which is legitimate — it carries no
+    // accelerator. The committed manifest already has this shape.
+    const {output} = gateApk(conformingEntries());
     expect(output).toContain('assets: 0/0 present');
   });
 
-  it('refuses a manifest that yields an empty variant allowlist', () => {
+  // A new fail-closed assertion with no test is how the previous holes became
+  // possible: it works today, and nothing holds it there.
+  it('fails on an ABI tree the manifest never declared', () => {
+    const entries = conformingEntries();
+    entries['lib/armeabi-v7a/librnllama.so'] = PLAIN_ELF;
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('UNDECLARED  lib/armeabi-v7a/');
+    expect(output).toContain('which the manifest does not declare');
+  });
+
+  it('reports the ABI trees it found, so the enumeration is visible', () => {
+    const {output} = gateApk(conformingEntries());
+    expect(output).toContain('ABIs in the artifact: arm64-v8a, x86_64');
+  });
+
+  it('enumerates ABI trees in a bundle too, under its base/ prefix', () => {
+    const entries = conformingEntries('base/');
+    entries['base/lib/armeabi-v7a/librnllama.so'] = PLAIN_ELF;
+    const archive = writeArchive('app-prod-release.aab', entries);
+    const {status, output} = runGate(['--aab', archive]);
+    expect(status).toBe(1);
+    expect(output).toContain('UNDECLARED  base/lib/armeabi-v7a/');
+  });
+
+  it('fails when a DSP asset is present but is not a DSP object', () => {
+    const entries = conformingEntries();
+    entries['assets/ggml-hexagon/libggml-htp-v73.so'] = buildDspStub(183); // EM_AARCH64
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('WRONG MACHINE');
+    expect(output).toContain('is not a DSP library');
+  });
+
+  it('fails when a DSP asset is not an ELF object at all', () => {
+    const entries = conformingEntries();
+    entries['assets/ggml-hexagon/libggml-htp-v73.so'] = Buffer.alloc(64, 0x41);
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('proven nothing about it');
+  });
+
+  it('refuses a manifest declaring no accelerator ABI at all', () => {
+    // Otherwise every accelerator floor is satisfied vacuously, and the ABI
+    // enumeration compares only against what the manifest names.
+    const weakened = path.join(workspace, 'no-accelerator-abi.json');
+    fs.writeFileSync(
+      weakened,
+      JSON.stringify({
+        abis: [
+          {
+            abi: 'armeabi-v7a',
+            requiredLibs: ['librnllama.so', 'librnllama_jni.so'],
+            requiredAssets: [],
+            requiredSymbols: [
+              {lib: 'librnllama.so', mustExport: ['lm_ggml_backend_reg_count']},
+            ],
+          },
+        ],
+      }),
+    );
+    const entries = {
+      'lib/armeabi-v7a/librnllama.so': buildElf([
+        {name: 'lm_ggml_backend_reg_count', defined: true},
+      ]),
+      'lib/armeabi-v7a/librnllama_jni.so': PLAIN_ELF,
+    };
+    const archive = writeArchive('app-prod-release.apk', entries);
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('no accelerator library');
+  });
+
+  it('refuses a wrappers-only manifest before it can yield an empty allowlist', () => {
     const weakened = path.join(workspace, 'wrappers-only.json');
     const edited = JSON.parse(JSON.stringify(manifest));
     for (const abi of edited.abis) {
@@ -615,16 +719,17 @@ describe('a check that cannot run', () => {
     }
     fs.writeFileSync(weakened, JSON.stringify(edited));
 
-    // An empty allowlist un-narrows the build: gradle passes no
-    // -DRNLLAMA_ANDROID_VARIANTS for an empty value, and CMake reads the empty
-    // variable as "every variant enabled".
+    // Stripping the libraries also strips the accelerator, so this is refused
+    // by the accelerator floor. variantsFromManifest keeps its own empty-list
+    // guard as a backstop: an empty value would make gradle pass no
+    // -DRNLLAMA_ANDROID_VARIANTS, and CMake reads that as "build everything".
     const {status, output} = runGate([
       '--print-variants',
       '--manifest',
       weakened,
     ]);
     expect(status).toBe(1);
-    expect(output).toContain('empty variant allowlist');
+    expect(output).toContain('no accelerator library');
   });
 
   it('refuses a repeated --apk rather than checking only the last one', () => {

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -229,6 +229,22 @@ describe('a conforming artifact', () => {
     expect(runGate(['--aab', archive]).status).toBe(1);
   });
 
+  // The bundle path must judge the library it found, not merely find one. A
+  // prefix that matched nothing would report the same "PASS" as a sound build.
+  it('fails as an app bundle whose backend library is the broken one', () => {
+    const entries = conformingEntries('base/');
+    entries[
+      'base/lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'
+    ] = hexagonDynsym(0, {withRequired: false});
+    const archive = writeArchive('app-prod-release.aab', entries);
+    const {status, output} = runGate(['--aab', archive]);
+    expect(status).toBe(1);
+    expect(output).toContain(
+      'base/lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so',
+    );
+    expect(output).toContain('does not export');
+  });
+
   it('writes the same report to --report', () => {
     const reportPath = path.join(workspace, 'payload-report.txt');
     const {output} = gateApk(conformingEntries(), ['--report', reportPath]);
@@ -369,6 +385,80 @@ describe('a check that cannot run', () => {
     const {status, output} = runGate(['--print-variants', '--apk', archive]);
     expect(status).toBe(1);
     expect(output).toContain('does not check an artifact');
+  });
+
+  it('fails when the artifact is not there at all', () => {
+    const {status, output} = runGate([
+      '--apk',
+      path.join(workspace, 'never-built.apk'),
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('proven nothing about it');
+  });
+
+  it('fails when the artifact is a readable archive holding nothing', () => {
+    const archive = writeArchive('app-prod-release.apk', {
+      'META-INF/placeholder': Buffer.from('x'),
+    });
+    expect(runGate(['--apk', archive]).status).toBe(1);
+  });
+
+  it('fails when the library has had its section headers stripped', () => {
+    const stripped = Buffer.from(PLAIN_ELF);
+    stripped.writeBigUInt64LE(0n, 0x28); // e_shoff
+    stripped.writeUInt16LE(0, 0x3c); // e_shnum
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      stripped;
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('section headers are absent');
+  });
+
+  // The report is the evidence the check ran. Failing to write it while
+  // reporting success would leave a pass nobody can audit.
+  it('fails when it cannot write the report, even if the artifact is sound', () => {
+    const {status, output} = gateApk(conformingEntries(), [
+      '--report',
+      path.join(workspace, 'no-such-directory', 'payload-report.txt'),
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('FAIL');
+  });
+
+  it('fails when the manifest declares no libraries for an ABI', () => {
+    const weakened = path.join(workspace, 'no-libs.json');
+    fs.writeFileSync(
+      weakened,
+      JSON.stringify({abis: [{abi: 'arm64-v8a', requiredLibs: []}]}),
+    );
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('declares no required libraries');
+  });
+
+  it('fails when the manifest declares no symbol rules', () => {
+    const weakened = path.join(workspace, 'no-symbol-rules.json');
+    const stripped = JSON.parse(JSON.stringify(manifest));
+    for (const abi of stripped.abis) {
+      abi.requiredSymbols = [];
+    }
+    fs.writeFileSync(weakened, JSON.stringify(stripped));
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('declares no symbol rules');
   });
 
   it('fails when the manifest declares no ABIs', () => {

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -461,6 +461,55 @@ describe('a check that cannot run', () => {
     expect(output).toContain('declares no symbol rules');
   });
 
+  // The regression that motivated this check satisfied every library and asset
+  // rule; the symbol rule was the only thing that caught it. A rule that names
+  // a library but asserts nothing about it therefore restores the incident with
+  // CI green, and counting rules rather than reading them would not notice.
+  it.each([
+    [
+      'a rule that asserts nothing',
+      rule => {
+        delete rule.mustExport;
+        delete rule.expectedMatchCount;
+      },
+    ],
+    [
+      'a rule whose mustExport has been emptied',
+      rule => {
+        rule.mustExport = [];
+        delete rule.expectedMatchCount;
+      },
+    ],
+    ['a rule naming no library', rule => delete rule.lib],
+  ])('fails on %s', (_label, weaken) => {
+    const weakened = path.join(workspace, 'weakened.json');
+    const edited = JSON.parse(JSON.stringify(manifest));
+    weaken(edited.abis[0].requiredSymbols[0]);
+    fs.writeFileSync(weakened, JSON.stringify(edited));
+
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      hexagonDynsym(0, {withRequired: false});
+    const archive = writeArchive('app-prod-release.apk', entries);
+
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('asserts nothing');
+  });
+
+  it('refuses a repeated --apk rather than checking only the last one', () => {
+    const first = writeArchive('first.apk', conformingEntries());
+    const second = writeArchive('second.apk', conformingEntries());
+    const {status, output} = runGate(['--apk', first, '--apk', second]);
+    expect(status).toBe(1);
+    expect(output).toContain('given twice');
+  });
+
   it('fails when the manifest declares no ABIs', () => {
     const emptyManifest = path.join(workspace, 'empty-manifest.json');
     fs.writeFileSync(emptyManifest, JSON.stringify({abis: []}));

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -335,7 +335,10 @@ describe('a check that cannot run', () => {
     expect(output).toContain('proven nothing about it');
   });
 
-  it('fails when a required library extracts as zero bytes', () => {
+  // Titled for the outcome, not the mechanism: an empty entry trips the
+  // zero-byte guard and the ELF length check alike, so this asserts that an
+  // unreadable library fails, not which of the two guards caught it.
+  it('fails when a required library holds nothing readable', () => {
     const entries = conformingEntries();
     entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
       Buffer.alloc(0);
@@ -424,6 +427,8 @@ describe('a check that cannot run', () => {
     ]);
     expect(status).toBe(1);
     expect(output).toContain('FAIL');
+    // Exit code aside, a human scanning the log must not see a pass.
+    expect(output).not.toContain('PASS:');
   });
 
   it('fails when the manifest declares no libraries for an ABI', () => {
@@ -544,6 +549,15 @@ describe('a check that cannot run', () => {
       'no required assets',
     ],
     [
+      'an accelerator ABI whose only rule examines a different library',
+      abis => {
+        abis[0].requiredSymbols = [
+          {lib: 'librnllama.so', mustExport: ['lm_ggml_backend_reg_count']},
+        ];
+      },
+      'no symbol rule examining it',
+    ],
+    [
       'an accelerator ABI with no symbol rule, even when another ABI has one',
       abis => {
         abis[0].requiredSymbols = [];
@@ -601,8 +615,9 @@ describe('a check that cannot run', () => {
     }
     fs.writeFileSync(weakened, JSON.stringify(edited));
 
-    // An empty allowlist would be exported as ORG_GRADLE_PROJECT_rnllamaVariants=
-    // and the build-log assertion would then grep for a bare prefix.
+    // An empty allowlist un-narrows the build: gradle passes no
+    // -DRNLLAMA_ANDROID_VARIANTS for an empty value, and CMake reads the empty
+    // variable as "every variant enabled".
     const {status, output} = runGate([
       '--print-variants',
       '--manifest',

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -1,0 +1,380 @@
+const {execFileSync} = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'verify-android-payload.js');
+const MANIFEST_PATH = path.join(
+  __dirname,
+  '..',
+  'android-payload-manifest.json',
+);
+const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8'));
+
+const ELF64_SHDR_SIZE = 64;
+const ELF64_SYM_SIZE = 24;
+
+/**
+ * A minimal little-endian AArch64 ELF64 shared object carrying nothing but a
+ * `.dynsym` and its string table.
+ *
+ * Synthetic rather than committed binaries: the cases that matter most here —
+ * a `.dynsym` that is absent, or present but empty — are artifacts no compiler
+ * emits, and a committed `.so` could not be reviewed.
+ */
+function buildElf(symbols, {omitDynsym = false, emptyDynsym = false} = {}) {
+  let dynstr = Buffer.from([0]);
+  const nameOffsets = [];
+  for (const symbol of symbols) {
+    nameOffsets.push(dynstr.length);
+    dynstr = Buffer.concat([
+      dynstr,
+      Buffer.from(symbol.name, 'utf-8'),
+      Buffer.from([0]),
+    ]);
+  }
+
+  const entries = emptyDynsym ? 1 : symbols.length + 1;
+  const dynsym = Buffer.alloc(entries * ELF64_SYM_SIZE);
+  if (!emptyDynsym) {
+    symbols.forEach((symbol, i) => {
+      const at = (i + 1) * ELF64_SYM_SIZE;
+      dynsym.writeUInt32LE(nameOffsets[i], at);
+      dynsym.writeUInt8(0x12, at + 4); // STB_GLOBAL | STT_FUNC
+      dynsym.writeUInt16LE(symbol.defined ? 1 : 0, at + 6);
+    });
+  }
+
+  const align8 = n => n + ((8 - (n % 8)) % 8);
+  const dynstrOffset = ELF64_SHDR_SIZE;
+  const dynsymOffset = align8(dynstrOffset + dynstr.length);
+  const shoff = align8(dynsymOffset + dynsym.length);
+  const sectionCount = omitDynsym ? 2 : 3;
+
+  const header = Buffer.alloc(ELF64_SHDR_SIZE);
+  header.writeUInt32BE(0x7f454c46, 0);
+  header.writeUInt8(2, 4); // ELFCLASS64
+  header.writeUInt8(1, 5); // ELFDATA2LSB
+  header.writeUInt8(1, 6); // EV_CURRENT
+  header.writeUInt16LE(3, 16); // ET_DYN
+  header.writeUInt16LE(0xb7, 18); // EM_AARCH64
+  header.writeUInt32LE(1, 20);
+  header.writeBigUInt64LE(BigInt(shoff), 0x28);
+  header.writeUInt16LE(ELF64_SHDR_SIZE, 52);
+  header.writeUInt16LE(ELF64_SHDR_SIZE, 0x3a);
+  header.writeUInt16LE(sectionCount, 0x3c);
+
+  const sections = Buffer.alloc(sectionCount * ELF64_SHDR_SIZE);
+  const writeSection = (index, {type, offset, size, link = 0, entsize = 0}) => {
+    const at = index * ELF64_SHDR_SIZE;
+    sections.writeUInt32LE(type, at + 4);
+    sections.writeBigUInt64LE(BigInt(offset), at + 24);
+    sections.writeBigUInt64LE(BigInt(size), at + 32);
+    sections.writeUInt32LE(link, at + 40);
+    sections.writeBigUInt64LE(BigInt(entsize), at + 56);
+  };
+  writeSection(1, {type: 3, offset: dynstrOffset, size: dynstr.length}); // SHT_STRTAB
+  if (!omitDynsym) {
+    writeSection(2, {
+      type: 11, // SHT_DYNSYM
+      offset: dynsymOffset,
+      size: dynsym.length,
+      link: 1,
+      entsize: ELF64_SYM_SIZE,
+    });
+  }
+
+  const out = Buffer.alloc(shoff + sections.length);
+  header.copy(out, 0);
+  dynstr.copy(out, dynstrOffset);
+  dynsym.copy(out, dynsymOffset);
+  sections.copy(out, shoff);
+  return out;
+}
+
+const REQUIRED_HEXAGON_SYMBOLS = [
+  'lm_ggml_backend_hexagon_reg',
+  'lm_ggml_backend_is_hexagon',
+];
+
+/**
+ * A `.dynsym` with `matchCount` entries containing "hexagon", of which the two
+ * required ones are defined unless `withRequired` is false, plus non-matching
+ * noise so the pattern count is not simply the symbol count.
+ */
+function hexagonDynsym(matchCount, {withRequired = true} = {}) {
+  const symbols = [];
+  if (withRequired) {
+    for (const name of REQUIRED_HEXAGON_SYMBOLS) {
+      symbols.push({name, defined: true});
+    }
+  }
+  while (symbols.length < matchCount) {
+    symbols.push({
+      name: `lm_ggml_hexagon_session_${symbols.length}`,
+      defined: true,
+    });
+  }
+  symbols.push({name: 'lm_ggml_backend_reg_count', defined: true});
+  symbols.push({name: 'malloc', defined: false});
+  return buildElf(symbols);
+}
+
+const PLAIN_ELF = buildElf([
+  {name: 'lm_ggml_backend_reg_count', defined: true},
+  {name: 'malloc', defined: false},
+]);
+
+/** The entry map of an artifact that satisfies the committed manifest. */
+function conformingEntries(prefix = '') {
+  const entries = {};
+  for (const abi of manifest.abis) {
+    for (const lib of abi.requiredLibs) {
+      entries[`${prefix}lib/${abi.abi}/${lib}`] = PLAIN_ELF;
+    }
+    for (const asset of abi.requiredAssets) {
+      entries[`${prefix}${asset}`] = Buffer.from('dsp');
+    }
+    for (const rule of abi.requiredSymbols) {
+      entries[`${prefix}lib/${abi.abi}/${rule.lib}`] = hexagonDynsym(
+        rule.expectedMatchCount.count,
+      );
+    }
+  }
+  return entries;
+}
+
+let workspace;
+
+beforeEach(() => {
+  workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-android-payload-'));
+});
+
+afterEach(() => {
+  fs.rmSync(workspace, {recursive: true, force: true});
+});
+
+function writeArchive(name, entries) {
+  const staging = fs.mkdtempSync(path.join(workspace, 'staging-'));
+  const roots = new Set();
+  for (const [entry, contents] of Object.entries(entries)) {
+    const target = path.join(staging, entry);
+    fs.mkdirSync(path.dirname(target), {recursive: true});
+    fs.writeFileSync(target, contents);
+    roots.add(entry.split('/')[0]);
+  }
+  const archive = path.join(workspace, name);
+  execFileSync('zip', ['-q', '-r', '-X', archive, ...roots], {cwd: staging});
+  return archive;
+}
+
+function runGate(args) {
+  try {
+    return {
+      status: 0,
+      output: execFileSync('node', [SCRIPT_PATH, ...args], {encoding: 'utf-8'}),
+    };
+  } catch (err) {
+    return {
+      status: err.status,
+      output: `${err.stdout || ''}${err.stderr || ''}`,
+    };
+  }
+}
+
+function gateApk(entries, extraArgs = []) {
+  return runGate([
+    '--apk',
+    writeArchive('app-prod-release.apk', entries),
+    ...extraArgs,
+  ]);
+}
+
+describe('the variant allowlist', () => {
+  // The allowlist gradle compiles and the payload the gate demands must come
+  // from the same declaration, or a build can satisfy one and not the other.
+  it('is derived from the manifest, bare variant names, wrappers dropped', () => {
+    const {status, output} = runGate(['--print-variants']);
+    expect(status).toBe(0);
+    expect(output.trim()).toBe(
+      'rnllama,rnllama_v8,rnllama_v8_2,rnllama_v8_2_dotprod,rnllama_v8_2_dotprod_i8mm,rnllama_v8_2_dotprod_i8mm_hexagon_opencl,rnllama_x86_64',
+    );
+  });
+
+  it('needs no artifact, so it is safe to call before anything is built', () => {
+    expect(runGate(['--print-variants']).status).toBe(0);
+  });
+});
+
+describe('a conforming artifact', () => {
+  it('passes', () => {
+    const {status, output} = gateApk(conformingEntries());
+    expect(status).toBe(0);
+    expect(output).toContain('PASS');
+    expect(output).toContain('extra rnllama libraries: none');
+  });
+
+  it('passes as an app bundle, whose entries sit under base/', () => {
+    const archive = writeArchive(
+      'app-prod-release.aab',
+      conformingEntries('base/'),
+    );
+    const {status, output} = runGate(['--aab', archive]);
+    expect(status).toBe(0);
+    expect(output).toContain('PASS');
+  });
+
+  it('fails as an app bundle if checked without the base/ prefix', () => {
+    const archive = writeArchive('app-prod-release.aab', conformingEntries());
+    expect(runGate(['--aab', archive]).status).toBe(1);
+  });
+
+  it('writes the same report to --report', () => {
+    const reportPath = path.join(workspace, 'payload-report.txt');
+    const {output} = gateApk(conformingEntries(), ['--report', reportPath]);
+    expect(fs.readFileSync(reportPath, 'utf-8')).toBe(output);
+  });
+});
+
+describe('the Hexagon backend', () => {
+  it('fails when the required symbols are absent, naming both', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      hexagonDynsym(0, {
+        withRequired: false,
+      });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    for (const name of REQUIRED_HEXAGON_SYMBOLS) {
+      expect(output).toContain(`MISSING  ${name}`);
+    }
+    expect(output).toContain('does not export');
+    expect(output).toContain('issues/858');
+  });
+
+  it('fails when a required symbol is only an undefined import', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      buildElf([
+        {name: 'lm_ggml_backend_hexagon_reg', defined: false},
+        {name: 'lm_ggml_backend_is_hexagon', defined: true},
+      ]);
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('MISSING  lm_ggml_backend_hexagon_reg');
+  });
+
+  it('fails on a changed symbol count, and says to re-declare it', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      hexagonDynsym(18);
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('18 .dynsym entries matching "hexagon"');
+    expect(output).toContain('re-declare');
+    expect(output).toContain('expectedMatchCount as 18');
+  });
+});
+
+describe('the declared payload', () => {
+  it('fails when a required library is missing, naming the entry', () => {
+    const entries = conformingEntries();
+    delete entries['lib/arm64-v8a/librnllama_v8_2_dotprod.so'];
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain(
+      'MISSING  lib/arm64-v8a/librnllama_v8_2_dotprod.so',
+    );
+    expect(output).toContain('ORG_GRADLE_PROJECT_rnllamaVariants');
+  });
+
+  it('fails when a DSP asset is missing', () => {
+    const entries = conformingEntries();
+    delete entries['assets/ggml-hexagon/libggml-htp-v73.so'];
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('MISSING  assets/ggml-hexagon/libggml-htp-v73.so');
+  });
+
+  it('permits and reports extra variants, so forcing prebuilts still passes', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_i8mm.so'] = PLAIN_ELF;
+    entries['lib/arm64-v8a/librnllama_jni_v8_2_i8mm.so'] = PLAIN_ELF;
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(0);
+    expect(output).toContain(
+      'extra rnllama libraries: librnllama_jni_v8_2_i8mm.so, librnllama_v8_2_i8mm.so',
+    );
+  });
+});
+
+describe('a check that cannot run', () => {
+  // Every case below must fail. A gate that passes because it read nothing is
+  // worse than no gate: it reports the artifact as sound on no evidence.
+  it('fails when the artifact is not a readable archive', () => {
+    const archive = path.join(workspace, 'truncated.apk');
+    fs.writeFileSync(archive, Buffer.from('PK truncated'));
+    const {status, output} = runGate(['--apk', archive]);
+    expect(status).toBe(1);
+    expect(output).toContain('proven nothing about it');
+  });
+
+  it('fails when a required library extracts as zero bytes', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      Buffer.alloc(0);
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('UNREADABLE');
+    expect(output).toContain('proven nothing about it');
+  });
+
+  it('fails when the library has no .dynsym section', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      buildElf([{name: 'lm_ggml_backend_hexagon_reg', defined: true}], {
+        omitDynsym: true,
+      });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('no .dynsym section');
+  });
+
+  it('fails when .dynsym is present but empty', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      buildElf([], {
+        emptyDynsym: true,
+      });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('.dynsym is empty');
+  });
+
+  it('fails when the library is not an ELF object at all', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      Buffer.alloc(256, 0x41);
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('not an ELF object');
+  });
+
+  it('fails when asked to check nothing', () => {
+    expect(runGate([]).status).toBe(1);
+  });
+
+  it('fails when the manifest declares no ABIs', () => {
+    const emptyManifest = path.join(workspace, 'empty-manifest.json');
+    fs.writeFileSync(emptyManifest, JSON.stringify({abis: []}));
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      emptyManifest,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('declares no ABIs');
+  });
+});

--- a/scripts/android-payload-manifest.json
+++ b/scripts/android-payload-manifest.json
@@ -1,0 +1,57 @@
+{
+  "$comment": "What a shipped Android artifact must contain. Read by scripts/verify-android-payload.js. See https://github.com/a-ghorbani/pocketpal-ai/issues/858 for why the Hexagon symbol rules exist.",
+  "matching": {
+    "countRule": "expectedMatchCount counts every .dynsym entry whose name contains the pattern, case-insensitively, including undefined imports. The declared numbers were measured with `llvm-nm -D <lib> | grep -ci <pattern>`, so the reader must match that convention or the two are calibrated differently.",
+    "mustExportRule": "mustExport names must be DEFINED in .dynsym (st_shndx != SHN_UNDEF). An undefined import proves only that something references the symbol, not that it was compiled in.",
+    "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants."
+  },
+  "abis": [
+    {
+      "abi": "arm64-v8a",
+      "requiredLibs": [
+        "librnllama.so",
+        "librnllama_jni.so",
+        "librnllama_v8.so",
+        "librnllama_jni_v8.so",
+        "librnllama_v8_2.so",
+        "librnllama_jni_v8_2.so",
+        "librnllama_v8_2_dotprod.so",
+        "librnllama_jni_v8_2_dotprod.so",
+        "librnllama_v8_2_dotprod_i8mm.so",
+        "librnllama_jni_v8_2_dotprod_i8mm.so",
+        "librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so",
+        "librnllama_jni_v8_2_dotprod_i8mm_hexagon_opencl.so"
+      ],
+      "requiredAssets": [
+        "assets/ggml-hexagon/libggml-htp-v73.so",
+        "assets/ggml-hexagon/libggml-htp-v75.so",
+        "assets/ggml-hexagon/libggml-htp-v79.so",
+        "assets/ggml-hexagon/libggml-htp-v81.so"
+      ],
+      "requiredSymbols": [
+        {
+          "lib": "librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so",
+          "mustExport": [
+            "lm_ggml_backend_hexagon_reg",
+            "lm_ggml_backend_is_hexagon"
+          ],
+          "expectedMatchCount": {
+            "pattern": "hexagon",
+            "count": 16
+          }
+        }
+      ]
+    },
+    {
+      "abi": "x86_64",
+      "requiredLibs": [
+        "librnllama.so",
+        "librnllama_jni.so",
+        "librnllama_x86_64.so",
+        "librnllama_jni_x86_64.so"
+      ],
+      "requiredAssets": [],
+      "requiredSymbols": []
+    }
+  ]
+}

--- a/scripts/android-payload-manifest.json
+++ b/scripts/android-payload-manifest.json
@@ -3,7 +3,8 @@
   "matching": {
     "countRule": "expectedMatchCount counts every .dynsym entry whose name contains the pattern, case-insensitively, including undefined imports. The declared numbers were measured with `llvm-nm -D <lib> | grep -ci <pattern>`, so the reader must match that convention or the two are calibrated differently.",
     "mustExportRule": "mustExport names must be DEFINED in .dynsym (st_shndx != SHN_UNDEF). An undefined import proves only that something references the symbol, not that it was compiled in.",
-    "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants."
+    "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants.",
+    "assetScopeRule": "requiredAssets paths are NOT ABI-scoped: Android packages assets/ once per artifact, not per ABI (verified against a built APK). They are declared under the ABI whose libraries need them, which is what ties the accelerator floor to the right ABI, but the path is resolved from the artifact root."
   },
   "abis": [
     {

--- a/scripts/android-payload-manifest.json
+++ b/scripts/android-payload-manifest.json
@@ -4,7 +4,8 @@
     "countRule": "expectedMatchCount counts every .dynsym entry whose name contains the pattern, case-insensitively, including undefined imports. The declared numbers were measured with `llvm-nm -D <lib> | grep -ci <pattern>`, so the reader must match that convention or the two are calibrated differently.",
     "mustExportRule": "mustExport names must be DEFINED in .dynsym (st_shndx != SHN_UNDEF). An undefined import proves only that something references the symbol, not that it was compiled in.",
     "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants.",
-    "assetScopeRule": "requiredAssets paths are NOT ABI-scoped: Android packages assets/ once per artifact, not per ABI (verified against a built APK). They are declared under the ABI whose libraries need them, which is what ties the accelerator floor to the right ABI, but the path is resolved from the artifact root."
+    "assetScopeRule": "requiredAssets paths are NOT ABI-scoped: Android packages assets/ once per artifact, not per ABI (verified against a built APK). They are declared under the ABI whose libraries need them, which is what ties the accelerator floor to the right ABI, but the path is resolved from the artifact root.",
+    "assetFormatRule": "An ABI declaring requiredAssets must also declare requiredAssetElfMachine, and every required asset is checked to be an ELF object for that machine. Presence by filename is not enough: a file of the right name that is not a DSP library produces the same user-visible outcome as a missing backend, with a passing report. 164 is EM_QDSP6."
   },
   "abis": [
     {
@@ -41,7 +42,8 @@
             "count": 16
           }
         }
-      ]
+      ],
+      "requiredAssetElfMachine": 164
     },
     {
       "abi": "x86_64",

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -135,6 +135,65 @@ function assertRuleDemandsSomething(rule, manifestPath) {
   }
 }
 
+function refuseAbi(abi, manifestPath, why) {
+  throw new Error(
+    `${manifestPath} declares ${why} for ${abi.abi || '(unnamed ABI)'}.`,
+  );
+}
+
+/** Shape and the one floor every ABI has, accelerator or not. */
+function assertAbiStructure(abi, manifestPath) {
+  if (
+    !abi.abi ||
+    !Array.isArray(abi.requiredLibs) ||
+    abi.requiredLibs.length === 0
+  ) {
+    refuseAbi(abi, manifestPath, 'no required libraries');
+  }
+  if (abi.requiredAssets !== undefined && !Array.isArray(abi.requiredAssets)) {
+    refuseAbi(abi, manifestPath, 'a requiredAssets that is not a list');
+  }
+  if (
+    abi.requiredSymbols !== undefined &&
+    !Array.isArray(abi.requiredSymbols)
+  ) {
+    refuseAbi(abi, manifestPath, 'a requiredSymbols that is not a list');
+  }
+  for (const rule of abi.requiredSymbols || []) {
+    assertRuleDemandsSomething(rule, manifestPath);
+  }
+}
+
+/**
+ * An ABI that carries an accelerator variant has to demand the things that
+ * make it work. Both lists degrade the same silent way: emptying one is the
+ * cheapest edit that unblocks a build, the rule simply stops being checked,
+ * and nothing else in the manifest covers it.
+ *
+ * Conditional because an ABI without an accelerator legitimately declares
+ * neither. The `_hexagon` test mirrors the name convention llama.rn's own
+ * CMake uses to decide which variant gets the backend; were upstream to rename
+ * it, the ladder-coverage test fails first.
+ */
+function assertAcceleratorFloors(abi, manifestPath) {
+  if (!abi.requiredLibs.some(lib => /_hexagon/.test(lib))) {
+    return;
+  }
+  if ((abi.requiredSymbols || []).length === 0) {
+    refuseAbi(abi, manifestPath, 'an accelerator library but no symbol rule');
+  }
+  // The DSP libraries are extracted as a set at runtime and the backend is
+  // disabled outright if any one is missing, so a compiled-in backend with no
+  // assets is dead on the device.
+  if ((abi.requiredAssets || []).length === 0) {
+    refuseAbi(
+      abi,
+      manifestPath,
+      'an accelerator library but no required assets',
+    );
+  }
+}
+
 function loadManifest(manifestPath) {
   let manifest;
   try {
@@ -152,19 +211,10 @@ function loadManifest(manifestPath) {
     );
   }
   for (const abi of manifest.abis) {
-    if (
-      !abi.abi ||
-      !Array.isArray(abi.requiredLibs) ||
-      abi.requiredLibs.length === 0
-    ) {
-      throw new Error(
-        `${manifestPath} declares no required libraries for ${abi.abi || '(unnamed ABI)'}.`,
-      );
-    }
-    for (const rule of abi.requiredSymbols || []) {
-      assertRuleDemandsSomething(rule, manifestPath);
-    }
+    assertAbiStructure(abi, manifestPath);
   }
+  // Between the two per-ABI passes so the broadest weakening gets the broadest
+  // message instead of being reported as one ABI's problem.
   const symbolRules = manifest.abis.reduce(
     (total, abi) => total + (abi.requiredSymbols || []).length,
     0,
@@ -173,6 +223,9 @@ function loadManifest(manifestPath) {
     throw new Error(
       `${manifestPath} declares no symbol rules, so no backend would be checked.`,
     );
+  }
+  for (const abi of manifest.abis) {
+    assertAcceleratorFloors(abi, manifestPath);
   }
   return manifest;
 }
@@ -424,11 +477,12 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
     const missingAssets = (abi.requiredAssets || []).filter(
       asset => !entries.has(`${prefix}${asset}`),
     );
-    if ((abi.requiredAssets || []).length > 0) {
-      report.push(
-        `    assets: ${abi.requiredAssets.length - missingAssets.length}/${abi.requiredAssets.length} present`,
-      );
-    }
+    // Printed even when nothing is declared: the summary line claims assets
+    // were checked, so a manifest that declares none has to be visible here.
+    const requiredAssets = abi.requiredAssets || [];
+    report.push(
+      `    assets: ${requiredAssets.length - missingAssets.length}/${requiredAssets.length} present`,
+    );
     for (const asset of missingAssets) {
       report.push(`      MISSING  ${prefix}${asset}`);
       fail(

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -49,7 +49,7 @@ function usage() {
 }
 
 function parseArgs(argv) {
-  const args = {manifest: DEFAULT_MANIFEST};
+  const args = {};
   for (let i = 0; i < argv.length; i++) {
     const flag = argv[i];
     switch (flag) {
@@ -63,6 +63,11 @@ function parseArgs(argv) {
         const value = argv[++i];
         if (!value || value.startsWith('--')) {
           throw new Error(`${flag} needs a path.\n\n${usage()}`);
+        }
+        // Refused rather than last-one-wins: a repeated flag would otherwise
+        // check one artifact while reporting on the whole invocation.
+        if (args[flag.slice(2)]) {
+          throw new Error(`${flag} was given twice.\n\n${usage()}`);
         }
         args[flag.slice(2)] = value;
         break;
@@ -81,6 +86,7 @@ function parseArgs(argv) {
       `--print-variants does not check an artifact; do not pass it with --apk/--aab.\n\n${usage()}`,
     );
   }
+  args.manifest = args.manifest || DEFAULT_MANIFEST;
   return args;
 }
 
@@ -109,6 +115,19 @@ function loadManifest(manifestPath) {
       throw new Error(
         `${manifestPath} declares no required libraries for ${abi.abi || '(unnamed ABI)'}.`,
       );
+    }
+    // A rule naming a library but asserting nothing about it is the shape a
+    // weakening edit takes — emptying mustExport during an upgrade rather than
+    // re-declaring it. The library is still present, so nothing else fails.
+    for (const rule of abi.requiredSymbols || []) {
+      if (
+        !rule.lib ||
+        ((rule.mustExport || []).length === 0 && !rule.expectedMatchCount)
+      ) {
+        throw new Error(
+          `${manifestPath} declares a symbol rule for ${rule.lib || '(unnamed library)'} that asserts nothing, so its backend would not be checked.`,
+        );
+      }
     }
   }
   const symbolRules = manifest.abis.reduce(

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+/**
+ * verify-android-payload.js — checks a built Android APK/AAB against
+ * scripts/android-payload-manifest.json before it can be published.
+ *
+ * Usage:
+ *   node scripts/verify-android-payload.js --apk <path> [--aab <path>] [--report <path>]
+ *   node scripts/verify-android-payload.js --print-variants
+ *
+ * `--print-variants` reads only the manifest and writes the gradle variant
+ * allowlist to stdout, so it is safe inside `$(...)`.
+ *
+ * Two things here are deliberate and would otherwise look arbitrary:
+ *
+ * - Backend presence is decided from `.dynsym`, never from `strings` or file
+ *   size. `strings` false-positives on unrelated `codec_*_ht` symbols, and two
+ *   builds that differ in whether the Hexagon backend is compiled in have
+ *   identical `opencl` string counts. `.dynsym` also survives stripping.
+ * - The ELF reader is in-process rather than a call out to `readelf`/`llvm-nm`.
+ *   macOS ships no `readelf`, and the NDK's `llvm-nm` sits at a host-specific
+ *   path, so shelling out would make the check unrunnable on exactly the
+ *   machines that need to run it locally.
+ *
+ * Exit 0 when every declared requirement holds, non-zero otherwise —
+ * including when the check could not read what it was asked to judge.
+ *
+ * Pattern mirrors scripts/verify-fonts.js.
+ */
+const {execFileSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_MANIFEST = path.join(__dirname, 'android-payload-manifest.json');
+const ISSUE_URL = 'https://github.com/a-ghorbani/pocketpal-ai/issues/858';
+
+const SHT_DYNSYM = 11;
+const SHN_UNDEF = 0;
+const ELF64_SYM_SIZE = 24;
+const ELF64_SHDR_SIZE = 64;
+
+function usage() {
+  return [
+    'Usage:',
+    '  node scripts/verify-android-payload.js --apk <path> [--aab <path>] [--report <path>]',
+    '  node scripts/verify-android-payload.js --print-variants',
+    '',
+    'At least one of --apk / --aab is required unless --print-variants is given.',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const args = {manifest: DEFAULT_MANIFEST};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    switch (flag) {
+      case '--print-variants':
+        args.printVariants = true;
+        break;
+      case '--apk':
+      case '--aab':
+      case '--manifest':
+      case '--report': {
+        const value = argv[++i];
+        if (!value || value.startsWith('--')) {
+          throw new Error(`${flag} needs a path.\n\n${usage()}`);
+        }
+        args[flag.slice(2)] = value;
+        break;
+      }
+      default:
+        throw new Error(`Unknown argument: ${flag}\n\n${usage()}`);
+    }
+  }
+  if (!args.printVariants && !args.apk && !args.aab) {
+    throw new Error(`Nothing to check.\n\n${usage()}`);
+  }
+  return args;
+}
+
+function loadManifest(manifestPath) {
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch (err) {
+    throw new Error(
+      `Could not read the manifest ${manifestPath}: ${err.message}`,
+    );
+  }
+  // A manifest that declares nothing would let every artifact pass, which is
+  // the failure mode this check exists to prevent.
+  if (!Array.isArray(manifest.abis) || manifest.abis.length === 0) {
+    throw new Error(
+      `${manifestPath} declares no ABIs, so it would pass any artifact.`,
+    );
+  }
+  for (const abi of manifest.abis) {
+    if (
+      !abi.abi ||
+      !Array.isArray(abi.requiredLibs) ||
+      abi.requiredLibs.length === 0
+    ) {
+      throw new Error(
+        `${manifestPath} declares no required libraries for ${abi.abi || '(unnamed ABI)'}.`,
+      );
+    }
+  }
+  const symbolRules = manifest.abis.reduce(
+    (total, abi) => total + (abi.requiredSymbols || []).length,
+    0,
+  );
+  if (symbolRules === 0) {
+    throw new Error(
+      `${manifestPath} declares no symbol rules, so no backend would be checked.`,
+    );
+  }
+  return manifest;
+}
+
+function variantsFromManifest(manifest) {
+  const variants = [];
+  for (const abi of manifest.abis) {
+    for (const lib of abi.requiredLibs) {
+      if (lib.startsWith('librnllama_jni')) {
+        continue;
+      }
+      const variant = lib.replace(/^lib/, '').replace(/\.so$/, '');
+      if (!variants.includes(variant)) {
+        variants.push(variant);
+      }
+    }
+  }
+  return variants;
+}
+
+function listZipEntries(archive) {
+  let out;
+  try {
+    out = execFileSync('unzip', ['-Z1', archive], {
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err) {
+    throw new Error(`could not list ${archive}: ${err.message.trim()}`);
+  }
+  const entries = out.split('\n').filter(Boolean);
+  if (entries.length === 0) {
+    throw new Error(`${archive} contains no entries`);
+  }
+  return entries;
+}
+
+function readZipEntry(archive, entry) {
+  let buf;
+  try {
+    buf = execFileSync('unzip', ['-p', archive, entry], {
+      maxBuffer: 512 * 1024 * 1024,
+    });
+  } catch (err) {
+    throw new Error(`could not extract ${entry}: ${err.message.trim()}`);
+  }
+  if (buf.length === 0) {
+    throw new Error(`${entry} extracted as zero bytes`);
+  }
+  return buf;
+}
+
+function readCString(buf, offset) {
+  if (offset < 0 || offset >= buf.length) {
+    throw new Error('a .dynsym name points outside the file');
+  }
+  const end = buf.indexOf(0, offset);
+  return buf.toString('utf-8', offset, end === -1 ? buf.length : end);
+}
+
+/**
+ * Every `.dynsym` entry, in file order, skipping the reserved null entry —
+ * the same set `llvm-nm -D` prints, which is what the manifest counts were
+ * calibrated against.
+ */
+function readDynsym(buf) {
+  if (buf.length < ELF64_SHDR_SIZE) {
+    throw new Error('file is too short to be an ELF object');
+  }
+  if (buf.readUInt32BE(0) !== 0x7f454c46) {
+    throw new Error('file is not an ELF object');
+  }
+  if (buf[4] !== 2 || buf[5] !== 1) {
+    throw new Error('file is not a little-endian 64-bit ELF object');
+  }
+
+  const shoff = Number(buf.readBigUInt64LE(0x28));
+  const shentsize = buf.readUInt16LE(0x3a);
+  const shnum = buf.readUInt16LE(0x3c);
+  if (shoff === 0 || shnum === 0) {
+    throw new Error('ELF section headers are absent');
+  }
+  if (shentsize < ELF64_SHDR_SIZE || shoff + shnum * shentsize > buf.length) {
+    throw new Error('ELF section header table is malformed or truncated');
+  }
+
+  const sections = [];
+  for (let i = 0; i < shnum; i++) {
+    const at = shoff + i * shentsize;
+    sections.push({
+      type: buf.readUInt32LE(at + 4),
+      offset: Number(buf.readBigUInt64LE(at + 24)),
+      size: Number(buf.readBigUInt64LE(at + 32)),
+      link: buf.readUInt32LE(at + 40),
+      entsize: Number(buf.readBigUInt64LE(at + 56)),
+    });
+  }
+
+  const dynsym = sections.find(section => section.type === SHT_DYNSYM);
+  if (!dynsym) {
+    throw new Error('the file has no .dynsym section');
+  }
+  if (dynsym.entsize !== ELF64_SYM_SIZE) {
+    throw new Error(`.dynsym has an unexpected entry size (${dynsym.entsize})`);
+  }
+  if (dynsym.offset + dynsym.size > buf.length) {
+    throw new Error('.dynsym runs past the end of the file');
+  }
+  const strtab = sections[dynsym.link];
+  if (!strtab) {
+    throw new Error(
+      '.dynsym points at a string table the file does not contain',
+    );
+  }
+
+  const count = Math.floor(dynsym.size / dynsym.entsize);
+  if (count < 2) {
+    throw new Error('.dynsym is empty');
+  }
+
+  const symbols = [];
+  for (let i = 1; i < count; i++) {
+    const at = dynsym.offset + i * dynsym.entsize;
+    symbols.push({
+      name: readCString(buf, strtab.offset + buf.readUInt32LE(at)),
+      defined: buf.readUInt16LE(at + 6) !== SHN_UNDEF,
+    });
+  }
+  return symbols;
+}
+
+function checkSymbolRule({rule, archive, artifactName, entry, report, fail}) {
+  let symbols;
+  try {
+    symbols = readDynsym(readZipEntry(archive, entry));
+  } catch (err) {
+    report.push(`    ${rule.lib}: UNREADABLE — ${err.message}`);
+    fail(
+      [
+        `could not read the exported symbols of ${entry} in ${artifactName}: ${err.message}.`,
+        'The payload check could not run, so it reports failure rather than success —',
+        'a check that cannot read the artifact has proven nothing about it.',
+      ].join('\n      '),
+    );
+    return;
+  }
+
+  report.push(`    ${rule.lib}: ${symbols.length} .dynsym entries`);
+
+  const missing = (rule.mustExport || []).filter(
+    name => !symbols.some(symbol => symbol.name === name && symbol.defined),
+  );
+  for (const name of rule.mustExport || []) {
+    report.push(
+      `      ${missing.includes(name) ? 'MISSING' : 'present'}  ${name}`,
+    );
+  }
+  if (missing.length > 0) {
+    fail(
+      [
+        `${entry} in ${artifactName} does not export ${missing.join(', ')}.`,
+        'The Hexagon (NPU) backend was not compiled into this build, so Snapdragon devices',
+        'will fall back to the CPU. Point HEXAGON_SDK_ROOT and HEXAGON_TOOLS_ROOT at an SDK',
+        'containing ipc/fastrpc/remote/ship/android_aarch64/libcdsprpc.so and rebuild.',
+        `Background: ${ISSUE_URL}`,
+      ].join('\n      '),
+    );
+  }
+
+  const expected = rule.expectedMatchCount;
+  if (!expected) {
+    return;
+  }
+  const pattern = expected.pattern.toLowerCase();
+  const matched = symbols.filter(symbol =>
+    symbol.name.toLowerCase().includes(pattern),
+  ).length;
+  report.push(
+    `      ${matched} .dynsym entries matching "${expected.pattern}" (declared ${expected.count})`,
+  );
+  if (matched !== expected.count && missing.length === 0) {
+    fail(
+      [
+        `${entry} in ${artifactName} has ${matched} .dynsym entries matching "${expected.pattern}";`,
+        `scripts/android-payload-manifest.json declares ${expected.count}.`,
+        'The required symbols are all present, so the backend is compiled in — this is a drift',
+        'tripwire, not a breakage. If the change is expected (a llama.rn upgrade, say), re-declare',
+        `expectedMatchCount as ${matched} in the same pull request so the diff is reviewed.`,
+      ].join('\n      '),
+    );
+  }
+}
+
+function checkArtifact({archive, kind, manifest, report, failures}) {
+  const artifactName = path.basename(archive);
+  const prefix = kind === 'aab' ? 'base/' : '';
+  const fail = message => failures.push(`FAIL: ${message}`);
+
+  report.push(`artifact: ${archive} (${kind})`);
+
+  let entries;
+  try {
+    entries = new Set(listZipEntries(archive));
+  } catch (err) {
+    report.push(`  UNREADABLE — ${err.message}`);
+    fail(
+      [
+        `${err.message}.`,
+        'The payload check could not run, so it reports failure rather than success —',
+        'a check that cannot read the artifact has proven nothing about it.',
+      ].join('\n      '),
+    );
+    return;
+  }
+
+  for (const abi of manifest.abis) {
+    report.push(`  ${abi.abi}`);
+
+    const missingLibs = [];
+    for (const lib of abi.requiredLibs) {
+      const entry = `${prefix}lib/${abi.abi}/${lib}`;
+      if (!entries.has(entry)) {
+        missingLibs.push(entry);
+      }
+    }
+    report.push(
+      `    libraries: ${abi.requiredLibs.length - missingLibs.length}/${abi.requiredLibs.length} present`,
+    );
+    for (const entry of missingLibs) {
+      report.push(`      MISSING  ${entry}`);
+      fail(
+        [
+          `${artifactName} is missing ${entry}.`,
+          'The build did not produce every library the manifest requires. If the variant allowlist',
+          '(ORG_GRADLE_PROJECT_rnllamaVariants) was narrowed, widen it to match the manifest; if the',
+          'manifest is what changed, update scripts/android-payload-manifest.json in the same pull request.',
+        ].join('\n      '),
+      );
+    }
+
+    const missingAssets = (abi.requiredAssets || []).filter(
+      asset => !entries.has(`${prefix}${asset}`),
+    );
+    if ((abi.requiredAssets || []).length > 0) {
+      report.push(
+        `    assets: ${abi.requiredAssets.length - missingAssets.length}/${abi.requiredAssets.length} present`,
+      );
+    }
+    for (const asset of missingAssets) {
+      report.push(`      MISSING  ${prefix}${asset}`);
+      fail(
+        [
+          `${artifactName} is missing ${prefix}${asset}.`,
+          'The Hexagon backend cannot run without its DSP libraries. They are synced from',
+          "node_modules/llama.rn/bin/arm64-v8a by llama.rn's syncRNLlamaHtpAssets task —",
+          'check that the dependency installed completely.',
+        ].join('\n      '),
+      );
+    }
+
+    const extras = [...entries]
+      .filter(entry => entry.startsWith(`${prefix}lib/${abi.abi}/librnllama`))
+      .map(entry => path.basename(entry))
+      .filter(lib => !abi.requiredLibs.includes(lib))
+      .sort();
+    report.push(
+      `    extra rnllama libraries: ${extras.length > 0 ? extras.join(', ') : 'none'}`,
+    );
+
+    for (const rule of abi.requiredSymbols || []) {
+      const entry = `${prefix}lib/${abi.abi}/${rule.lib}`;
+      if (missingLibs.includes(entry)) {
+        continue;
+      }
+      checkSymbolRule({rule, archive, artifactName, entry, report, fail});
+    }
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const manifest = loadManifest(args.manifest);
+
+  if (args.printVariants) {
+    process.stdout.write(`${variantsFromManifest(manifest).join(',')}\n`);
+    return 0;
+  }
+
+  const report = ['Android payload check', `manifest: ${args.manifest}`, ''];
+  const failures = [];
+
+  for (const [flag, kind] of [
+    ['apk', 'apk'],
+    ['aab', 'aab'],
+  ]) {
+    if (args[flag]) {
+      checkArtifact({archive: args[flag], kind, manifest, report, failures});
+      report.push('');
+    }
+  }
+
+  report.push(
+    failures.length === 0
+      ? 'PASS: every declared library, asset and backend symbol is present.'
+      : failures.join('\n\n'),
+  );
+
+  const text = `${report.join('\n')}\n`;
+  process.stdout.write(text);
+  if (args.report) {
+    fs.writeFileSync(args.report, text);
+  }
+  return failures.length === 0 ? 0 : 1;
+}
+
+if (require.main === module) {
+  try {
+    process.exit(main());
+  } catch (err) {
+    console.error(`FAIL: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {readDynsym, variantsFromManifest};

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -90,6 +90,51 @@ function parseArgs(argv) {
   return args;
 }
 
+/**
+ * A symbol rule has to demand that something is *present*. The shape a
+ * weakening edit takes is emptying `mustExport` during a dependency bump
+ * instead of re-declaring it, and the library itself is still there, so no
+ * other rule notices. `expectedMatchCount` only counts as a demand when it
+ * asks for a positive number of matches: `count: 0` asserts the backend is
+ * absent, which is both self-contradictory next to `mustExport` and exactly
+ * the state this check exists to reject.
+ */
+function assertRuleDemandsSomething(rule, manifestPath) {
+  const named = rule.lib || '(unnamed library)';
+  const refuse = why => {
+    throw new Error(
+      `${manifestPath} declares a symbol rule for ${named} that ${why}, so its backend would not be checked.`,
+    );
+  };
+
+  if (!rule.lib) {
+    refuse('names no library');
+  }
+  const mustExport = rule.mustExport || [];
+  if (!Array.isArray(mustExport)) {
+    refuse('has a mustExport that is not a list');
+  }
+
+  const count = rule.expectedMatchCount;
+  if (count !== undefined) {
+    if (
+      typeof count !== 'object' ||
+      count === null ||
+      typeof count.pattern !== 'string' ||
+      count.pattern.length === 0 ||
+      !Number.isInteger(count.count) ||
+      count.count < 0
+    ) {
+      refuse('has a malformed expectedMatchCount');
+    }
+  }
+
+  const demandsPresence = mustExport.length > 0 || (count && count.count > 0);
+  if (!demandsPresence) {
+    refuse('asserts nothing');
+  }
+}
+
 function loadManifest(manifestPath) {
   let manifest;
   try {
@@ -116,18 +161,8 @@ function loadManifest(manifestPath) {
         `${manifestPath} declares no required libraries for ${abi.abi || '(unnamed ABI)'}.`,
       );
     }
-    // A rule naming a library but asserting nothing about it is the shape a
-    // weakening edit takes — emptying mustExport during an upgrade rather than
-    // re-declaring it. The library is still present, so nothing else fails.
     for (const rule of abi.requiredSymbols || []) {
-      if (
-        !rule.lib ||
-        ((rule.mustExport || []).length === 0 && !rule.expectedMatchCount)
-      ) {
-        throw new Error(
-          `${manifestPath} declares a symbol rule for ${rule.lib || '(unnamed library)'} that asserts nothing, so its backend would not be checked.`,
-        );
-      }
+      assertRuleDemandsSomething(rule, manifestPath);
     }
   }
   const symbolRules = manifest.abis.reduce(
@@ -142,7 +177,7 @@ function loadManifest(manifestPath) {
   return manifest;
 }
 
-function variantsFromManifest(manifest) {
+function variantsFromManifest(manifest, manifestPath) {
   const variants = [];
   for (const abi of manifest.abis) {
     for (const lib of abi.requiredLibs) {
@@ -154,6 +189,14 @@ function variantsFromManifest(manifest) {
         variants.push(variant);
       }
     }
+  }
+  // An empty allowlist is not "build everything", it is a workflow that exports
+  // ORG_GRADLE_PROJECT_rnllamaVariants= and an assertion that then greps for a
+  // bare prefix and matches any build.
+  if (variants.length === 0) {
+    throw new Error(
+      `${manifestPath} yields an empty variant allowlist; every required library is a JNI wrapper.`,
+    );
   }
   return variants;
 }
@@ -424,7 +467,9 @@ function main() {
   const manifest = loadManifest(args.manifest);
 
   if (args.printVariants) {
-    process.stdout.write(`${variantsFromManifest(manifest).join(',')}\n`);
+    process.stdout.write(
+      `${variantsFromManifest(manifest, args.manifest).join(',')}\n`,
+    );
     return 0;
   }
 

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -179,8 +179,18 @@ function assertAcceleratorFloors(abi, manifestPath) {
   if (!abi.requiredLibs.some(lib => /_hexagon/.test(lib))) {
     return;
   }
-  if ((abi.requiredSymbols || []).length === 0) {
-    refuseAbi(abi, manifestPath, 'an accelerator library but no symbol rule');
+  // Not merely "a rule", but a rule that looks at the accelerator library. A
+  // rule pointing at librnllama.so and demanding a symbol every build exports
+  // satisfies every other floor, leaves the derived allowlist byte-identical,
+  // and passes an artifact with no backend at all.
+  if (
+    !(abi.requiredSymbols || []).some(rule => /_hexagon/.test(rule.lib || ''))
+  ) {
+    refuseAbi(
+      abi,
+      manifestPath,
+      'an accelerator library but no symbol rule examining it',
+    );
   }
   // The DSP libraries are extracted as a set at runtime and the backend is
   // disabled outright if any one is missing, so a compiled-in backend with no
@@ -243,9 +253,12 @@ function variantsFromManifest(manifest, manifestPath) {
       }
     }
   }
-  // An empty allowlist is not "build everything", it is a workflow that exports
-  // ORG_GRADLE_PROJECT_rnllamaVariants= and an assertion that then greps for a
-  // bare prefix and matches any build.
+  // An empty allowlist silently un-narrows the build: gradle skips passing
+  // -DRNLLAMA_ANDROID_VARIANTS at all for an empty value, and CMake reads the
+  // resulting empty variable as "every variant enabled"
+  // (cmake/rnllama-build-options.cmake). The build-log assertion would also
+  // fail, since gradle prints nothing either — this just fails earlier, and
+  // says which of the two it is.
   if (variants.length === 0) {
     throw new Error(
       `${manifestPath} yields an empty variant allowlist; every required library is a JNI wrapper.`,
@@ -286,12 +299,20 @@ function readZipEntry(archive, entry) {
   return buf;
 }
 
-function readCString(buf, offset) {
-  if (offset < 0 || offset >= buf.length) {
-    throw new Error('a .dynsym name points outside the file');
+/**
+ * Bounded by the string table, not by the file: a `.dynstr` region containing
+ * no NUL would otherwise make every lookup scan to EOF, turning a malformed
+ * artifact into an O(symbols x filesize) scan rather than a prompt failure.
+ */
+function readCString(buf, offset, limit) {
+  if (offset < 0 || offset >= limit || limit > buf.length) {
+    throw new Error('a .dynsym name points outside its string table');
   }
   const end = buf.indexOf(0, offset);
-  return buf.toString('utf-8', offset, end === -1 ? buf.length : end);
+  if (end === -1 || end >= limit) {
+    throw new Error('a .dynsym name is not terminated inside its string table');
+  }
+  return buf.toString('utf-8', offset, end);
 }
 
 /**
@@ -358,7 +379,11 @@ function readDynsym(buf) {
   for (let i = 1; i < count; i++) {
     const at = dynsym.offset + i * dynsym.entsize;
     symbols.push({
-      name: readCString(buf, strtab.offset + buf.readUInt32LE(at)),
+      name: readCString(
+        buf,
+        strtab.offset + buf.readUInt32LE(at),
+        strtab.offset + strtab.size,
+      ),
       defined: buf.readUInt16LE(at + 6) !== SHN_UNDEF,
     });
   }
@@ -447,6 +472,34 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
       ].join('\n      '),
     );
     return;
+  }
+
+  // The manifest says what each declared ABI must contain; it cannot say
+  // anything about an ABI nobody declared. Adding one to abiFilters or
+  // reactNativeArchitectures would otherwise ship a tree this check never
+  // opens — and the variant allowlist is matched by exact name, so that tree
+  // would carry only the generic portable-C pair.
+  const declaredAbis = new Set(manifest.abis.map(entry => entry.abi));
+  const libPrefix = `${prefix}lib/`;
+  const shippedAbis = [
+    ...new Set(
+      [...entries]
+        .filter(entry => entry.startsWith(libPrefix))
+        .map(entry => entry.slice(libPrefix.length).split('/')[0])
+        .filter(Boolean),
+    ),
+  ].sort();
+  report.push(`  ABIs in the artifact: ${shippedAbis.join(', ') || 'none'}`);
+  for (const abi of shippedAbis.filter(name => !declaredAbis.has(name))) {
+    report.push(`    UNDECLARED  ${libPrefix}${abi}/`);
+    fail(
+      [
+        `${artifactName} ships ${libPrefix}${abi}/, which the manifest does not declare.`,
+        'Nothing checked that tree, so its native payload is unverified. Either declare the ABI in',
+        'scripts/android-payload-manifest.json, or drop it from reactNativeArchitectures and the',
+        "app's abiFilters so it is not shipped.",
+      ].join('\n      '),
+    );
   }
 
   for (const abi of manifest.abis) {
@@ -546,11 +599,22 @@ function main() {
       : failures.join('\n\n'),
   );
 
+  // The report file is written before the verdict is printed. It is the
+  // evidence that the check ran, so a pass nobody can audit is not a pass —
+  // and a run that printed PASS and then failed on the write would read, to a
+  // human scanning the log, as a pass.
   const text = `${report.join('\n')}\n`;
-  process.stdout.write(text);
   if (args.report) {
-    fs.writeFileSync(args.report, text);
+    try {
+      fs.writeFileSync(args.report, text);
+    } catch (err) {
+      process.stdout.write(`${report.slice(0, -1).join('\n')}\n`);
+      throw new Error(
+        `could not write the report to ${args.report}: ${err.message}. The check ran, but its evidence could not be recorded.`,
+      );
+    }
   }
+  process.stdout.write(text);
   return failures.length === 0 ? 0 : 1;
 }
 

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -365,7 +365,9 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
       fail(
         [
           `${artifactName} is missing ${prefix}${asset}.`,
-          'The Hexagon backend cannot run without its DSP libraries. They are synced from',
+          'All four DSP libraries are required, not only the one a given device uses:',
+          'RNLlama.java extracts them as a set and disables the Hexagon backend entirely',
+          'if any one is absent. They are synced into the artifact from',
           "node_modules/llama.rn/bin/arm64-v8a by llama.rn's syncRNLlamaHtpAssets task —",
           'check that the dependency installed completely.',
         ].join('\n      '),

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -74,6 +74,13 @@ function parseArgs(argv) {
   if (!args.printVariants && !args.apk && !args.aab) {
     throw new Error(`Nothing to check.\n\n${usage()}`);
   }
+  // Refused rather than ignored: --print-variants returns before reading any
+  // artifact, so accepting both would silently pass whatever it was given.
+  if (args.printVariants && (args.apk || args.aab)) {
+    throw new Error(
+      `--print-variants does not check an artifact; do not pass it with --apk/--aab.\n\n${usage()}`,
+    );
+  }
   return args;
 }
 

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -179,12 +179,18 @@ function assertAcceleratorFloors(abi, manifestPath) {
   if (!abi.requiredLibs.some(lib => /_hexagon/.test(lib))) {
     return;
   }
-  // Not merely "a rule", but a rule that looks at the accelerator library. A
-  // rule pointing at librnllama.so and demanding a symbol every build exports
-  // satisfies every other floor, leaves the derived allowlist byte-identical,
-  // and passes an artifact with no backend at all.
+  // Not merely "a rule", but a rule that looks at the accelerator library
+  // itself. Two near-misses both pass every other floor and both accept an
+  // artifact with no backend: a rule pointing at librnllama.so, and a rule
+  // pointing at the accelerator's own JNI wrapper — whose name also contains
+  // "_hexagon", but which is a thin shim exporting stable Java_* entry points
+  // and none of the backend symbols.
   if (
-    !(abi.requiredSymbols || []).some(rule => /_hexagon/.test(rule.lib || ''))
+    !(abi.requiredSymbols || []).some(
+      rule =>
+        /_hexagon/.test(rule.lib || '') &&
+        !/^librnllama_jni/.test(rule.lib || ''),
+    )
   ) {
     refuseAbi(
       abi,
@@ -200,6 +206,13 @@ function assertAcceleratorFloors(abi, manifestPath) {
       abi,
       manifestPath,
       'an accelerator library but no required assets',
+    );
+  }
+  if (!Number.isInteger(abi.requiredAssetElfMachine)) {
+    refuseAbi(
+      abi,
+      manifestPath,
+      'required assets but no requiredAssetElfMachine to check them against',
     );
   }
 }
@@ -232,6 +245,21 @@ function loadManifest(manifestPath) {
   if (symbolRules === 0) {
     throw new Error(
       `${manifestPath} declares no symbol rules, so no backend would be checked.`,
+    );
+  }
+  // Every accelerator floor below is conditional on an ABI declaring an
+  // accelerator library, so a manifest declaring none would satisfy all of
+  // them vacuously — and the ABI enumeration only compares against what the
+  // manifest names, so a tree carrying no ladder at all would pass.
+  if (
+    !manifest.abis.some(abi =>
+      abi.requiredLibs.some(
+        lib => /_hexagon/.test(lib) && !/^librnllama_jni/.test(lib),
+      ),
+    )
+  ) {
+    throw new Error(
+      `${manifestPath} declares no accelerator library for any ABI, so no backend would be checked.`,
     );
   }
   for (const abi of manifest.abis) {
@@ -297,6 +325,22 @@ function readZipEntry(archive, entry) {
     throw new Error(`${entry} extracted as zero bytes`);
   }
   return buf;
+}
+
+/**
+ * The ELF machine an object targets. Shares the header layout between ELF32
+ * and ELF64 — `e_machine` sits at the same offset in both — so this works for
+ * the DSP libraries, which are ELF32, as well as the arm64 libraries.
+ */
+function readElfMachine(buf) {
+  if (buf.length < 20) {
+    throw new Error('file is too short to be an ELF object');
+  }
+  if (buf.readUInt32BE(0) !== 0x7f454c46) {
+    throw new Error('file is not an ELF object');
+  }
+  const littleEndian = buf[5] === 1;
+  return littleEndian ? buf.readUInt16LE(18) : buf.readUInt16BE(18);
 }
 
 /**
@@ -536,6 +580,42 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
     report.push(
       `    assets: ${requiredAssets.length - missingAssets.length}/${requiredAssets.length} present`,
     );
+    // Presence by filename is not enough: a file of the right name that is not
+    // a DSP library leaves the backend as dead on the device as a missing one,
+    // and would report PASS.
+    for (const asset of (abi.requiredAssets || []).filter(
+      candidate => !missingAssets.includes(candidate),
+    )) {
+      const entry = `${prefix}${asset}`;
+      let machine;
+      try {
+        machine = readElfMachine(readZipEntry(archive, entry));
+      } catch (err) {
+        report.push(`      UNREADABLE  ${entry} — ${err.message}`);
+        fail(
+          [
+            `could not read ${entry} in ${artifactName}: ${err.message}.`,
+            'The payload check could not run, so it reports failure rather than success —',
+            'a check that cannot read the artifact has proven nothing about it.',
+          ].join('\n      '),
+        );
+        continue;
+      }
+      if (machine !== abi.requiredAssetElfMachine) {
+        report.push(
+          `      WRONG MACHINE  ${entry} (e_machine ${machine}, expected ${abi.requiredAssetElfMachine})`,
+        );
+        fail(
+          [
+            `${entry} in ${artifactName} is not a DSP library: its ELF e_machine is ${machine},`,
+            `and the manifest requires ${abi.requiredAssetElfMachine}.`,
+            'A file of the right name that the DSP cannot load disables the Hexagon backend just as',
+            'surely as a missing one. Check that llama.rn shipped real bin/arm64-v8a payloads.',
+          ].join('\n      '),
+        );
+      }
+    }
+
     for (const asset of missingAssets) {
       report.push(`      MISSING  ${prefix}${asset}`);
       fail(


### PR DESCRIPTION
Fixes #858.

> **Scope of the claim:** this restores the backend to the *shipped library*. It does not demonstrate NPU acceleration on a device — `isHexagonSupported()` engages the backend only on Snapdragon 8-series SoCs, and nothing in CI can observe that, since no emulator has a DSP and the check reads `.dynsym` rather than runtime behaviour. Presence is what regressed and presence is what is restored; on-device engagement needs a real 8-series device and should be confirmed after the first release.

Android release builds have shipped **without** the Hexagon/NPU backend since the llama.rn 0.13.0-rc.0 upgrade. That version sets `rnllamaBuildFromSource=true` in its own `android/gradle.properties`, which forces a full from-source Android build and bypasses the prebuilt `jniLibs` upstream compiles *with* the Hexagon SDK. Our CI has no SDK, so gradle prints a warning, CMake prints a warning, and the backend is quietly left out. Nothing anywhere asserted otherwise.

The llama.rn pin is unchanged at `0.13.0-rc.0` — `package.json`, `ios/Podfile.lock` and `yarn.lock` are untouched. This is CI configuration plus one new check.

## What this does

**1. Declares what a shipped Android artifact must contain, and checks it before any upload.**

`scripts/android-payload-manifest.json` lists, per ABI, every `librnllama*` library and DSP asset that must be present, plus the two `.dynsym` symbols that prove the Hexagon backend is compiled in. `scripts/verify-android-payload.js` enforces it and runs between the build and every publish step — including inside the release path, where the fastlane lane had to be split so `upload_to_play_store` could no longer outrun the check.

Presence is read from `.dynsym`, not `strings` or file size: `.dynsym` survives stripping, and the two llama.rn builds that differ in whether the backend exists have *identical* `opencl` string counts. The reader is in-process rather than a shell-out to `readelf`/`llvm-nm`, so the check runs on macOS too — a developer can point it at a local build.

A check that cannot read what it was asked to judge fails, and it validates its own manifest as strictly as it validates the artifact — a symbol rule has to demand that something is *present* before it counts as a rule.

**2. Provisions the Hexagon SDK** on the two Android jobs that produce a shippable artifact, and caches it along with ccache and the configured NDK build tree.

The SDK is **verified by content, not by tag**. `snapdragon-toolchain` is not Qualcomm — it redistributes a trimmed repackaging of the Community Edition, without checksums, and a release tag names a mutable asset. Its headers are compiled into the shipped hexagon library and its `libcdsprpc.so` is linked into it, in a job that also holds the release keystore and Play credentials. So the tarball is checked against a recorded SHA-256, that digest is part of the cache key, and the files the build actually reads are re-verified on **every** run — a cache hit skips the download entirely, so a restored tree would otherwise never be re-checked. Both digests were taken from two independently acquired copies of the SDK that agree on all 56 consumed files.

**3. Declares the build mode and the variant allowlist** in every workflow that builds Android, instead of inheriting whichever value llama.rn happens to ship. The allowlist is derived from the same manifest, so one declaration decides both what gets compiled and what must be present.

**4. Applies all of the above to the e2e build too.** A build used to validate a release may *add* test scaffolding — different flavor, automation bridge, `debuggable`, dummy signing — but it may not *subtract* production capability. `e2e-tests.yml` therefore provisions the SDK, asserts the allowlist reached gradle, and gates the payload before uploading its APK. This matters concretely: e2e runs on real devices and the fleet includes a Snapdragon 8 Gen 2, which is the one SoC family `isHexagonSupported()` accepts — so that job is the only place the NPU path can be exercised before a release, and it was the job building without the backend.

Verified by dispatching that workflow on this branch: the e2e APK's payload came back **identical to the release APK's** — same 12 arm64 libraries, same 4 DSP assets, 6527 `.dynsym` entries, both symbols, 16 hexagon matches, extras none. Cost: **48.9 min**, against 54.3 min for the preceding run of the same branch without the SDK — no measurable increase, the difference being within runner variance.

That gate is the mirror of the existing DCE check: **DCE asserts the prod artifact carries no test code; the payload gate asserts a test artifact carries all the production payload.** Two directions of one invariant, which is why they stay separate rather than being merged — each is blind to what the other catches.

## Evidence

The first two CI runs are a deliberate experiment: the check and the allowlist landed first, and the Hexagon SDK arrived only in the second. To be precise about it, that second commit also brought the disk-headroom step and the three caches, so it is not literally a one-line delta — but none of those can synthesise exported symbols into a binary, so the causal claim about the backend stands.

| | Run 1 — `32401062065` (no SDK) | Run 2 — `32410730113` (SDK added) |
| --- | --- | --- |
| `lm_ggml_backend_hexagon_reg` | **absent** | **present** |
| `lm_ggml_backend_is_hexagon` | **absent** | **present** |
| `.dynsym` entries matching `hexagon` | **0** | **16** (declared 16) |
| `.dynsym` entries read | 6458 | 6527 |
| declared libraries / DSP assets | 12/12, 4/4, 4/4 | 12/12, 4/4, 4/4 |
| extra rnllama variants | none | none |
| `build-android` | **red at the payload check, and nowhere else** | green |
| APK artifact upload | **skipped** | uploaded |

Run 1 is also what rules out the gate passing (or failing) by accident: it parsed 6458 real symbols and found zero matches, rather than reading nothing and reporting zero. Extras being empty in both runs is the evidence that the allowlist declaration actually reached gradle — an allowlist that never arrived would have built all seven arm64 variants, which the check permits as extras.

**Instrument calibration.** The in-process ELF reader was cross-checked against the NDK's `llvm-nm -D | grep -ci hexagon` on both real artifacts, so the reader is verified rather than trusted:

| Artifact | `.dynsym` entries (gate / `llvm-nm`) | `hexagon` matches (gate / `llvm-nm`) |
| --- | --- | --- |
| Shipped broken CI APK (run `32347391124`) | 6458 / 6458 | 0 / 0 |
| This branch, built with the SDK | 6527 / 6527 | 16 / 16 |

Both required symbols are reported `T` (defined) by `llvm-nm` on the passing artifact — which is what `mustExport` requires, since an undefined import would prove nothing.

**Both shipped forms are checked against real artifacts.** The APK and the AAB are packaged differently, and the check resolves paths per form. A genuine `:app:bundleProdRelease` output — not a synthetic re-rooting — was verified to place entries at exactly `base/lib/<abi>/…` and `base/assets/…`, and the check passes on it: 12/12 arm64 libraries, 4/4 DSP assets, 16 hexagon matches. `ci.yml` builds no bundle so it checks only the APK; `release.yml` checks both.

**Build time**, against thresholds committed before the first run:

| | Threshold | Measured |
| --- | --- | --- |
| cold `build-android` (all three new caches miss) | ≤ 75 min | **43.9 min** — run `32410730113` |
| warm `build-android` (all three restore) | ≤ 35 min | **23.2 min** — run `32415207752` |

Run 2 is a genuinely cold measurement: its logs show `Cache not found` for all three new entries, including the `ccache-android-` restore-key prefix. Run 3 restored all three and shows what each is worth — compiler invocations fell from **2965 to 412** (the restored NDK build tree letting ninja skip the rest), and ccache served **398/398 of those, 100% direct hits, 0 misses**. That hit rate is the reason `CCACHE_COMPILERCHECK: content` and the `CCACHE_SLOPPINESS` list are set: the NDK is reinstalled every run and `yarn install` rewrites mtimes under `node_modules`, so at ccache's defaults nearly every object would have missed — and it would have read as a cold cache rather than a misconfigured one. Warm now lands within ~2 min of the 21 min pre-regression prebuilt baseline.

## Notes for review

- **The cache budget deserves a decision rather than a shrug.** The repository was already at **9.78 GB of the 10 GB cap across 17 entries** before this PR added anything. Adding SDK 963 MB + ccache 852 MB + `.cxx` 659 MB took it to 10.62 GB, LRU evicted older entries, and it has settled at **8.98 GB across 13 entries** with all three new caches intact — the warm run restored every one of them. So eviction happened but did not cost us anything this time; the exposure is that it is silent, and a busier week could evict the SDK entry with the only symptom being a slow run. For scale, `actions/setup-java`'s gradle cache is 6.7 GB across three entries — 63% of the cap and untouched by this PR.
- The allowlist keeps 6 of 7 arm64 variants. Upstream's own CI list of three is not safe to copy: `librnllama_v8` carries the ARM quantised-matmul kernels while `librnllama` is the portable-C fallback, so dropping the middle rungs would silently demote every non-Snapdragon arm64 device — a second silent performance regression, shipped by the change that exists to prevent them. The one variant dropped, `rnllama_v8_2_i8mm`, is a named bet with its fall-through rung recorded in `scripts/__tests__/android-ladder-coverage.test.js`.
- **Ground truth that explains the shape of most of this review:** the APK that shipped the regression contains **all 12 declared libraries and all 4 DSP assets**. Every rule in the manifest except the symbol rule passes on it. That is why each way of quietly disarming the symbol rule mattered more than it looked.
- **The check's own failure mode is passing by absence, so every list in the manifest has a floor.** A declaration must demand that something is *present*: `abis` and `requiredLibs` non-empty; a symbol rule needs non-empty `mustExport` or an `expectedMatchCount` with a real pattern and `count > 0`, **and must examine the accelerator library itself** — not any library, and not its JNI wrapper, whose name also contains `_hexagon` but which exports only stable `Java_*` entry points. An ABI declaring a `_hexagon` library needs non-empty `requiredAssets`, and each asset is checked to be an ELF object for the declared machine (EM_QDSP6) rather than merely present by filename — a file of the right name that the DSP cannot load is as dead as a missing one. At least one ABI must declare a real accelerator library, or every conditional floor is satisfied vacuously. And the check enumerates the artifact's own `lib/<abi>/` trees, so an ABI nobody declared can no longer ship unexamined. Four weakenings were measured **passing on real artifacts** before those floors existed — a rule asserting nothing, a rule demanding `count: 0` (which asserts the backend is *absent*, so the incident build satisfies it exactly), an emptied `requiredAssets` that passed an APK with **zero** DSP libraries, and emptied arm64 symbol rules while x86_64 still carried one. In each case the other rules were already satisfied by the bad build, so the emptied one was the only thing catching it. The `assets:` row now prints even when nothing is declared, so a weakened manifest is visible in the report rather than quietly losing the line.
- **Where that hardening stops** is worth knowing before extending it: the script can enforce that a declaration demands presence, but not that the demand is *meaningful*. Re-pointing a rule at `librnllama.so` and an always-present symbol defeats the gate, and catching it would mean hardcoding which library and symbols matter — duplicating the thing the manifest exists to declare. Past that line the control is a reviewed manifest diff. Two weakenings already fail closed by construction: dropping the hexagon library from `requiredLibs` (the allowlist derives from it, so the variant stops being built and instrument-honesty fires) and deleting the arm64 ABI entry.
- Two declarations reach gradle only through the environment, and both used to fail silently. The build step fails if the mode variable is empty, and a separate step greps the build log for the exact variant list gradle reported. Those prove different things and the commit history says which is which.
- **The release path cannot be exercised before merge.** `release.yml` is `workflow_dispatch` and would bump the version, push a tag and upload to Play, so the lane split, the gate's position between build and upload, the AAB path and the moved tag push are **verified by reading only**. Residual risk is bounded in the safe direction — a lane or path error fails *before* `upload_to_play_store`, and supply rejects a missing `aab:` path — but the first release run after this merges should be watched.
- Upstream's CI asserts nothing about the payload: `readelf|objdump|dynsym|llvm-nm|aapt|bundletool` appears nowhere in it. It would not have caught this either.

Preconditions checked rather than assumed: `AndroidManifest.xml` already declares both `uses-native-library` entries (`libOpenCL.so`, `libcdsprpc.so`), the pinned NDK matches upstream's, and the ABI list matches.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
