### PR TITLE
Per-row chat actions on Home: pin, rename, export, delete

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1054,7 +1054,12 @@
         "total": "Total: ",
         "usage": "Usage: "
       },
-      "byteSizes": ["Bytes", "KB", "MB", "GB"]
+      "byteSizes": [
+        "Bytes",
+        "KB",
+        "MB",
+        "GB"
+      ]
     },
     "chatView": {
       "menuItems": {
@@ -1650,6 +1655,7 @@
     "modelChipPrefix": "Model used",
     "modelChipEmpty": "Select a model",
     "chatHistory": "Chat history",
+    "sessionActions": "Chat actions",
     "emptyHint": "Select a pal or model, then start typing. Your conversations will appear here.",
     "sendLabel": "Send message",
     "searchLabel": "Search chats"

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -1,5 +1,11 @@
-import React, {useContext, useEffect, useMemo, useState} from 'react';
-import {Image, ScrollView, Text, View} from 'react-native';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {Alert, Image, ScrollView, Text, View} from 'react-native';
 
 import {observer} from 'mobx-react';
 import {useNavigation} from '@react-navigation/native';
@@ -21,7 +27,10 @@ import {
 import {getFullThumbnailUri} from '../../utils/imageUtils';
 import {ROUTES} from '../../utils/navigationConstants';
 import {Pressable} from '../../components/ui/primitives/Pressable';
+import {Menu} from '../../components/Menu';
+import {RenameModal} from '../../components/RenameModal';
 import {ChatPalModelPickerSheet} from '../../components/ChatPalModelPickerSheet';
+import {exportChatSession} from '../../utils/exportUtils';
 import {
   PlusFilledIcon,
   SendArrowIcon,
@@ -31,6 +40,10 @@ import {
   ClockIcon,
   DotsHorizontalIcon,
   MessageCircleMdIcon,
+  StarIcon,
+  EditIcon,
+  ShareIcon,
+  TrashIcon,
 } from '../../assets/icons';
 import type {Pal} from '../../types/pal';
 import type {SessionMetaData} from '../../store/ChatSessionStore';
@@ -78,63 +91,147 @@ const HistoryRow: React.FC<{
   session: SessionMetaData;
   styles: HomeStyles;
   onPress: () => void;
-}> = observer(({session, styles, onPress}) => {
-  const theme = useTheme();
-  const pal = session.activePalId
-    ? palStore.getPalById(session.activePalId)
-    : undefined;
-  const palUri = pal ? palThumbnailUri(pal) : undefined;
-  const palFill = pal?.color?.[0] ?? theme.colors.surfaceVariant;
-  return (
-    <Pressable
-      style={styles.historyRow}
-      onPress={onPress}
-      accessibilityRole="button"
-      accessibilityLabel={session.title}
-      testID={`home-history-${session.id}`}>
-      <View style={styles.historyRowMain}>
-        <Text style={styles.historyRowTitle} numberOfLines={1}>
-          {session.title}
-        </Text>
-        <View style={styles.historyInfoRow}>
-          {pal ? (
-            <View style={[styles.historyAvatar, {backgroundColor: palFill}]}>
-              {palUri ? (
-                <Image
-                  source={{uri: palUri}}
-                  style={styles.historyAvatarImage}
-                />
-              ) : (
-                palAvatarArt(pal)
-              )}
-            </View>
-          ) : null}
-          {pal ? (
-            <Text style={styles.historyMetaText} numberOfLines={1}>
-              {pal.name}
+  menuVisible: boolean;
+  onMorePress: () => void;
+  onMenuDismiss: () => void;
+  onPressPin: (sessionId: string) => void;
+  onPressRename: (session: SessionMetaData) => void;
+  onPressExport: (sessionId: string) => void;
+  onPressDelete: (sessionId: string) => void;
+}> = observer(
+  ({
+    session,
+    styles,
+    onPress,
+    menuVisible,
+    onMorePress,
+    onMenuDismiss,
+    onPressPin,
+    onPressRename,
+    onPressExport,
+    onPressDelete,
+  }) => {
+    const theme = useTheme();
+    const l10n = useContext(L10nContext);
+    const pal = session.activePalId
+      ? palStore.getPalById(session.activePalId)
+      : undefined;
+    const palUri = pal ? palThumbnailUri(pal) : undefined;
+    const palFill = pal?.color?.[0] ?? theme.colors.surfaceVariant;
+    return (
+      <Pressable
+        style={styles.historyRow}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={session.title}
+        testID={`home-history-${session.id}`}>
+        <View style={styles.historyRowMain}>
+          <View style={styles.historyTitleRow}>
+            {session.pinned ? (
+              <StarIcon
+                width={12}
+                height={12}
+                fill={theme.colors.yellowAccent}
+                testID={`home-session-pinned-${session.id}`}
+              />
+            ) : null}
+            <Text style={styles.historyRowTitle} numberOfLines={1}>
+              {session.title}
             </Text>
-          ) : null}
-          <Text style={styles.historyMetaText}>·</Text>
-          <ClockIcon
-            width={14}
-            height={14}
-            stroke={theme.colors.foregroundTertiary}
-          />
-          <Text style={styles.historyMetaText} numberOfLines={1}>
-            {formatRelativeAge(session.date)}
-          </Text>
+          </View>
+          <View style={styles.historyInfoRow}>
+            {pal ? (
+              <View style={[styles.historyAvatar, {backgroundColor: palFill}]}>
+                {palUri ? (
+                  <Image
+                    source={{uri: palUri}}
+                    style={styles.historyAvatarImage}
+                  />
+                ) : (
+                  palAvatarArt(pal)
+                )}
+              </View>
+            ) : null}
+            {pal ? (
+              <Text style={styles.historyMetaText} numberOfLines={1}>
+                {pal.name}
+              </Text>
+            ) : null}
+            <Text style={styles.historyMetaText}>·</Text>
+            <ClockIcon
+              width={14}
+              height={14}
+              stroke={theme.colors.foregroundTertiary}
+            />
+            <Text style={styles.historyMetaText} numberOfLines={1}>
+              {formatRelativeAge(session.date)}
+            </Text>
+          </View>
         </View>
-      </View>
-      <View style={styles.historyMore}>
-        <DotsHorizontalIcon
-          width={14}
-          height={14}
-          stroke={theme.colors.foregroundTertiary}
-        />
-      </View>
-    </Pressable>
-  );
-});
+        <Menu
+          visible={menuVisible}
+          onDismiss={onMenuDismiss}
+          anchorPosition="bottom"
+          anchor={
+            <Pressable
+              style={styles.historyMore}
+              onPress={onMorePress}
+              accessibilityRole="button"
+              accessibilityLabel={l10n.home.sessionActions}
+              hitSlop={{top: 8, bottom: 8, left: 8, right: 8}}
+              testID={`home-session-more-${session.id}`}>
+              <DotsHorizontalIcon
+                width={14}
+                height={14}
+                stroke={theme.colors.foregroundTertiary}
+              />
+            </Pressable>
+          }>
+          <Menu.Item
+            testID={`home-session-pin-${session.id}`}
+            onPress={() => onPressPin(session.id)}
+            label={
+              session.pinned
+                ? l10n.components.sidebarContent.unpin
+                : l10n.components.sidebarContent.pin
+            }
+            leadingIcon={() => (
+              // star.svg is stroke-only and .svgrrc binds that stroke to the fill
+              // prop, so fill='none' paints nothing — omitting fill is what
+              // yields the outline. No test catches this (svg is mocked).
+              <StarIcon
+                width={20}
+                height={20}
+                {...(session.pinned
+                  ? {fill: theme.colors.primary}
+                  : {stroke: theme.colors.primary})}
+              />
+            )}
+          />
+          <Menu.Item
+            testID={`home-session-rename-${session.id}`}
+            onPress={() => onPressRename(session)}
+            label={l10n.common.rename}
+            leadingIcon={() => <EditIcon stroke={theme.colors.primary} />}
+          />
+          <Menu.Item
+            testID={`home-session-export-${session.id}`}
+            onPress={() => onPressExport(session.id)}
+            label={l10n.common.export}
+            leadingIcon={() => <ShareIcon stroke={theme.colors.primary} />}
+          />
+          <Menu.Item
+            testID={`home-session-delete-${session.id}`}
+            onPress={() => onPressDelete(session.id)}
+            label={l10n.common.delete}
+            labelStyle={{color: theme.colors.error}}
+            leadingIcon={() => <TrashIcon stroke={theme.colors.error} />}
+          />
+        </Menu>
+      </Pressable>
+    );
+  },
+);
 
 export const HomeScreen: React.FC = observer(() => {
   const theme = useTheme();
@@ -149,6 +246,9 @@ export const HomeScreen: React.FC = observer(() => {
     undefined,
   );
   const [isPickerVisible, setPickerVisible] = useState(false);
+  const [menuSessionId, setMenuSessionId] = useState<string | null>(null);
+  const [sessionToRename, setSessionToRename] =
+    useState<SessionMetaData | null>(null);
 
   // Defensive: clear any stale one-shot auto-focus flag whenever Home regains
   // focus, so a launch that navigated but never mounted Chat can't carry over.
@@ -167,7 +267,7 @@ export const HomeScreen: React.FC = observer(() => {
   // bodies (read by the row observers), not these keys, so it won't recompute.
   const pals = palStore.pals;
   const sessionOrderSig = sessions
-    .map(s => `${s.id}:${s.date}:${s.activePalId ?? ''}`)
+    .map(s => `${s.id}:${s.date}:${s.activePalId ?? ''}:${s.pinned ? 1 : 0}`)
     .join('|');
   const palOrderSig = pals
     .map(p => `${p.id}:${p.name}:${p.source ?? ''}`)
@@ -215,11 +315,14 @@ export const HomeScreen: React.FC = observer(() => {
       }
       return 0;
     });
-    // History rows render newest-first (getAllSessions has no order); copy so
-    // the store is not mutated for a presentation need.
-    const recent = [...sessions].sort((a, b) =>
-      a.date < b.date ? 1 : a.date > b.date ? -1 : 0,
-    );
+    // History rows render pinned-first, then newest-first (getAllSessions has
+    // no order); copy so the store is not mutated for a presentation need.
+    const recent = [...sessions].sort((a, b) => {
+      if (!!a.pinned !== !!b.pinned) {
+        return a.pinned ? -1 : 1;
+      }
+      return a.date < b.date ? 1 : a.date > b.date ? -1 : 0;
+    });
     return {recentSessions: recent, orderedPals: ordered, defaultPalId: dft};
     // Recomputes only when ordering-relevant fields change (the signatures).
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -281,6 +384,63 @@ export const HomeScreen: React.FC = observer(() => {
   };
 
   const handleModelChipPress = () => setPickerVisible(true);
+
+  const closeMenu = useCallback(() => setMenuSessionId(null), []);
+
+  const handlePressPin = useCallback(
+    async (sessionId: string) => {
+      closeMenu();
+      await chatSessionStore.togglePinSession(sessionId);
+    },
+    [closeMenu],
+  );
+
+  const handlePressRename = useCallback(
+    (session: SessionMetaData) => {
+      closeMenu();
+      setSessionToRename(session);
+    },
+    [closeMenu],
+  );
+
+  const handlePressExport = useCallback(
+    async (sessionId: string) => {
+      closeMenu();
+      try {
+        await exportChatSession(sessionId);
+      } catch {
+        Alert.alert(
+          l10n.common.error,
+          l10n.components.sidebarContent.exportError,
+        );
+      }
+    },
+    [closeMenu, l10n],
+  );
+
+  const handlePressDelete = useCallback(
+    (sessionId: string) => {
+      closeMenu();
+      Alert.alert(
+        l10n.components.sidebarContent.deleteChatTitle,
+        l10n.components.sidebarContent.deleteChatMessage,
+        [
+          {text: l10n.common.cancel, style: 'cancel'},
+          {
+            text: l10n.common.delete,
+            style: 'destructive',
+            onPress: async () => {
+              // The deleted session may be the active one; reset first so Chat
+              // never resolves a session that is about to disappear.
+              chatSessionStore.resetActiveSession();
+              await chatSessionStore.deleteSession(sessionId);
+            },
+          },
+        ],
+      );
+    },
+    [closeMenu, l10n],
+  );
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']} testID="home-screen">
@@ -462,6 +622,13 @@ export const HomeScreen: React.FC = observer(() => {
                   session={session}
                   styles={styles}
                   onPress={() => void handleHistoryPress(session)}
+                  menuVisible={menuSessionId === session.id}
+                  onMorePress={() => setMenuSessionId(session.id)}
+                  onMenuDismiss={closeMenu}
+                  onPressPin={id => void handlePressPin(id)}
+                  onPressRename={handlePressRename}
+                  onPressExport={id => void handlePressExport(id)}
+                  onPressDelete={handlePressDelete}
                 />
               ))}
             </View>
@@ -476,6 +643,12 @@ export const HomeScreen: React.FC = observer(() => {
           theme.colors.mutedBackground,
         ]}
         style={styles.bottomFade}
+      />
+
+      <RenameModal
+        visible={sessionToRename !== null}
+        session={sessionToRename}
+        onClose={() => setSessionToRename(null)}
       />
 
       {isPickerVisible && (

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -119,13 +119,17 @@ const HistoryRow: React.FC<{
     const palUri = pal ? palThumbnailUri(pal) : undefined;
     const palFill = pal?.color?.[0] ?? theme.colors.surfaceVariant;
     return (
-      <Pressable
-        style={styles.historyRow}
-        onPress={onPress}
-        accessibilityRole="button"
-        accessibilityLabel={session.title}
-        testID={`home-history-${session.id}`}>
-        <View style={styles.historyRowMain}>
+      // The row is a plain container, not a Pressable: an accessible parent
+      // collapses its children into one element, which hid the kebab from the
+      // a11y tree entirely (tappable by coordinate, unreachable by VoiceOver).
+      // The open-chat target and the kebab are siblings instead.
+      <View style={styles.historyRow}>
+        <Pressable
+          style={styles.historyRowMain}
+          onPress={onPress}
+          accessibilityRole="button"
+          accessibilityLabel={session.title}
+          testID={`home-history-${session.id}`}>
           <View style={styles.historyTitleRow}>
             {session.pinned ? (
               <StarIcon
@@ -167,7 +171,7 @@ const HistoryRow: React.FC<{
               {formatRelativeAge(session.date)}
             </Text>
           </View>
-        </View>
+        </Pressable>
         <Menu
           visible={menuVisible}
           onDismiss={onMenuDismiss}
@@ -228,7 +232,7 @@ const HistoryRow: React.FC<{
             leadingIcon={() => <TrashIcon stroke={theme.colors.error} />}
           />
         </Menu>
-      </Pressable>
+      </View>
     );
   },
 );

--- a/src/screens/HomeScreen/__tests__/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen/__tests__/HomeScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Alert} from 'react-native';
 import {runInAction} from 'mobx';
 import {fireEvent, waitFor} from '@testing-library/react-native';
 
@@ -13,6 +14,12 @@ import {
 import {mockLocalPal} from '../../../../jest/fixtures/pals';
 
 import {HomeScreen} from '../HomeScreen';
+
+const mockExportChatSession = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../utils/exportUtils', () => ({
+  ...jest.requireActual('../../../utils/exportUtils'),
+  exportChatSession: (id: string) => mockExportChatSession(id),
+}));
 
 const mockPicker = jest.fn((_props: any) => null);
 jest.mock('../../../components/ChatPalModelPickerSheet', () => ({
@@ -449,5 +456,167 @@ describe('HomeScreen', () => {
     expect(getByText(placeholderFor('Pip'))).toBeTruthy();
     fireEvent.press(getByTestId('home-pal-pip'));
     expect(getByText(en.home.composerPlaceholderGeneric)).toBeTruthy();
+  });
+
+  describe('chat-row overflow menu', () => {
+    // The drawer carried per-row pin/rename/export/delete; the bottom-tab swap
+    // dropped it, leaving pinning with no call site anywhere in the app.
+    const twoSessions = () =>
+      runInAction(() => {
+        chatSessionStore.sessions = [
+          {
+            id: 'a',
+            title: 'First chat',
+            date: '2026-06-01T10:00:00.000Z',
+            messages: [],
+            completionSettings: {} as any,
+            settingsSource: 'custom',
+          },
+          {
+            id: 'b',
+            title: 'Second chat',
+            date: '2026-06-02T10:00:00.000Z',
+            messages: [],
+            completionSettings: {} as any,
+            settingsSource: 'custom',
+          },
+        ] as any;
+      });
+
+    const openMenu = (getByTestId: any, id: string) => {
+      fireEvent.press(getByTestId(`home-session-more-${id}`));
+    };
+
+    it('the kebab is an actual control, not decoration', () => {
+      twoSessions();
+      const {getByTestId} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      const kebab = getByTestId('home-session-more-a');
+      expect(kebab.props.accessibilityRole).toBe('button');
+      expect(kebab.props.accessibilityLabel).toBe(en.home.sessionActions);
+      // The negative control for this whole slice: before the fix the kebab was
+      // a bare View, so opening a menu from it was impossible.
+      expect(kebab.props.onClick ?? kebab.props.onPress).toBeDefined();
+    });
+
+    it('opens the menu for the tapped row only', () => {
+      twoSessions();
+      const {getByTestId, queryByTestId} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      expect(queryByTestId('home-session-pin-a')).toBeNull();
+
+      openMenu(getByTestId, 'a');
+
+      expect(getByTestId('home-session-pin-a')).toBeTruthy();
+      expect(queryByTestId('home-session-pin-b')).toBeNull();
+    });
+
+    it('pin routes to togglePinSession — the writer the nav swap orphaned', () => {
+      twoSessions();
+      const {getByTestId} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      openMenu(getByTestId, 'a');
+      fireEvent.press(getByTestId('home-session-pin-a'));
+
+      expect(chatSessionStore.togglePinSession).toHaveBeenCalledWith('a');
+    });
+
+    it('export routes to exportChatSession', async () => {
+      twoSessions();
+      const {getByTestId} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      openMenu(getByTestId, 'b');
+      fireEvent.press(getByTestId('home-session-export-b'));
+
+      await waitFor(() => {
+        expect(mockExportChatSession).toHaveBeenCalledWith('b');
+      });
+    });
+
+    it('delete asks first and only deletes on confirm', () => {
+      twoSessions();
+      const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+      const {getByTestId} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      openMenu(getByTestId, 'a');
+      fireEvent.press(getByTestId('home-session-delete-a'));
+
+      expect(chatSessionStore.deleteSession).not.toHaveBeenCalled();
+      expect(alert).toHaveBeenCalled();
+
+      const confirm = (alert.mock.calls[0][2] as any[]).find(
+        b => b.style === 'destructive',
+      );
+      confirm.onPress();
+
+      expect(chatSessionStore.deleteSession).toHaveBeenCalledWith('a');
+      alert.mockRestore();
+    });
+
+    it('labels the item Unpin and marks the row when the session is pinned', () => {
+      runInAction(() => {
+        chatSessionStore.sessions = [
+          {
+            id: 'p',
+            title: 'Pinned chat',
+            date: '2026-06-01T10:00:00.000Z',
+            pinned: true,
+            messages: [],
+            completionSettings: {} as any,
+            settingsSource: 'custom',
+          },
+        ] as any;
+      });
+      const {getByTestId, getByText} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      expect(getByTestId('home-session-pinned-p')).toBeTruthy();
+
+      openMenu(getByTestId, 'p');
+      expect(getByText(en.components.sidebarContent.unpin)).toBeTruthy();
+    });
+
+    it('sorts pinned sessions above newer unpinned ones', () => {
+      runInAction(() => {
+        chatSessionStore.sessions = [
+          {
+            id: 'newer',
+            title: 'Newer unpinned',
+            date: '2026-06-10T10:00:00.000Z',
+            messages: [],
+            completionSettings: {} as any,
+            settingsSource: 'custom',
+          },
+          {
+            id: 'older',
+            title: 'Older pinned',
+            date: '2026-06-01T10:00:00.000Z',
+            pinned: true,
+            messages: [],
+            completionSettings: {} as any,
+            settingsSource: 'custom',
+          },
+        ] as any;
+      });
+      const {getAllByTestId} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      const order = getAllByTestId(/^home-history-/)
+        .map(n => n.props.testID)
+        .filter(id => id !== 'home-history-search');
+      expect(order).toEqual(['home-history-older', 'home-history-newer']);
+    });
   });
 });

--- a/src/screens/HomeScreen/__tests__/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen/__tests__/HomeScreen.test.tsx
@@ -487,6 +487,34 @@ describe('HomeScreen', () => {
       fireEvent.press(getByTestId(`home-session-more-${id}`));
     };
 
+    it('exposes the kebab as its own a11y element, not folded into the row', () => {
+      // RN collapses children of an accessible parent into one element. With the
+      // row itself Pressable the kebab vanished from the a11y tree — tappable by
+      // coordinate, unreachable by VoiceOver. Caught on device, not by jest;
+      // this guards the structure that fixed it.
+      twoSessions();
+      const {getByTestId} = render(<HomeScreen />, {
+        withNavigation: true,
+        withSafeArea: true,
+      });
+      const row = getByTestId('home-history-a');
+      const kebab = getByTestId('home-session-more-a');
+      expect(row.props.accessibilityRole).toBe('button');
+      expect(kebab.props.accessibilityRole).toBe('button');
+      // Neither may contain the other, or the a11y tree folds them back together.
+      const contains = (a: any, b: any) => {
+        let n = b.parent;
+        while (n) {
+          if (n === a) {
+            return true;
+          }
+          n = n.parent;
+        }
+        return false;
+      };
+      expect(contains(row, kebab)).toBe(false);
+    });
+
     it('the kebab is an actual control, not decoration', () => {
       twoSessions();
       const {getByTestId} = render(<HomeScreen />, {

--- a/src/screens/HomeScreen/styles.ts
+++ b/src/screens/HomeScreen/styles.ts
@@ -277,7 +277,13 @@ export const createStyles = (theme: Theme) =>
       flex: 1,
       gap: theme.spacing.xxs,
     },
+    historyTitleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.spacing.xxs,
+    },
     historyRowTitle: {
+      flexShrink: 1,
       ...theme.typography.uiM,
       fontSize: 14,
       lineHeight: 20,


### PR DESCRIPTION
## Per-row chat actions on Home: pin, rename, export, delete

The bottom-tab migration unmounted `SidebarContent`, and with it the only call
site of `chatSessionStore.togglePinSession`. Pinned chat sessions shipped on
`main`, and after the nav swap the feature became unreachable on this branch —
the persisted `chat_sessions.pinned` column and the store's `Pinned` group had
no way to be set and no way to be seen.

Canonical Home already answers where it belongs. The populated frame
(`888:33822` "Homepage - default", **not** `888:33856` "first time user") ends
every chat row with a kebab (`888:33844` → `4359:1587`). We already drew that
kebab — as a bare `View` with no `onPress`. A control that looks tappable and
isn't is its own bug; it just never surfaced because the screen that was
captured for parity had no history rows.

### What changed

`HistoryRow`'s kebab is now a real control anchoring a per-row menu with the
same items the drawer offered — every one routing to a store method that already
existed:

| Item | Routes to |
| --- | --- |
| Pin / Unpin | `togglePinSession` |
| Rename | shared `RenameModal` → `updateSessionTitleBySessionId` |
| Export | `exportChatSession` (alerts on failure) |
| Delete | `deleteSession`, behind an `Alert` confirm; resets the active session first |

Pinned rows also **look and sort pinned** — filled star, ordered above unpinned.
A toggle whose effect is invisible isn't a feature; Home previously ordered by
recency alone and never read the flag.

### Scope notes

- **Markdown export was never unreachable.** I initially reported it lost along
  with pinning; it is not. `HeaderRight` is mounted (`ChatHeader` ← `ChatView`)
  and offers export-as-Markdown for the active session. Only pinning was
  genuinely orphaned.
- **Not re-homed:** bulk-selection mode (`Select…`, bulk delete/export). It was a
  drawer-list affordance with no canonical Home equivalent and nowhere to put a
  selection bar in a flat recency list. `bulkDeleteSessions` /
  `bulkExportSessions` stay unreferenced — they go with the `SidebarContent`
  deletion in the cleanup phase.
- **Designer ask (non-blocking):** canonical specifies the kebab but not the
  menu's contents or appearance — a metadata sweep of the Homepage section
  (`888:33821`) finds no dropdown frame. The item set is inherited from the
  drawer; presentation reuses the existing `Menu`/`Menu.Item`, the same
  DS-derived precedent as the chat-header overflow.
- **testIDs:** new controls use a `home-session-*` prefix, deliberately not
  `home-history-*`. An existing ordering test selects rows by
  `/^home-history-/`, and sharing the prefix would have silently widened it.

### Tests

Seven new tests, and they are gated rather than presence-asserting: reverting
the kebab to its old decorative `View` fails **6 of the 7**. They cover the
control's role/label, per-row menu isolation, each of the four writers, the
confirm-before-delete path, the Unpin label + star on a pinned row, and
pinned-first ordering.

- `yarn typecheck` — pass. `yarn lint` — pass (0 errors; 54 pre-existing warnings).
- `yarn test` — **281 suites / 4505 tests pass** (2 skipped).

### Docs

`app-shell.md` gains §4a (the row-action contract), three single-writer rows and
D13/D14; its deferred-cleanup entry that *gated* on re-homing pin is now
satisfied, so `SidebarContent` is dead in full and can be deleted outright in the
cleanup phase. `chat-flow.md` §8b is re-headed to record that `groupedSessions`
currently has no consumer while the pin writer is live again.

Visual evidence to follow on this PR.

---
Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
