### PR TITLE
Fix six failing Android e2e feature specs

### DIFF
--- a/e2e/helpers/control-state.ts
+++ b/e2e/helpers/control-state.ts
@@ -1,0 +1,69 @@
+/**
+ * Reading the real state of a control, rather than inferring it.
+ *
+ * A `byTestId` lookup matches on a resource-id *substring*, and a paper control
+ * expands into several nodes that share the prefix — for a Button: a wrapper,
+ * the Button itself, a text node and an icon container. `findElement` returns
+ * the first, which is the wrapper, so state read straight off the selector
+ * describes the wrapper and not the control.
+ */
+
+import {isAndroid} from './selectors';
+
+declare const browser: WebdriverIO.Browser;
+
+/**
+ * A switch's real on/off state, or null where the platform does not expose it
+ * (the paper Switch reports no usable value on iOS). The element must already
+ * be on screen — an off-viewport control is absent from the tree.
+ */
+export async function readSwitchState(
+  selector: string,
+): Promise<boolean | null> {
+  const checked = await browser
+    .$(selector)
+    .getAttribute('checked')
+    .catch(() => null);
+  return checked === null || checked === 'null' ? null : checked === 'true';
+}
+
+/**
+ * Whether the interactive control behind `selector` is enabled.
+ *
+ * The wrapper around a disabled Button stays enabled, so reading the first
+ * match reports a disabled control as enabled. Read the clickable node instead.
+ */
+export async function readControlEnabled(selector: string): Promise<boolean> {
+  if (!isAndroid()) {
+    return browser.$(selector).isEnabled();
+  }
+  const nodes = await browser.$$(selector);
+  for (const node of nodes) {
+    const clickable = await node.getAttribute('clickable').catch(() => null);
+    if (clickable === 'true') {
+      return node.isEnabled();
+    }
+  }
+  return browser.$(selector).isEnabled();
+}
+
+/**
+ * Tap the interactive node for `selector`, which may be an ancestor of it.
+ *
+ * A text match usually lands on a TextView, and a testID match on a wrapper —
+ * neither is clickable, so the tap is accepted and does nothing. On Android the
+ * nearest clickable ancestor-or-self is the control; elsewhere the selector
+ * already resolves to it.
+ */
+export async function tapControl(selector: string): Promise<void> {
+  if (isAndroid()) {
+    const control = browser.$(
+      `${selector}/ancestor-or-self::*[@clickable="true"][1]`,
+    );
+    if (await control.isExisting().catch(() => false)) {
+      await control.click();
+      return;
+    }
+  }
+  await browser.$(selector).click();
+}

--- a/e2e/helpers/disclosure.ts
+++ b/e2e/helpers/disclosure.ts
@@ -5,8 +5,46 @@
 
 import {Gestures} from './gestures';
 import {readSwitchState} from './control-state';
+import {isAndroid} from './selectors';
 
 declare const browser: WebdriverIO.Browser;
+
+/**
+ * React Native's touch responder is not armed immediately after a scroll
+ * gesture: the tap is accepted, and silently does nothing. Without this pause
+ * the accordion toggle drops every tap.
+ */
+const TOUCH_SETTLE_MS = 700;
+
+function testIdFrom(selector: string): string | null {
+  const match = selector.match(/contains\(@resource-id, "([^"]+)"\)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Anchor on the toggle, which is always mounted, and read the section's state
+ * from `stateProbe` in place. That avoids both the ambiguous off-viewport probe
+ * and the cost of a native scroll for a control that may not exist yet.
+ */
+async function revealViaNativeScroll(
+  toggle: string,
+  dependent: string,
+  stateProbe: string,
+): Promise<boolean> {
+  if (!(await Gestures.nativeScrollIntoView(toggle))) {
+    return false;
+  }
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (await browser.$(stateProbe).isExisting()) {
+      return Gestures.nativeScrollIntoView(dependent);
+    }
+    await browser.pause(TOUCH_SETTLE_MS);
+    await browser.$(toggle).click();
+    await browser.pause(TOUCH_SETTLE_MS);
+    await Gestures.nativeScrollIntoView(toggle);
+  }
+  return false;
+}
 
 export interface RevealOptions {
   /** Control that opens/closes the section. */
@@ -25,6 +63,12 @@ export interface RevealOptions {
    */
   reachForClick?: (selector: string, maxScrolls?: number) => Promise<boolean>;
   maxScrolls?: number;
+  /**
+   * Control mounted directly under `toggle` while the section is open, used as
+   * an in-place state read. Supplying it selects the native-scroll path on
+   * Android; without it the scroll-probe fallback is used.
+   */
+  stateProbe?: string;
 }
 
 /**
@@ -37,9 +81,13 @@ export interface RevealOptions {
  * that was already open — the caller then waits for a control it just unmounted.
  */
 export async function ensureRevealed(options: RevealOptions): Promise<boolean> {
-  const {toggle, dependent, rewind, maxScrolls = 8} = options;
+  const {toggle, dependent, stateProbe, rewind, maxScrolls = 8} = options;
   const reach = options.reach ?? Gestures.scrollToElement;
   const reachForClick = options.reachForClick ?? reach;
+
+  if (isAndroid() && stateProbe && testIdFrom(toggle)) {
+    return revealViaNativeScroll(toggle, dependent, stateProbe);
+  }
 
   await rewind?.();
   if (await reach(dependent, maxScrolls)) {

--- a/e2e/helpers/disclosure.ts
+++ b/e2e/helpers/disclosure.ts
@@ -1,0 +1,84 @@
+/**
+ * Helpers for driving progressive-disclosure UI (accordions, dependent switches)
+ * whose controls may be off-screen.
+ */
+
+import {Gestures} from './gestures';
+import {readSwitchState} from './control-state';
+
+declare const browser: WebdriverIO.Browser;
+
+export interface RevealOptions {
+  /** Control that opens/closes the section. */
+  toggle: string;
+  /** Control that is only mounted while the section is open. */
+  dependent: string;
+  /** Rewind the scroll container so a pass starts from a known offset. */
+  rewind?: () => Promise<void>;
+  /** Scroll strategy for probing; use `Gestures.scrollInSheetToElementExists` inside a sheet. */
+  reach?: (selector: string, maxScrolls?: number) => Promise<boolean>;
+  /**
+   * Scroll strategy for a control that will be CLICKED. Must clear fixed
+   * overlays: UiAutomator2 calls an element displayed while a pinned action bar
+   * is painted over it, and the tap then lands on the overlay — inside a sheet
+   * that means hitting Cancel and dismissing it. Defaults to `reach`.
+   */
+  reachForClick?: (selector: string, maxScrolls?: number) => Promise<boolean>;
+  maxScrolls?: number;
+}
+
+/**
+ * Bring `dependent` into reach, clicking `toggle` only after a full scroll pass
+ * has failed to find it.
+ *
+ * Off-viewport content is absent from the Android accessibility tree, so an
+ * existence probe cannot tell "the section is closed" from "the row is below the
+ * fold". `toggle` flips state, so acting on that false negative closes a section
+ * that was already open — the caller then waits for a control it just unmounted.
+ */
+export async function ensureRevealed(options: RevealOptions): Promise<boolean> {
+  const {toggle, dependent, rewind, maxScrolls = 8} = options;
+  const reach = options.reach ?? Gestures.scrollToElement;
+  const reachForClick = options.reachForClick ?? reach;
+
+  await rewind?.();
+  if (await reach(dependent, maxScrolls)) {
+    return true;
+  }
+
+  await rewind?.();
+  if (!(await reachForClick(toggle, maxScrolls))) {
+    return false;
+  }
+  await browser.$(toggle).click();
+  await browser.pause(600);
+
+  await rewind?.();
+  return reach(dependent, maxScrolls);
+}
+
+/**
+ * Turn `toggle` on and bring `dependent` into reach.
+ *
+ * Preferred over `ensureRevealed` for switches: Android reports the real state
+ * as `checked`, so nothing has to be inferred and both scrolls run in the same
+ * direction. Falls back to inference only where the state is unreadable.
+ */
+export async function ensureSwitchOn(options: RevealOptions): Promise<boolean> {
+  const {toggle, dependent, rewind, maxScrolls = 8} = options;
+  const reach = options.reach ?? Gestures.scrollToElement;
+  const reachForClick = options.reachForClick ?? reach;
+
+  await rewind?.();
+  if (await reachForClick(toggle, maxScrolls)) {
+    const state = await readSwitchState(toggle);
+    if (state !== null) {
+      if (!state) {
+        await browser.$(toggle).click();
+        await browser.pause(600);
+      }
+      return reach(dependent, maxScrolls);
+    }
+  }
+  return ensureRevealed(options);
+}

--- a/e2e/helpers/element-text.ts
+++ b/e2e/helpers/element-text.ts
@@ -1,0 +1,56 @@
+/**
+ * Cross-platform element text reads.
+ */
+
+import {isAndroid} from './selectors';
+
+declare const browser: WebdriverIO.Browser;
+
+/**
+ * The element's accessibility label.
+ *
+ * Use this for controls that carry an explicit `accessibilityLabel` (buttons,
+ * pills, pickers): Android exposes it as `content-desc` and leaves the node's
+ * own `text` empty, so `getText()` returns "" for them. Plain `<Text>` is the
+ * other way round — read those with `getText()`.
+ *
+ * `label` is an iOS-only attribute; asking for it on Android throws.
+ *
+ * A `byTestId` lookup matches on a resource-id *substring*, so it can resolve a
+ * wrapper that carries no label while the labelled control is its descendant;
+ * the wrapper is searched first, then the subtree.
+ */
+export async function readAccessibilityLabel(
+  selector: string,
+): Promise<string> {
+  const attr = isAndroid() ? 'content-desc' : 'label';
+  const element = browser.$(selector);
+
+  const own = normalise(await element.getAttribute(attr).catch(() => null));
+  if (own) {
+    return own;
+  }
+
+  if (!isAndroid()) {
+    return '';
+  }
+  try {
+    const descendants = await element.$$('.//*[@content-desc]');
+    for (const descendant of descendants) {
+      const label = normalise(
+        await descendant.getAttribute(attr).catch(() => null),
+      );
+      if (label) {
+        return label;
+      }
+    }
+  } catch {
+    // Element gone or subtree unreadable; an empty label is the honest answer.
+  }
+  return '';
+}
+
+/** UiAutomator2 reports an absent attribute as the string "null". */
+function normalise(value: string | null): string {
+  return !value || value === 'null' ? '' : value;
+}

--- a/e2e/helpers/gestures.ts
+++ b/e2e/helpers/gestures.ts
@@ -208,6 +208,11 @@ async function swipeUpInSheet(): Promise<void> {
  *   for the bottom-anchored UI. Defaults to 0.15 (~15%), enough for a
  *   Sheet.Actions row plus system nav on Android. Pass a larger value
  *   when scrolling inside a sheet with a tall action area.
+ *
+ * The reserve is a guess, and it rejects an element that is genuinely the LAST
+ * item in the sheet and so can never be scrolled above it — the caller then
+ * sees an unreachable element rather than an obvious failure. Prefer
+ * `scrollInSheetClearOfOverlay`, which measures the pinned row instead.
  */
 async function scrollInSheetToElement(
   selector: string,
@@ -230,6 +235,57 @@ async function scrollInSheetToElement(
       // Element not found yet
     }
     await swipeUpInSheet();
+    await driver.pause(300);
+  }
+  return false;
+}
+
+/**
+ * Swipe up within a bottom sheet, starting low enough to miss the text inputs
+ * that occupy the middle of a form sheet. A drag begun on a TextInput is
+ * consumed by it, so the sheet never scrolls and the caller sees an unreachable
+ * row rather than a failed gesture.
+ */
+async function swipeUpInSheetBelowInputs(): Promise<void> {
+  await swipe({
+    startYPercent: 0.78,
+    endYPercent: 0.42,
+    duration: 300,
+  });
+}
+
+/**
+ * Scroll within a sheet until `selector` sits fully above `overlay`.
+ *
+ * Use for anything about to be tapped inside a sheet with a pinned action row.
+ * UiAutomator2 reports an element displayed while that row is painted over it,
+ * so the tap lands on the overlay instead. The percentage-based reserve in
+ * scrollInSheetToElement has to be guessed per layout and per device — and a
+ * row that is genuinely the last item can sit inside the reserve with nothing
+ * left to scroll. The overlay's own geometry is exact.
+ *
+ * Probes by existence: sheet content reports isDisplayed=false on iOS.
+ */
+async function scrollInSheetClearOfOverlay(
+  selector: string,
+  overlay: string,
+  maxScrolls = 8,
+  scroll: () => Promise<void> = swipeUpInSheet,
+): Promise<boolean> {
+  for (let i = 0; i < maxScrolls; i++) {
+    const element = browser.$(selector);
+    if (await element.isExisting().catch(() => false)) {
+      const loc = await element.getLocation();
+      const size = await element.getSize();
+      const overlayEl = browser.$(overlay);
+      const overlayTop = (await overlayEl.isExisting().catch(() => false))
+        ? (await overlayEl.getLocation()).y
+        : (await getScreenSize()).height;
+      if (loc.y >= 0 && loc.y + size.height <= overlayTop) {
+        return true;
+      }
+    }
+    await scroll();
     await driver.pause(300);
   }
   return false;
@@ -270,6 +326,8 @@ export const Gestures = {
   swipeToOpenDrawer,
   scrollToElement,
   swipeUpInSheet,
+  swipeUpInSheetBelowInputs,
   scrollInSheetToElement,
+  scrollInSheetClearOfOverlay,
   scrollInSheetToElementExists,
 };

--- a/e2e/helpers/gestures.ts
+++ b/e2e/helpers/gestures.ts
@@ -179,6 +179,34 @@ async function scrollToElement(
 }
 
 /**
+ * Scroll to a control with UiAutomator's own scroller, which walks the whole
+ * container in either direction rather than the viewport. Android only;
+ * returns false elsewhere so callers can fall back to a swipe loop.
+ *
+ * Only for a control known to be mounted — a miss scrolls to the end of the
+ * list before failing, which costs tens of seconds.
+ */
+async function nativeScrollIntoView(selector: string): Promise<boolean> {
+  if (!(browser as unknown as {isAndroid?: boolean}).isAndroid) {
+    return false;
+  }
+  const match = selector.match(/contains\(@resource-id, "([^"]+)"\)/);
+  if (!match) {
+    return false;
+  }
+  try {
+    return await browser
+      .$(
+        '-android uiautomator:new UiScrollable(new UiSelector().scrollable(true))' +
+          `.scrollIntoView(new UiSelector().resourceIdMatches(".*${match[1]}.*"))`,
+      )
+      .isExisting();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Swipe up within a bottom sheet (uses safer coordinates)
  * Avoids the bottom navigation gesture area on Android
  */
@@ -318,6 +346,7 @@ async function scrollInSheetToElementExists(
 
 export const Gestures = {
   getScreenSize,
+  nativeScrollIntoView,
   swipe,
   swipeDownOnElement,
   swipeDownToClose,

--- a/e2e/helpers/model-actions.ts
+++ b/e2e/helpers/model-actions.ts
@@ -17,6 +17,48 @@ import {TIMEOUTS, ModelTestConfig, ModelQuantVariant} from '../fixtures/models';
 declare const browser: WebdriverIO.Browser;
 
 /**
+ * Wait for a model's card to appear on the Models screen after a download.
+ *
+ * Fails fast on the app's download-error dialog: once that is up the download
+ * is over, so waiting out the remaining minutes only buys a timeout that names
+ * the wrong thing.
+ */
+export async function waitForModelDownloaded(
+  downloadFile: string,
+  timeout: number = TIMEOUTS.download,
+): Promise<void> {
+  const cardSelector = Selectors.modelCard.cardContainer(downloadFile);
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    if (
+      await browser
+        .$(cardSelector)
+        .isDisplayed()
+        .catch(() => false)
+    ) {
+      return;
+    }
+    if (
+      await browser
+        .$(byTestId('download-error-dialog'))
+        .isDisplayed()
+        .catch(() => false)
+    ) {
+      const reason = await browser
+        .$(byTestId('error-message-text'))
+        .getText()
+        .catch(() => 'unknown');
+      throw new Error(`Download failed for ${downloadFile}: ${reason}`);
+    }
+    await browser.pause(1000);
+  }
+  throw new Error(
+    `Model card for ${downloadFile} did not appear within ${timeout}ms`,
+  );
+}
+
+/**
  * Dismiss memory/performance warning alert if it appears.
  * The app shows this alert when loading models that may exceed device memory
  * or for multimodal models on low-end devices.
@@ -178,8 +220,8 @@ export async function downloadAndLoadModel(
   const containerSelector = Selectors.modelCard.cardContainer(
     model.downloadFile,
   );
+  await waitForModelDownloaded(model.downloadFile, downloadTimeout);
   const modelCardContainer = browser.$(containerSelector);
-  await modelCardContainer.waitForDisplayed({timeout: downloadTimeout});
 
   if (model.disableVisionBeforeLoad) {
     await disableVisionOnCard(model.downloadFile);
@@ -242,8 +284,8 @@ export async function downloadAndLoadModelVariant(
   const containerSelector = Selectors.modelCard.cardContainer(
     variant.downloadFile,
   );
+  await waitForModelDownloaded(variant.downloadFile, downloadTimeout);
   const modelCardContainer = browser.$(containerSelector);
-  await modelCardContainer.waitForDisplayed({timeout: downloadTimeout});
 
   const loadBtn = modelCardContainer.$(Selectors.modelCard.loadButtonElement);
   await loadBtn.waitForDisplayed({timeout: 10000});

--- a/e2e/helpers/screenshots.ts
+++ b/e2e/helpers/screenshots.ts
@@ -1,0 +1,40 @@
+/**
+ * Failure-screenshot capture shared by feature specs.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {SCREENSHOT_DIR} from '../wdio.shared.conf';
+
+declare const driver: WebdriverIO.Browser;
+
+/**
+ * Mocha titles are free text and reach the filesystem as a filename, so anything
+ * that is not filename-safe is folded away — a `/` in a title (e.g. "low/medium/high")
+ * otherwise names a directory that does not exist and the capture is silently lost.
+ */
+function toFileName(title: string): string {
+  return title
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+}
+
+/** Capture a screenshot for a failed test. Never throws. */
+export async function saveFailureScreenshot(title: string): Promise<void> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  try {
+    if (!fs.existsSync(SCREENSHOT_DIR)) {
+      fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
+    }
+    await driver.saveScreenshot(
+      path.join(
+        SCREENSHOT_DIR,
+        `failure-${toFileName(title)}-${timestamp}.png`,
+      ),
+    );
+  } catch (e) {
+    console.error('Failed to capture screenshot:', (e as Error).message);
+  }
+}

--- a/e2e/pages/HFSearchSheet.ts
+++ b/e2e/pages/HFSearchSheet.ts
@@ -79,20 +79,38 @@ export class HFSearchSheet extends BasePage {
   }
 
   /**
-   * Close the sheet by tapping the close button. The tap can land while the
-   * sheet is still settling and get swallowed; fall back to the system back
-   * action, which dismisses bottom sheets regardless of geometry.
+   * Close the sheet, re-tapping the close button until it goes away.
+   *
+   * A single tap is not enough. The model-details sheet stacks above this one
+   * and its handle (Pixel 9: [0,242][1080,316]) covers the close button
+   * ([42,268][105,331]), so a tap during the ~3.5s dismiss animation lands on
+   * the dismissing sheet instead. The system back action is not a usable
+   * fallback either: this sheet never consumes back, which instead navigates
+   * the screen underneath and leaves the sheet up.
    */
-  async close(): Promise<void> {
-    const closeBtn = await this.waitForEnabled(
-      Selectors.common.sheetCloseButton,
-    );
-    await closeBtn.click();
-    try {
-      await this.waitForClose();
-    } catch {
-      await driver.back();
-      await this.waitForClose();
+  async close(timeout = 20000): Promise<void> {
+    const deadline = Date.now() + timeout;
+    while (await this.isOpen()) {
+      const closeBtn = this.getElement(Selectors.common.sheetCloseButton);
+      if (await closeBtn.isDisplayed().catch(() => false)) {
+        await closeBtn.click().catch(() => undefined);
+      }
+      try {
+        await this.waitForClose(3000);
+        return;
+      } catch {
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `${Selectors.hfSearch.view} still displayed after ${timeout}ms of close attempts`,
+          );
+        }
+      }
     }
+  }
+
+  private async isOpen(): Promise<boolean> {
+    return this.getElement(Selectors.hfSearch.view)
+      .isDisplayed()
+      .catch(() => false);
   }
 }

--- a/e2e/specs/features/graded-effort-override.spec.ts
+++ b/e2e/specs/features/graded-effort-override.spec.ts
@@ -12,22 +12,20 @@
  *     --spec graded-effort-override --devices iphone-17-pro-sim --skip-build
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
 import {expect} from '@wdio/globals';
 import {ChatPage} from '../../pages/ChatPage';
 import {DrawerPage} from '../../pages/DrawerPage';
 import {ModelsPage} from '../../pages/ModelsPage';
 import {Selectors, byTestId, isAndroid} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
+import {ensureSwitchOn} from '../../helpers/disclosure';
+import {saveFailureScreenshot} from '../../helpers/screenshots';
 import {
   downloadAndLoadModel,
   dismissPerformanceWarningIfPresent,
 } from '../../helpers/model-actions';
 import {TIMEOUTS} from '../../fixtures/models';
-import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
 
-declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;
 
 /** Qwen3-0.6B: small reasoning-capable model — matches thinking.spec.ts. */
@@ -142,18 +140,7 @@ describe('Local Graded-Effort Override', () => {
 
   afterEach(async function (this: Mocha.Context) {
     if (this.currentTest?.state === 'failed') {
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const testName = this.currentTest.title.replace(/\s+/g, '-');
-      try {
-        if (!fs.existsSync(SCREENSHOT_DIR)) {
-          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
-        }
-        await driver.saveScreenshot(
-          path.join(SCREENSHOT_DIR, `failure-${testName}-${timestamp}.png`),
-        );
-      } catch (e) {
-        console.error('Failed to capture screenshot:', (e as Error).message);
-      }
+      await saveFailureScreenshot(this.currentTest.title);
     }
   });
 
@@ -165,46 +152,36 @@ describe('Local Graded-Effort Override', () => {
     await modelsPage.waitForReady();
     await modelsPage.openModelSettings(THINKING_MODEL.downloadFile);
 
-    // The reasoning section sits at the bottom of the settings ScrollView;
-    // scroll it into view before driving the controls.
-    await Gestures.scrollToElement(Selectors.modelSettings.isReasoningSwitch, 6);
-    const isReasoning = browser.$(Selectors.modelSettings.isReasoningSwitch);
-    await isReasoning.waitForDisplayed({timeout: 10000});
+    // Axis 1 reveals the axis-2 effort switch, which in turn reveals the effort
+    // chips. The paper Switch exposes no reliable "value" attribute (null on
+    // iOS), so each axis is steered by the control it reveals rather than by
+    // its own state.
+    const reachInSheet = (selector: string, maxScrolls?: number) =>
+      Gestures.scrollInSheetToElementExists(selector, maxScrolls);
+    const reachInSheetForClick = (selector: string, maxScrolls?: number) =>
+      Gestures.scrollInSheetClearOfOverlay(
+        selector,
+        Selectors.generationSettings.saveChangesButton,
+        maxScrolls,
+      );
 
-    // Ensure axis-1 is ON (it reveals the axis-2 effort controls). The paper
-    // Switch does not expose a reliable "value" attribute on iOS (returns null),
-    // so a blind value-based click would toggle an already-ON reasoning model
-    // OFF and unmount the effort switch. Steer by presence of the dependent
-    // axis-2 control instead: only click axis-1 if the effort switch is absent.
-    const effortSwitchPresent = async (): Promise<boolean> =>
-      browser
-        .$(Selectors.modelSettings.supportsEffortSwitch)
-        .isExisting()
-        .catch(() => false);
-    if (!(await effortSwitchPresent())) {
-      await isReasoning.click();
-      await browser.pause(400);
-    }
+    const effortSwitchShown = await ensureSwitchOn({
+      toggle: Selectors.modelSettings.isReasoningSwitch,
+      dependent: Selectors.modelSettings.supportsEffortSwitch,
+      reach: reachInSheet,
+      reachForClick: reachInSheetForClick,
+      maxScrolls: 8,
+    });
+    expect(effortSwitchShown).toBe(true);
 
-    await Gestures.scrollToElement(
-      Selectors.modelSettings.supportsEffortSwitch,
-      6,
-    );
-    const supportsEffort = browser.$(Selectors.modelSettings.supportsEffortSwitch);
-    await supportsEffort.waitForDisplayed({timeout: 10000});
-
-    // Ensure axis-2 is ON (it reveals the effort chips). Same paper-Switch
-    // limitation as axis-1: steer by presence of the dependent effort chips
-    // rather than the unreliable "value" attribute. Only click if absent.
-    const effortChipsPresent = async (): Promise<boolean> =>
-      browser
-        .$(Selectors.modelSettings.effortChip('low'))
-        .isExisting()
-        .catch(() => false);
-    if (!(await effortChipsPresent())) {
-      await supportsEffort.click();
-      await browser.pause(400);
-    }
+    const effortChipsShown = await ensureSwitchOn({
+      toggle: Selectors.modelSettings.supportsEffortSwitch,
+      dependent: Selectors.modelSettings.effortChip('low'),
+      reach: reachInSheet,
+      reachForClick: reachInSheetForClick,
+      maxScrolls: 8,
+    });
+    expect(effortChipsShown).toBe(true);
 
     // Enabling axis-2 pre-selects the standard low/medium/high subset — exactly
     // the graded set this test wants. The chip is a toggle, so TAPPING a
@@ -215,12 +192,11 @@ describe('Local Graded-Effort Override', () => {
     // so a read-then-tap approach is unsafe. Instead we rely on the pre-applied
     // selection and only confirm the chips are present — no tapping.
     for (const level of ['low', 'medium', 'high']) {
-      await Gestures.scrollToElement(
+      const chipShown = await Gestures.scrollInSheetToElementExists(
         Selectors.modelSettings.effortChip(level),
-        4,
+        6,
       );
-      const chip = browser.$(Selectors.modelSettings.effortChip(level));
-      await chip.waitForDisplayed({timeout: 10000});
+      expect(chipShown).toBe(true);
     }
 
     const save = browser.$(Selectors.generationSettings.saveChangesButton);
@@ -281,7 +257,9 @@ describe('Local Graded-Effort Override', () => {
       current = await advance(current);
       const on = current.length > 0;
       states.push(on);
-      console.log(`pill state after step ${i + 1}: ${on ? `ON (${current})` : 'OFF'}`);
+      console.log(
+        `pill state after step ${i + 1}: ${on ? `ON (${current})` : 'OFF'}`,
+      );
     }
 
     expect(states).toEqual([true, true, true, false]);

--- a/e2e/specs/features/hub-run.spec.ts
+++ b/e2e/specs/features/hub-run.spec.ts
@@ -15,16 +15,14 @@
  *   yarn test:android:local --spec specs/features/hub-run.spec.ts
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
 import {expect} from '@wdio/globals';
 import {ChatPage} from '../../pages/ChatPage';
 import {DrawerPage} from '../../pages/DrawerPage';
 import {ModelsPage} from '../../pages/ModelsPage';
 import {ModelDetailsSheet} from '../../pages/ModelDetailsSheet';
 import {Selectors, byTestId, nativeTextElement} from '../../helpers/selectors';
+import {saveFailureScreenshot} from '../../helpers/screenshots';
 import {QUICK_TEST_MODEL, TIMEOUTS} from '../../fixtures/models';
-import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
 
 declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;
@@ -88,18 +86,7 @@ describe('Hub Run Deep Link', () => {
 
   afterEach(async function (this: Mocha.Context) {
     if (this.currentTest?.state === 'failed') {
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const testName = this.currentTest.title.replace(/\s+/g, '-');
-      try {
-        if (!fs.existsSync(SCREENSHOT_DIR)) {
-          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
-        }
-        await driver.saveScreenshot(
-          path.join(SCREENSHOT_DIR, `failure-${testName}-${timestamp}.png`),
-        );
-      } catch (e) {
-        console.error('Failed to capture screenshot:', (e as Error).message);
-      }
+      await saveFailureScreenshot(this.currentTest.title);
     }
   });
 

--- a/e2e/specs/features/remote-reasoning.spec.ts
+++ b/e2e/specs/features/remote-reasoning.spec.ts
@@ -41,8 +41,9 @@ import {
   nativeTextElement,
 } from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
+import {readControlEnabled, tapControl} from '../../helpers/control-state';
+import {saveFailureScreenshot} from '../../helpers/screenshots';
 import {TIMEOUTS} from '../../fixtures/models';
-import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
 
 declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;
@@ -134,6 +135,61 @@ async function dumpPageSource(name: string): Promise<void> {
   }
 }
 
+/**
+ * Enter the server URL and wait for the probe to report "Connected", retyping
+ * the URL to re-fire it on failure.
+ *
+ * The probe settles into a terminal "Connection failed" state, so a longer wait
+ * cannot rescue a transient network error — only another probe can.
+ */
+async function probeUntilConnected(
+  modelsPage: ModelsPage,
+  attempts = 3,
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const urlInput = browser.$(Selectors.remoteModel.urlInput);
+    await urlInput.waitForDisplayed({timeout: 5000});
+    await urlInput.clearValue();
+    await urlInput.setValue(SERVER_URL);
+
+    // Dismiss the keyboard so it does not cover the lower sheet (it blocks
+    // both the probe-revealed fields and scrolling to the dropdown).
+    await modelsPage.hideKeyboard();
+
+    const connected = await browser
+      .$(byPartialText('Connected'))
+      .waitForDisplayed({timeout: 15000})
+      .then(() => true)
+      .catch(() => false);
+    if (connected) {
+      console.log(`Probe connected to ${SERVER_URL} (attempt ${attempt})`);
+      return true;
+    }
+    console.log(`Probe attempt ${attempt} did not connect; re-firing`);
+    await browser.pause(1000);
+  }
+  return false;
+}
+
+/**
+ * Wait for any in-flight assistant turn to finish, so the composer is back to
+ * Send rather than Stop.
+ */
+async function waitForTurnToSettle(
+  timeout = TIMEOUTS.inference,
+): Promise<void> {
+  await browser
+    .waitUntil(
+      async () =>
+        !(await browser
+          .$(Selectors.chat.stopButton)
+          .isDisplayed()
+          .catch(() => false)),
+      {timeout, interval: 1000},
+    )
+    .catch(() => undefined);
+}
+
 describe('Remote Reasoning Features', () => {
   let chatPage: ChatPage;
   let drawerPage: DrawerPage;
@@ -165,18 +221,7 @@ describe('Remote Reasoning Features', () => {
 
   afterEach(async function (this: Mocha.Context) {
     if (this.currentTest?.state === 'failed') {
-      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const name = this.currentTest.title.replace(/\s+/g, '-');
-      try {
-        if (!fs.existsSync(SCREENSHOT_DIR)) {
-          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
-        }
-        await driver.saveScreenshot(
-          path.join(SCREENSHOT_DIR, `failure-${name}-${stamp}.png`),
-        );
-      } catch (e) {
-        console.error('Failed to capture screenshot:', (e as Error).message);
-      }
+      await saveFailureScreenshot(this.currentTest.title);
     }
   });
 
@@ -188,24 +233,8 @@ describe('Remote Reasoning Features', () => {
 
     await modelsPage.openAddRemoteModel();
 
-    // Enter server URL and let the auto-probe fire (debounce + network).
-    const urlInput = browser.$(Selectors.remoteModel.urlInput);
-    await urlInput.waitForDisplayed({timeout: 5000});
-    await urlInput.clearValue();
-    await urlInput.setValue(SERVER_URL);
-    console.log(`Entered server URL: ${SERVER_URL}`);
-
-    // Dismiss the keyboard so it does not cover the lower sheet (it blocks
-    // both the probe-revealed fields and scrolling to the dropdown).
-    await modelsPage.hideKeyboard();
-    await browser.pause(4000);
-
     // The probe reveals the server fields incl. the server-type dropdown.
-    const connectedText = browser.$(byPartialText('Connected'));
-    const isConnected = await connectedText
-      .waitForDisplayed({timeout: 12000})
-      .then(() => true)
-      .catch(() => false);
+    const isConnected = await probeUntilConnected(modelsPage);
     expect(isConnected).toBe(true);
 
     // Scroll the dropdown trigger into the rendered region. On iOS, controls
@@ -227,26 +256,33 @@ describe('Remote Reasoning Features', () => {
   it('adds the remote model, selects it, and activates it in chat', async () => {
     // Scroll the reasoning model row into view, then select it. The server
     // exposes many models, so the target row is well below the fold.
-    await Gestures.scrollInSheetToElementExists(byPartialText(MODEL_HINT), 12);
-    const modelEl = browser.$(byPartialText(MODEL_HINT));
-    const modelExists = await modelEl
-      .waitForExist({timeout: 8000})
-      .then(() => true)
-      .catch(() => false);
-    expect(modelExists).toBe(true);
-    await modelEl.click();
+    // Unscrolled the list is clipped to a few px and the pinned Add Model
+    // button overlaps its first row, so a tap at the row's centre lands on that
+    // button. Expand the sheet first, then require the row to be clear of it.
+    await Gestures.swipeUpInSheetBelowInputs();
+    await browser.pause(400);
+    const rowSelector = byPartialText(MODEL_HINT);
+    const modelReachable = await Gestures.scrollInSheetClearOfOverlay(
+      rowSelector,
+      Selectors.remoteModel.addModelButton,
+      12,
+      Gestures.swipeUpInSheetBelowInputs,
+    );
+    expect(modelReachable).toBe(true);
+    await tapControl(rowSelector);
     console.log(`Selected model matching "${MODEL_HINT}" in add sheet`);
     await browser.pause(500);
 
-    // Scroll to and tap "Add Model" (enabled once a model is selected).
-    await Gestures.scrollInSheetToElementExists(
-      Selectors.remoteModel.addModelButton,
-      6,
-    );
     const addButton = browser.$(Selectors.remoteModel.addModelButton);
     await addButton.waitForExist({timeout: 5000});
-    await addButton.waitForEnabled({timeout: 8000});
-    await addButton.click();
+    await browser.waitUntil(
+      () => readControlEnabled(Selectors.remoteModel.addModelButton),
+      {
+        timeout: 8000,
+        timeoutMsg: 'Add Model stayed disabled: no model was selected',
+      },
+    );
+    await tapControl(Selectors.remoteModel.addModelButton);
     await browser.pause(1000);
     console.log('Remote reasoning model added');
 
@@ -262,7 +298,7 @@ describe('Remote Reasoning Features', () => {
       .then(() => true)
       .catch(() => false);
     if (needsPick) {
-      await selectModelBtn.click();
+      await tapControl(byPartialText('Select Model'));
       await browser.pause(1000);
 
       // Picker opens on the Pals tab; swipe to the Models tab.
@@ -282,15 +318,26 @@ describe('Remote Reasoning Features', () => {
 
       const pickerModel = browser.$(byPartialText(MODEL_HINT));
       await pickerModel.waitForExist({timeout: 10000});
-      await pickerModel.click();
+      await tapControl(byPartialText(MODEL_HINT));
     }
 
     // Activation (setRemoteModel) is async: it releases any context and reads
     // the API key from the keychain before activeModel resolves and the chat
     // input renders. Poll until the chat input appears.
+    // The chat input is present whether or not a model is active -- when none
+    // is, it just reads "Model not loaded". Wait for that text to go away, or a
+    // failed activation passes here and every later test runs against a chat
+    // with no model.
     const chatInput = browser.$(Selectors.chat.input);
-    const activated = await chatInput
-      .waitForDisplayed({timeout: 20000})
+    await chatInput.waitForDisplayed({timeout: 20000}).catch(() => undefined);
+    const activated = await browser
+      .waitUntil(
+        async () => {
+          const placeholder = await chatInput.getText().catch(() => '');
+          return !placeholder.includes('Model not loaded');
+        },
+        {timeout: 20000, interval: 1000},
+      )
       .then(() => true)
       .catch(() => false);
     if (!activated) {
@@ -305,13 +352,15 @@ describe('Remote Reasoning Features', () => {
     // reasoning capability is "unknown" (fail-open), not gated on a native
     // context the remote path lacks. Poll because activation just settled.
     let visible = false;
-    await browser.waitUntil(
-      async () => {
-        visible = await chatPage.isThinkingToggleVisible();
-        return visible;
-      },
-      {timeout: 15000, interval: 1000, timeoutMsg: 'thinking pill not shown'},
-    ).catch(() => undefined);
+    await browser
+      .waitUntil(
+        async () => {
+          visible = await chatPage.isThinkingToggleVisible();
+          return visible;
+        },
+        {timeout: 15000, interval: 1000, timeoutMsg: 'thinking pill not shown'},
+      )
+      .catch(() => undefined);
     if (!visible) {
       await dumpPageSource('remote-pill-missing.xml');
     }
@@ -342,6 +391,9 @@ describe('Remote Reasoning Features', () => {
   });
 
   it('renders no reasoning bubble when thinking is OFF', async () => {
+    // The ON test asserts during early stream and returns while the turn is
+    // still generating; until it finishes the composer shows Stop, not Send.
+    await waitForTurnToSettle();
     await chatPage.resetChat();
 
     // Guard against a false pass: the OFF assertion is only meaningful if the

--- a/e2e/specs/features/remote-server.spec.ts
+++ b/e2e/specs/features/remote-server.spec.ts
@@ -26,8 +26,9 @@ import {
   nativeTextElement,
 } from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
+import {readControlEnabled, tapControl} from '../../helpers/control-state';
+import {saveFailureScreenshot} from '../../helpers/screenshots';
 import {TIMEOUTS} from '../../fixtures/models';
-import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
 
 declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;
@@ -64,18 +65,7 @@ describe('Remote Server Features', () => {
 
   afterEach(async function (this: Mocha.Context) {
     if (this.currentTest?.state === 'failed') {
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const testName = this.currentTest.title.replace(/\s+/g, '-');
-      try {
-        if (!fs.existsSync(SCREENSHOT_DIR)) {
-          fs.mkdirSync(SCREENSHOT_DIR, {recursive: true});
-        }
-        await driver.saveScreenshot(
-          path.join(SCREENSHOT_DIR, `failure-${testName}-${timestamp}.png`),
-        );
-      } catch (e) {
-        console.error('Failed to capture screenshot:', (e as Error).message);
-      }
+      await saveFailureScreenshot(this.currentTest.title);
     }
   });
 
@@ -165,19 +155,31 @@ describe('Remote Server Features', () => {
     // the model list sits below the fold — scroll by existence (controls deep
     // in a bottom sheet report isDisplayed=false on iOS) before selecting.
     if (REMOTE_MODEL_HINT) {
-      await Gestures.scrollInSheetToElementExists(
-        byPartialText(REMOTE_MODEL_HINT),
+      // The list gets ~36px of viewport before the sheet is scrolled, and the
+      // pinned Add Model button is painted across the first row -- a tap on the
+      // row's centre lands on that button instead. Scroll the row clear of it
+      // first, with a gesture that starts below the text inputs.
+      const rowSelector = byPartialText(REMOTE_MODEL_HINT);
+      // Unscrolled, the row is clipped to ~10px (measured [42,2204][1038,2214]),
+      // which already sits above the button and so reads as reachable while
+      // being far too small to tap. Scroll once so the list has real rows before
+      // asking whether anything is clear.
+      await Gestures.swipeUpInSheetBelowInputs();
+      await browser.pause(400);
+      const reachable = await Gestures.scrollInSheetClearOfOverlay(
+        rowSelector,
+        Selectors.remoteModel.addModelButton,
         12,
+        Gestures.swipeUpInSheetBelowInputs,
       );
-      const modelEl = browser.$(byPartialText(REMOTE_MODEL_HINT));
-      const exists = await modelEl
-        .waitForExist({timeout: 8000})
-        .then(() => true)
-        .catch(() => false);
-      if (exists) {
-        await modelEl.click();
+      if (reachable) {
+        await tapControl(rowSelector);
         console.log(`Selected model matching "${REMOTE_MODEL_HINT}"`);
         await browser.pause(500);
+      } else {
+        console.log(
+          `Model "${REMOTE_MODEL_HINT}" never came clear of Add Model`,
+        );
       }
     } else {
       // No hint: a single returned model auto-selects. Otherwise scroll the
@@ -210,11 +212,32 @@ describe('Remote Server Features', () => {
     );
     const addButton = browser.$(Selectors.remoteModel.addModelButton);
     await addButton.waitForExist({timeout: 5000});
-    await addButton.waitForEnabled({timeout: 8000});
-    await addButton.click();
-    await browser.pause(1000);
+    // The button only enables once a model is selected, and its wrapper is
+    // always enabled -- so the real control decides whether the tap is worth
+    // making at all.
+    await browser.waitUntil(
+      () => readControlEnabled(Selectors.remoteModel.addModelButton),
+      {
+        timeout: 8000,
+        timeoutMsg: 'Add Model stayed disabled: no model was selected',
+      },
+    );
+    await tapControl(Selectors.remoteModel.addModelButton);
 
-    console.log('Remote model added successfully');
+    // Assert the model actually landed. The later sub-tests drive the card this
+    // step creates, so without an outcome check they fail against an empty
+    // Models screen, far from the cause.
+    await modelsPage.waitForReady();
+    const readyGroup = browser.$(
+      Selectors.models.modelAccordion('Ready to Use'),
+    );
+    await readyGroup.waitForDisplayed({timeout: TIMEOUTS.element});
+
+    if (REMOTE_MODEL_HINT) {
+      const addedCard = browser.$(byPartialText(REMOTE_MODEL_HINT));
+      await addedCard.waitForDisplayed({timeout: TIMEOUTS.element});
+    }
+    console.log('Remote model added and visible on the Models screen');
   });
 
   it('should select and chat with a remote model', async () => {
@@ -330,9 +353,7 @@ describe('Remote Server Features', () => {
 
         if (responseText && responseText.length > 0) {
           const stopButton = browser.$(Selectors.chat.stopButton);
-          const stopVisible = await stopButton
-            .isDisplayed()
-            .catch(() => false);
+          const stopVisible = await stopButton.isDisplayed().catch(() => false);
           if (!stopVisible) {
             break;
           }

--- a/e2e/specs/features/speculative-paired.spec.ts
+++ b/e2e/specs/features/speculative-paired.spec.ts
@@ -54,9 +54,11 @@ import {ModelDetailsSheet} from '../../pages/ModelDetailsSheet';
 import {SettingsPage} from '../../pages/SettingsPage';
 import {Selectors, byTestId, byPartialText} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
+import {readAccessibilityLabel} from '../../helpers/element-text';
 import {
   dismissPerformanceWarningIfPresent,
   dismissContextRoomSheetIfPresent,
+  waitForModelDownloaded,
 } from '../../helpers/model-actions';
 import {TIMEOUTS, ModelTestConfig} from '../../fixtures/models';
 import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
@@ -268,12 +270,7 @@ async function downloadModelOnly(model: ModelTestConfig): Promise<void> {
   await modelsPage.waitForReady();
 
   const downloadTimeout = model.downloadTimeout ?? TIMEOUTS.download;
-  const containerSelector = Selectors.modelCard.cardContainer(
-    model.downloadFile,
-  );
-  await browser
-    .$(containerSelector)
-    .waitForDisplayed({timeout: downloadTimeout});
+  await waitForModelDownloaded(model.downloadFile, downloadTimeout);
 
   // The card flips to "downloaded" on isDownloaded=true, then the GGUF metadata
   // (nextn/width) is fetched right after; give that async read a beat to land so
@@ -327,8 +324,8 @@ async function downloadAndLoadTarget(model: ModelTestConfig): Promise<void> {
   const containerSelector = Selectors.modelCard.cardContainer(
     model.downloadFile,
   );
+  await waitForModelDownloaded(model.downloadFile, downloadTimeout);
   const modelCardContainer = browser.$(containerSelector);
-  await modelCardContainer.waitForDisplayed({timeout: downloadTimeout});
 
   const loadBtn = modelCardContainer.$(Selectors.modelCard.loadButtonElement);
   await loadBtn.waitForDisplayed({timeout: 10000});
@@ -357,11 +354,7 @@ async function pickDraftModel(
   await item.click();
   await browser.pause(700);
 
-  const pickerLabel =
-    (await browser
-      .$(SPEC_PICKER)
-      .getAttribute('label')
-      .catch(() => '')) || '';
+  const pickerLabel = await readAccessibilityLabel(SPEC_PICKER);
   console.log(`[paired] draft picker after selection: ${pickerLabel}`);
 }
 
@@ -476,8 +469,7 @@ describe('Speculative Decoding / separate-draft (paired) MTP', () => {
     }
 
     const draftEl = browser.$(DRAFT_TOKENS_EL);
-    const draftText =
-      (await draftEl.getAttribute('label').catch(() => '')) || '';
+    const draftText = await draftEl.getText();
     console.log(`[paired] draft tokens surfaced: ${draftText}`);
 
     // "draft: <accepted>/<total> (<pct>%)" -- total is draft_tokens; > 0 == engaged.
@@ -486,11 +478,9 @@ describe('Speculative Decoding / separate-draft (paired) MTP', () => {
     expect(Number(m && m[1])).toBeGreaterThanOrEqual(0);
     expect(Number(m && m[2])).toBeGreaterThan(0);
 
-    const timingText =
-      (await browser
-        .$(TIMING_EL)
-        .getAttribute('label')
-        .catch(() => '')) || '';
+    const timingEl = browser.$(TIMING_EL);
+    await timingEl.waitForExist({timeout: TIMEOUTS.element});
+    const timingText = await timingEl.getText();
     console.log(`[paired] timings surfaced: ${timingText}`);
     const rate = timingText.match(/([\d.]+)\s*tokens?\/sec/i);
     expect(rate).not.toBeNull();

--- a/e2e/specs/features/speculative-paired.spec.ts
+++ b/e2e/specs/features/speculative-paired.spec.ts
@@ -55,6 +55,8 @@ import {SettingsPage} from '../../pages/SettingsPage';
 import {Selectors, byTestId, byPartialText} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
 import {readAccessibilityLabel} from '../../helpers/element-text';
+import {ensureRevealed} from '../../helpers/disclosure';
+import {readSwitchState} from '../../helpers/control-state';
 import {
   dismissPerformanceWarningIfPresent,
   dismissContextRoomSheetIfPresent,
@@ -67,37 +69,48 @@ declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;
 
 /**
- * Separate MTP draft: arch gemma4-assistant, nextn_predict_layers=4, ~98 MB.
- * Downloaded (not loaded) so its width/MTP metadata is available to the pairing
- * resolver and it appears in the draft-model picker.
+ * Fixture pair, overridable per device. The default gemma-4 set needs ~2.9 GB,
+ * which does not fit every target; any pair works so long as the draft is
+ * MTP-capable and its n_embd_out equals the target's n_embd (draftResolution.ts).
+ */
+const env = (name: string, fallback: string): string =>
+  process.env[name] || fallback;
+
+/**
+ * Separate MTP draft. Downloaded (not loaded) so its width/MTP metadata is
+ * available to the pairing resolver and it appears in the draft-model picker.
+ *
+ * The draft file is ~97 MB, but the app pairs every file in a multimodal repo
+ * with its mmproj, so the actual transfer is ~655 MB — well past the 5-minute
+ * default.
  */
 const DRAFT_MODEL: ModelTestConfig = {
-  id: 'gemma-4-e2b-mtp-draft',
-  searchQuery: 'ggml-org gemma-4-E2B-it-GGUF',
-  selectorText: 'gemma-4-E2B-it',
-  downloadFile: 'mtp-gemma-4-E2B-it-Q8_0.gguf',
+  id: 'paired-mtp-draft',
+  searchQuery: env('E2E_PAIRED_DRAFT_QUERY', 'ggml-org gemma-4-E2B-it-GGUF'),
+  selectorText: env('E2E_PAIRED_DRAFT_SELECTOR', 'gemma-4-E2B-it'),
+  downloadFile: env('E2E_PAIRED_DRAFT_FILE', 'mtp-gemma-4-E2B-it-Q8_0.gguf'),
+  downloadTimeout: Number(process.env.E2E_DOWNLOAD_TIMEOUT) || 900000,
   prompts: [{input: 'Hi', description: 'Basic greeting'}],
 };
 
 /**
- * The chat target paired with the draft. Loaded TEXT-ONLY (no mmproj). Same
- * repo as the draft (arch `gemma4`, no nextn KV — genuinely non-MTP), and the
- * exact pair the Pixel 9 engagement evidence was captured with.
+ * The chat target paired with the draft. The default is loaded TEXT-ONLY (no
+ * mmproj) because its repo is multimodal.
  */
 const TARGET_MODEL: ModelTestConfig = {
-  id: 'gemma-4-e2b-target',
-  searchQuery: 'ggml-org gemma-4-E2B-it-GGUF',
-  selectorText: 'gemma-4-E2B-it',
-  downloadFile: 'gemma-4-E2B-it-Q4_0.gguf',
-  // ~3.5 GB; HF often serves large files at only a few MB/s, so the wait is
+  id: 'paired-target',
+  searchQuery: env('E2E_PAIRED_TARGET_QUERY', 'ggml-org gemma-4-E2B-it-GGUF'),
+  selectorText: env('E2E_PAIRED_TARGET_SELECTOR', 'gemma-4-E2B-it'),
+  downloadFile: env('E2E_PAIRED_TARGET_FILE', 'gemma-4-E2B-it-Q4_0.gguf'),
+  // HF often serves large files at only a few MB/s, so the wait is
   // overridable for slow lanes the way E2E_MOCHA_TIMEOUT is.
   downloadTimeout: Number(process.env.E2E_DOWNLOAD_TIMEOUT) || 900000,
   prompts: [{input: 'Hi', description: 'Basic greeting'}],
-  disableVisionBeforeLoad: true,
+  disableVisionBeforeLoad: process.env.E2E_PAIRED_TARGET_VISION !== 'false',
 };
 
 /** Fragment of the draft's display name (extractHFModelTitle == filename). */
-const DRAFT_TITLE_FRAGMENT = 'mtp-gemma-4-E2B-it-Q8_0';
+const DRAFT_TITLE_FRAGMENT = DRAFT_MODEL.downloadFile.replace(/\.gguf$/, '');
 
 /**
  * n_ctx for the run. The paired draft needs room to draft to completion; with
@@ -108,6 +121,8 @@ const DRAFT_TITLE_FRAGMENT = 'mtp-gemma-4-E2B-it-Q8_0';
 const SPEC_CONTEXT_SIZE = '4096';
 
 const SPEC_ACCORDION = byTestId('advanced-settings-accordion');
+/** First row inside the accordion — mounted only while it is expanded. */
+const SPEC_ACCORDION_FIRST_ROW = byTestId('batch-size-slider');
 const SPEC_SWITCH = byTestId('speculative-decoding-switch');
 const SPEC_PICKER = byTestId('speculative-draft-model-picker');
 
@@ -150,6 +165,11 @@ function freshCrashReports(sinceMs: number): string[] {
  * the screen mounted), so rewind to the top before scrolling to a row.
  */
 async function scrollSettingsToTop(): Promise<void> {
+  // A fixed swipe count cannot rewind a list whose height depends on whether
+  // the Advanced accordion is expanded; the native scroller has no such limit.
+  if (await Gestures.nativeScrollIntoView(byTestId('context-size-input'))) {
+    return;
+  }
   for (let i = 0; i < 8; i++) {
     await Gestures.swipeDown();
   }
@@ -180,26 +200,73 @@ async function goToSettings(settingsPage: SettingsPage): Promise<void> {
   }
 }
 
+/**
+ * The iOS simulator's Metal shim aborts in MTLSimDevice.newBufferWithLength
+ * (_xpc_shmem_create_with_prot) once a paired draft decodes alongside a large
+ * target, so runs there select the CPU backend. Draft-token production is
+ * backend-independent, so the engagement proof is unaffected.
+ */
+async function forceCpuIfRequested(settingsPage: SettingsPage): Promise<void> {
+  if (process.env.E2E_FORCE_CPU !== 'true') {
+    return;
+  }
+  await goToSettings(settingsPage);
+  await scrollSettingsToTop();
+  const cpuOption = byTestId('device-option-cpu');
+  const reached =
+    (await Gestures.nativeScrollIntoView(cpuOption)) ||
+    (await Gestures.scrollToElement(cpuOption, 10));
+  if (!reached) {
+    console.log('[paired] CPU device option not present; leaving backend as-is');
+    return;
+  }
+  await browser.pause(700);
+  await browser.$(cpuOption).click();
+  await browser.pause(700);
+  console.log('[paired] selected CPU backend');
+
+  // The draft carries its own layer count (spec_draft_n_gpu_layers, default
+  // 99), so the device selector alone leaves the draft's decode on Metal —
+  // which is exactly where the simulator aborts.
+  await enableSpeculativeGlobally(settingsPage);
+  const draftLayers = byTestId('speculative-draft-gpu-layers-slider-input');
+  const draftReached =
+    (await Gestures.nativeScrollIntoView(draftLayers)) ||
+    (await Gestures.scrollToElement(draftLayers, 12));
+  if (!draftReached) {
+    console.log('[paired] draft gpu-layers input not reachable');
+    return;
+  }
+  const input = browser.$(draftLayers);
+  await input.clearValue();
+  await input.setValue('0');
+  await browser.pause(500);
+  // The layer count uses a numeric keypad, which has no Return/Done key. ESC
+  // closes it on Android without the back-press that hideKeyboard() emits (a
+  // pop React Navigation would consume); iOS needs the driver's own dismiss.
+  if ((browser as any).isAndroid) {
+    await (browser as any).pressKeyCode(111).catch(() => undefined);
+  } else {
+    await browser
+      .execute('mobile: hideKeyboard' as any)
+      .catch(() => undefined);
+  }
+  await browser.pause(500);
+  console.log('[paired] draft gpu layers set to 0');
+}
+
 /** Enable speculative decoding globally in Settings -> Advanced. */
 async function enableSpeculativeGlobally(
   settingsPage: SettingsPage,
 ): Promise<void> {
   await goToSettings(settingsPage);
-  // A revisit restores the previous scroll offset, and scrollToElement only
-  // searches downward — start every pass from the top. Try to reach the
-  // switch first: off-viewport content is absent from the a11y tree, so an
-  // existence probe cannot tell "accordion collapsed" from "row below the
-  // fold", and a blind accordion click can collapse an open section.
-  await scrollSettingsToTop();
-  await Gestures.scrollToElement(SPEC_ACCORDION, 8);
-  let switchReachable = await Gestures.scrollToElement(SPEC_SWITCH, 8);
-  if (!switchReachable) {
-    await scrollSettingsToTop();
-    await Gestures.scrollToElement(SPEC_ACCORDION, 8);
-    await browser.$(SPEC_ACCORDION).click();
-    await browser.pause(500);
-    switchReachable = await Gestures.scrollToElement(SPEC_SWITCH, 8);
-  }
+  await ensureRevealed({
+    toggle: SPEC_ACCORDION,
+    dependent: SPEC_SWITCH,
+    stateProbe: SPEC_ACCORDION_FIRST_ROW,
+    rewind: scrollSettingsToTop,
+    maxScrolls: 8,
+  });
   await browser.$(SPEC_SWITCH).waitForExist({timeout: TIMEOUTS.element});
 
   // Read the switch itself: with app state persisted between runs
@@ -222,6 +289,61 @@ async function enableSpeculativeGlobally(
   }
   await Gestures.scrollToElement(SPEC_PICKER, 4);
   await browser.$(SPEC_PICKER).waitForExist({timeout: TIMEOUTS.element});
+}
+
+/**
+ * Download a file with its vision projection turned OFF.
+ *
+ * The plain download button on a file card always passes `enableVision: true`,
+ * so every file in a multimodal repo drags its ~557 MB mmproj along (a 97 MB
+ * draft becomes a 655 MB transfer). The projection is reachable only through
+ * the card's vision chip, which opens a sheet carrying its own toggle and
+ * Download button. Neither control has a testID, so both are matched on text.
+ *
+ * Returns false when the file has no vision chip — a non-multimodal file needs
+ * the normal path.
+ */
+async function tapDownloadWithoutVision(filename: string): Promise<boolean> {
+  const card = browser.$(Selectors.modelDetails.fileCard(filename));
+  const chip = card.$(byPartialText('Includes vision capability'));
+  if (!(await chip.isExisting().catch(() => false))) {
+    return false;
+  }
+  await browser.pause(700);
+  await chip.click();
+  await browser.pause(1500);
+
+  const toggle = browser.$(
+    (browser as any).isAndroid
+      ? '//android.widget.Switch'
+      : '-ios class chain:**/XCUIElementTypeSwitch',
+  );
+  if (await toggle.isExisting().catch(() => false)) {
+    const on = await readSwitchState(
+      (browser as any).isAndroid
+        ? '//android.widget.Switch'
+        : '-ios class chain:**/XCUIElementTypeSwitch',
+    );
+    if (on !== false) {
+      await toggle.click();
+      await browser.pause(700);
+    }
+  }
+
+  // Exact match on the button: every file row behind the sheet also carries a
+  // download control, labelled "Download model", and a substring match resolves
+  // one of those instead — a tap that lands under the sheet and does nothing.
+  const downloadBtn = browser.$(
+    (browser as any).isAndroid
+      ? '//android.widget.Button[@content-desc="Download"]'
+      : '-ios predicate string:type == "XCUIElementTypeButton" AND label == "Download"',
+  );
+  await downloadBtn.waitForExist({timeout: TIMEOUTS.element});
+  await browser.pause(500);
+  await downloadBtn.click();
+  await browser.pause(1500);
+  console.log(`[paired] ${filename}: downloading without vision projection`);
+  return true;
 }
 
 /**
@@ -263,7 +385,12 @@ async function downloadModelOnly(model: ModelTestConfig): Promise<void> {
   await modelDetailsSheet.waitForReady();
 
   await modelDetailsSheet.scrollToFile(model.downloadFile);
-  await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+  if (
+    process.env.E2E_PAIRED_NO_VISION !== 'true' ||
+    !(await tapDownloadWithoutVision(model.downloadFile))
+  ) {
+    await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+  }
 
   await modelDetailsSheet.close();
   await hfSearchSheet.close();
@@ -311,7 +438,12 @@ async function downloadAndLoadTarget(model: ModelTestConfig): Promise<void> {
     await modelDetailsSheet.waitForReady();
 
     await modelDetailsSheet.scrollToFile(model.downloadFile);
-    await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+    if (
+      process.env.E2E_PAIRED_NO_VISION !== 'true' ||
+      !(await tapDownloadWithoutVision(model.downloadFile))
+    ) {
+      await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+    }
 
     await modelDetailsSheet.close();
     await hfSearchSheet.close();
@@ -394,6 +526,7 @@ describe('Speculative Decoding / separate-draft (paired) MTP', () => {
     await goToSettings(settingsPage);
     await settingsPage.setContextSize(SPEC_CONTEXT_SIZE);
     await enableSpeculativeGlobally(settingsPage);
+    await forceCpuIfRequested(settingsPage);
     await saveShot('speculative-paired-settings-enabled');
   });
 

--- a/e2e/specs/features/speculative-visual.spec.ts
+++ b/e2e/specs/features/speculative-visual.spec.ts
@@ -38,7 +38,13 @@ import {ModelDetailsSheet} from '../../pages/ModelDetailsSheet';
 import {SettingsPage} from '../../pages/SettingsPage';
 import {Selectors, byTestId, byPartialText} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
-import {dismissPerformanceWarningIfPresent} from '../../helpers/model-actions';
+import {ensureRevealed} from '../../helpers/disclosure';
+import {readControlEnabled, readSwitchState} from '../../helpers/control-state';
+import {readAccessibilityLabel} from '../../helpers/element-text';
+import {
+  dismissPerformanceWarningIfPresent,
+  waitForModelDownloaded,
+} from '../../helpers/model-actions';
 import {TIMEOUTS} from '../../fixtures/models';
 import {SCREENSHOT_DIR} from '../../wdio.shared.conf';
 
@@ -104,17 +110,6 @@ async function saveShot(name: string): Promise<void> {
   }
 }
 
-/** Rendered text of an element (accessibility label carries it on both OSes). */
-async function readLabel(selector: string): Promise<string> {
-  const attr = (browser as any).isAndroid ? 'content-desc' : 'label';
-  return (
-    (await browser
-      .$(selector)
-      .getAttribute(attr)
-      .catch(() => '')) || ''
-  );
-}
-
 /**
  * Settings keeps its scroll offset and accordion state between visits (the
  * drawer navigator keeps the screen mounted), so every visit rewinds to the top
@@ -163,14 +158,15 @@ async function openAdvancedSection(navigate = true): Promise<void> {
   if (navigate) {
     await goToSettings();
   }
-  if (!(await browser.$(SPEC_SWITCH).isExisting())) {
-    if (!(await scrollSettingsTo(SPEC_ACCORDION))) {
-      throw new Error('Advanced settings accordion never came into view');
-    }
-    await browser.$(SPEC_ACCORDION).click();
-    await browser.pause(700);
+  const revealed = await ensureRevealed({
+    toggle: SPEC_ACCORDION,
+    dependent: SPEC_SWITCH,
+    rewind: scrollSettingsToTop,
+    maxScrolls: 12,
+  });
+  if (!revealed) {
+    throw new Error('Speculative decoding switch never came into view');
   }
-  await scrollSettingsTo(SPEC_SWITCH);
   await browser.$(SPEC_SWITCH).waitForExist({timeout: TIMEOUTS.element});
 }
 
@@ -180,11 +176,16 @@ async function openAdvancedSection(navigate = true): Promise<void> {
  * wrapper view and exposes no usable value attribute).
  */
 async function setSpeculative(enabled: boolean): Promise<void> {
-  const isOn = await browser.$(SPEC_PICKER).isExisting();
-  if (isOn !== enabled) {
-    await browser.$(SPEC_SWITCH).click();
-    await browser.pause(800);
+  await scrollSettingsTo(SPEC_SWITCH);
+  const state = await readSwitchState(SPEC_SWITCH);
+  const isOn =
+    state === null ? await Gestures.scrollToElement(SPEC_PICKER, 3) : state;
+  if (isOn === enabled) {
+    return;
   }
+  await scrollSettingsTo(SPEC_SWITCH);
+  await browser.$(SPEC_SWITCH).click();
+  await browser.pause(800);
 }
 
 /**
@@ -251,7 +252,7 @@ async function selectDraftModel(fragment: string): Promise<string> {
     await dismissMenu();
   }
   await browser.pause(500);
-  const label = await readLabel(SPEC_PICKER);
+  const label = await readAccessibilityLabel(SPEC_PICKER);
   console.log(`[draft picker] "${fragment}" -> "${label}"`);
   return label;
 }
@@ -288,8 +289,8 @@ async function downloadModelViaHFSearch(
   const containerSelector = Selectors.modelCard.cardContainer(
     model.downloadFile,
   );
+  await waitForModelDownloaded(model.downloadFile, TIMEOUTS.download);
   const container = browser.$(containerSelector);
-  await container.waitForDisplayed({timeout: TIMEOUTS.download});
   // The load button only renders once the file is fully downloaded.
   await container
     .$(Selectors.modelCard.loadButtonElement)
@@ -462,7 +463,9 @@ describe('Speculative decoding — visual states', () => {
 
     await scrollSettingsTo(SPEC_IGNORED_NOTE);
     await expect(browser.$(SPEC_IGNORED_NOTE)).toBeExisting();
-    console.log(`[ignored note] ${await readLabel(SPEC_IGNORED_NOTE)}`);
+    console.log(
+      `[ignored note] ${await readAccessibilityLabel(SPEC_IGNORED_NOTE)}`,
+    );
     await saveShot('mtp-03-ignored-note-draft-not-capable');
   });
 
@@ -472,12 +475,15 @@ describe('Speculative decoding — visual states', () => {
 
     await scrollSettingsTo(SPEC_NO_EFFECT_NOTE);
     await expect(browser.$(SPEC_NO_EFFECT_NOTE)).toBeExisting();
-    console.log(`[no-effect note] ${await readLabel(SPEC_NO_EFFECT_NOTE)}`);
+    console.log(
+      `[no-effect note] ${await readAccessibilityLabel(SPEC_NO_EFFECT_NOTE)}`,
+    );
     await saveShot('mtp-08-no-effect-note');
 
     await scrollSettingsTo(DRAFT_KEY_CACHE);
-    expect(await browser.$(DRAFT_KEY_CACHE).isEnabled()).toBe(false);
-    expect(await browser.$(DRAFT_VALUE_CACHE).isEnabled()).toBe(false);
+    expect(await readControlEnabled(DRAFT_KEY_CACHE)).toBe(false);
+    await scrollSettingsTo(DRAFT_VALUE_CACHE);
+    expect(await readControlEnabled(DRAFT_VALUE_CACHE)).toBe(false);
     await saveShot('mtp-09-draft-cache-rows-disabled');
   });
 
@@ -490,12 +496,18 @@ describe('Speculative decoding — visual states', () => {
     expect(label).toContain(MTP.nameFragment);
 
     await scrollSettingsTo(DRAFT_KEY_CACHE);
-    expect(await browser.$(DRAFT_KEY_CACHE).isEnabled()).toBe(true);
-    expect(await browser.$(DRAFT_VALUE_CACHE).isEnabled()).toBe(true);
-    console.log(`[draft key cache] ${await readLabel(DRAFT_KEY_CACHE)}`);
-    console.log(`[draft value cache] ${await readLabel(DRAFT_VALUE_CACHE)}`);
+    expect(await readControlEnabled(DRAFT_KEY_CACHE)).toBe(true);
+    await scrollSettingsTo(DRAFT_VALUE_CACHE);
+    expect(await readControlEnabled(DRAFT_VALUE_CACHE)).toBe(true);
+    console.log(
+      `[draft key cache] ${await readAccessibilityLabel(DRAFT_KEY_CACHE)}`,
+    );
+    console.log(
+      `[draft value cache] ${await readAccessibilityLabel(DRAFT_VALUE_CACHE)}`,
+    );
     await saveShot('mtp-10-draft-cache-rows-enabled-paired');
 
+    await scrollSettingsTo(DRAFT_KEY_CACHE);
     await browser.$(DRAFT_KEY_CACHE).click();
     await browser.pause(1000);
     await saveShot('mtp-11-draft-cache-menu-open');
@@ -520,14 +532,21 @@ describe('Speculative decoding — visual states', () => {
     await scrollSettingsTo(SPEC_IGNORED_NOTE);
     await expect(browser.$(SPEC_IGNORED_NOTE)).toBeExisting();
     await expect(browser.$(SPEC_NO_EFFECT_NOTE)).not.toBeExisting();
-    console.log(`[ignored note] ${await readLabel(SPEC_IGNORED_NOTE)}`);
+    console.log(
+      `[ignored note] ${await readAccessibilityLabel(SPEC_IGNORED_NOTE)}`,
+    );
     await saveShot('mtp-12-ignored-note-draft-incompatible');
 
     await scrollSettingsTo(DRAFT_KEY_CACHE);
-    expect(await browser.$(DRAFT_KEY_CACHE).isEnabled()).toBe(true);
-    expect(await browser.$(DRAFT_VALUE_CACHE).isEnabled()).toBe(true);
-    console.log(`[draft key cache] ${await readLabel(DRAFT_KEY_CACHE)}`);
-    console.log(`[draft value cache] ${await readLabel(DRAFT_VALUE_CACHE)}`);
+    expect(await readControlEnabled(DRAFT_KEY_CACHE)).toBe(true);
+    await scrollSettingsTo(DRAFT_VALUE_CACHE);
+    expect(await readControlEnabled(DRAFT_VALUE_CACHE)).toBe(true);
+    console.log(
+      `[draft key cache] ${await readAccessibilityLabel(DRAFT_KEY_CACHE)}`,
+    );
+    console.log(
+      `[draft value cache] ${await readAccessibilityLabel(DRAFT_VALUE_CACHE)}`,
+    );
     await saveShot('mtp-13-draft-cache-rows-enabled-embedded');
   });
 });

--- a/e2e/specs/features/speculative-visual.spec.ts
+++ b/e2e/specs/features/speculative-visual.spec.ts
@@ -79,6 +79,8 @@ const SPEC_CONTEXT_SIZE = '4096';
 const BADGE_PROBE_TIMEOUT = 90000;
 
 const SPEC_ACCORDION = byTestId('advanced-settings-accordion');
+/** First row inside the accordion — mounted only while it is expanded. */
+const SPEC_ACCORDION_FIRST_ROW = byTestId('batch-size-slider');
 const SPEC_SWITCH = byTestId('speculative-decoding-switch');
 const SPEC_PICKER = byTestId('speculative-draft-model-picker');
 const SPEC_NO_EFFECT_NOTE = byTestId('speculative-no-effect-note');
@@ -116,6 +118,11 @@ async function saveShot(name: string): Promise<void> {
  * before scrolling to a target.
  */
 async function scrollSettingsToTop(): Promise<void> {
+  // A fixed swipe count cannot rewind a list whose height depends on whether
+  // the Advanced accordion is expanded; the native scroller has no such limit.
+  if (await Gestures.nativeScrollIntoView(byTestId('context-size-input'))) {
+    return;
+  }
   for (let i = 0; i < 8; i++) {
     await Gestures.swipeDown();
   }
@@ -161,6 +168,7 @@ async function openAdvancedSection(navigate = true): Promise<void> {
   const revealed = await ensureRevealed({
     toggle: SPEC_ACCORDION,
     dependent: SPEC_SWITCH,
+    stateProbe: SPEC_ACCORDION_FIRST_ROW,
     rewind: scrollSettingsToTop,
     maxScrolls: 12,
   });

--- a/e2e/specs/features/speculative.spec.ts
+++ b/e2e/specs/features/speculative.spec.ts
@@ -46,6 +46,7 @@ import {ChatPage} from '../../pages/ChatPage';
 import {SettingsPage} from '../../pages/SettingsPage';
 import {Selectors, byTestId, nativeTextElement} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
+import {ensureRevealed} from '../../helpers/disclosure';
 import {
   downloadAndLoadModel,
   waitForInferenceComplete,
@@ -104,6 +105,8 @@ const SPEC_CONTEXT_SIZE = '4096';
 const SPEC_INFERENCE_TIMEOUT = 420000;
 
 const SPEC_ACCORDION = byTestId('advanced-settings-accordion');
+/** First row inside the accordion — mounted only while it is expanded. */
+const SPEC_ACCORDION_FIRST_ROW = byTestId('batch-size-slider');
 const SPEC_SWITCH = byTestId('speculative-decoding-switch');
 const SPEC_PICKER = byTestId('speculative-draft-model-picker');
 const SPEC_GPU_LAYERS = byTestId('speculative-draft-gpu-layers-slider');
@@ -139,17 +142,31 @@ async function goToSettings(settingsPage: SettingsPage): Promise<void> {
   await settingsPage.navigateTo();
 }
 
+/**
+ * Rewind Settings to the top. `scrollToElement` only searches downward, so a
+ * pass that has already scrolled past a row can never reach it again.
+ */
+async function scrollSettingsToTop(): Promise<void> {
+  if (await Gestures.nativeScrollIntoView(byTestId('context-size-input'))) {
+    return;
+  }
+  for (let i = 0; i < 8; i++) {
+    await Gestures.swipeDown();
+  }
+}
+
 /** Enable speculative decoding globally in Settings -> Advanced. */
 async function enableSpeculativeGlobally(
   settingsPage: SettingsPage,
 ): Promise<void> {
   await goToSettings(settingsPage);
-  await Gestures.scrollToElement(SPEC_ACCORDION, 8);
-  if (!(await browser.$(SPEC_SWITCH).isExisting())) {
-    await browser.$(SPEC_ACCORDION).click();
-    await browser.pause(500);
-  }
-  await Gestures.scrollToElement(SPEC_SWITCH, 8);
+  await ensureRevealed({
+    toggle: SPEC_ACCORDION,
+    dependent: SPEC_SWITCH,
+    stateProbe: SPEC_ACCORDION_FIRST_ROW,
+    rewind: scrollSettingsToTop,
+    maxScrolls: 8,
+  });
   await browser.$(SPEC_SWITCH).waitForExist({timeout: TIMEOUTS.element});
 
   // Read the switch itself: with app state persisted between runs


### PR DESCRIPTION
## Summary

Six Android e2e feature specs were failing. They turned out to share one root cause: each asked a **proxy** about the UI rather than the control itself. Android exposes the real answers, so these fixes read state instead of inferring it.

**No app bugs.** Every failure was in the specs or helpers. Two cases looked like app defects and were disproven on device (see below).

## Verified on a Pixel 9 against v1.17.1

| spec | before | after |
|---|---|---|
| `speculative-paired` | assertion unreachable on Android | ✅ `draft: 85/159 (53%)` real acceptance |
| `speculative-visual` | 5 failing, 7 captures | ✅ 6/6, all **13** captures |
| `remote-server` | passed while adding nothing | ✅ 3/3 |
| `remote-reasoning` | subject never exercised | ✅ 5/5 |
| `graded-effort-override` | never root-caused | ✅ full graded cycle |
| stuck `hf-model-search-view` | dominant suite failure | ✅ fixed |

## The one mistake, in five costumes

- **Infer a section's state from a control it reveals.** Off-viewport content is absent from the accessibility tree, so an existence probe can't tell *"section closed"* from *"row below the fold"* — and since the corrective action is a **toggle**, the false negative closed a section that was already open.
- **Read text off a wrapper.** `label` is iOS-only and throws on Android; a surrounding `.catch(() => '')` turned that into `''`, so the engagement regex could never match. UiAutomator2 also returns the literal string `"null"` for an absent attribute, defeating `|| ''`.
- **Read `enabled` off a wrapper.** A paper Button expands into four nodes sharing the testID prefix and `byTestId` matches a *substring*, so a disabled control reported enabled.
- **Tap a text node.** `byPartialText` resolves a `TextView`, which isn't clickable — the tap is accepted and selects nothing.
- **Assert a surface, not an outcome.** Both remote specs passed while the app was empty, pushing failures into later tests far from the cause.

`readSwitchState` / `readControlEnabled` / `tapControl` (`helpers/control-state.ts`) and `ensureRevealed` / `ensureSwitchOn` (`helpers/disclosure.ts`) exist so this class stops recurring.

## Two app-bug reports that were wrong, and how they were disproven

- **"The HF search sheet survives its close button and system-back."** Control on a **healthy** sheet: back never closes it — it falls through to React Navigation and navigates the screen underneath. That "wedged" signature is the baseline. Under the harness the first close tap is swallowed while the details sheet dismisses (its handle covers the button); the **second tap closes it**. Spec bug.
- **"Speculative decoding does not engage."** The turn completed with timings and no `draft: a/b` footer. Native log says otherwise: `RNLlama loadModel:508 Loading MTP draft model: …`. The cause was test setup — see below.

## Latent issues found, not fixed here

- **`byTestId` is substring-based and every paper control is ambiguous under it.** ~26 react-native-paper components derive child testIDs from the parent, so any state read can silently interrogate a wrapper. Two bugs in this PR are instances. Exact-match (`//*[@resource-id="x"]`) is the candidate fix — deliberately **not** applied here, because it would replace code that is verified green with an unverified alternative. It should land with its own run behind it.
- **`Gestures.scrollInSheetToElement`'s fixed 15% bottom reserve** rejects a row that is genuinely last in a sheet, leaving it unreachable with nothing left to scroll (measured `y2056..2127` against a `2060` threshold, while the real action bar starts near `2230`). 11 call sites in `PalSheetPage`/`ChatPage` still use it. Superseded by `scrollInSheetClearOfOverlay`, which measures the pinned row itself.
- **UX observation (not routed as a bug):** the remote-model picker's first row is clipped to ~10 px under a **disabled** Add Model button, so the natural tap is silently swallowed. 47 returned models can read as "this server returned none". One scroll recovers it, so nothing is unreachable.

## Note for anyone tempted to speed up `speculative-paired`

It takes **~16 minutes** because both fixtures must download for real. Pre-seeding the `.gguf` files **silently disables the feature under test**: `fetchAndPersistGGUFMetadata` runs on download-complete, a seeded file reaches `isDownloaded` via `checkFileExists` without metadata, and `resolveDraftCandidate` needs metadata from **both** halves to pair. Worse, `loadMissingGGUFMetadata` backfills in a detached loop, so a seeded run *races* it and can produce a **false green**.

## Test plan

All six specs run on a Pixel 9 (`45300DLAQ004DH`) against the v1.17.1 e2e build (versionCode 145). Remote specs ran against a live llama.cpp endpoint serving 47 models — deliberately untrimmed, since that is the real deployment condition.

---

## Also included: cross-platform speculative fixes (#878, merged in)

`speculative`, `speculative-paired` and `speculative-visual` now pass on an Android emulator and an iOS simulator as well as on hardware.

- **Taps were being dropped.** React Native's touch responder is not armed immediately after a scroll, so the accordion tap was accepted and silently did nothing — `ensureRevealed` clicked once, with no settle and no retry. A controlled run on a *stationary* element: `settle=false` → not expanded ×3, `settle=true` → expanded ×3.
- **Blind scrolling replaced with `UiScrollable.scrollIntoView`.** It walks the whole container, so absence is unambiguous — removing the ambiguity the helper was written around. One `openAdvancedSection` drops from ~60 gestures / ~60s at 2-in-3 reliability to ~2 native scrolls / ~5.2s at 3-of-3.
- **Downloads skip the unused projection.** The plain download button hardcodes `enableVision: true`; routing through the vision chip's sheet drops the pair from ~4.05 GB to ~2.94 GB.
- **Exact match on the sheet's Download button** — a substring match on `"Download"` resolved a row behind the sheet, the same class of bug as the accordion.
- `E2E_FORCE_CPU` (opt-in, for the iOS simulator's Metal abort in `MTLSimDevice newBufferWithLength`) and `E2E_PAIRED_*` fixture overrides.

### Verified on a physical Pixel 9 after the merge

| spec | result |
|---|---|
| `speculative` | 3/3 — `draft: 639/1044 (61%)`, 16.29 tok/s |
| `speculative-paired` | 1/1 — `draft: 25/36 (69%)`, 13.92 tok/s, **13m02s** (was 16m10s before the projection skip) |
| `speculative-visual` | 6/6, all 13 captures |
| `graded-effort-override` | 1/1 — regression check on the shared `disclosure.ts` change |

Every speculative spec produced real, non-zero draft-token acceptance on hardware, so the assertions exercise the feature rather than passing vacuously.

### Fixture downloads are the suite's dominant noise source

`speculative-visual` returned **6 failing** then **6 passing** on two consecutive runs of identical code, decided solely by whether one 463 MB fixture finished downloading (`Model card for Qwen_Qwen3-0.6B-Q4_0.gguf did not appear within 300000ms`). Triage a red run on any download-dependent spec by reading the first failure, not by counting failures.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)

