### PR TITLE
Upgrade llama.rn to 0.13.0-rc.1 (llama.cpp b10588)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Versions are pinned in [`package.json`](package.json); the highlights:
 | UI | React Native Paper `5.14.5`, React Navigation |
 | State | MobX `6` (`mobx`, `mobx-react`, `mobx-persist-store`) |
 | Persistence | WatermelonDB (chat history), AsyncStorage (settings), Keychain (secrets) |
-| LLM | `llama.rn` `0.13.0-rc.0` → llama.cpp · GGUF |
+| LLM | `llama.rn` `0.13.0-rc.1` → llama.cpp · GGUF |
 | TTS | `react-native-speech` `2.3.1` + `onnxruntime-react-native` `1.23.2` · ONNX |
 | Tooling | Yarn 1 (Classic), ESLint, Prettier, Jest, Husky + Commitlint |
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.13.0-rc.0):
+  - llama-rn (0.13.0-rc.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3751,7 +3751,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  llama-rn: e1b526654aa8c618ac793bf2bdf71447723f0386
+  llama-rn: 46ed89f784eb5bc614657dcf31160f0d792675bc
   onnxruntime-c: 4a1a1a81da2087869dc9b6357f182952db2df29c
   onnxruntime-react-native: 4451eff6b1aa60589186c6a8422d436fba6a9192
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
     "expr-eval": "^2.0.2",
-    "llama.rn": "0.13.0-rc.0",
+    "llama.rn": "0.13.0-rc.1",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -352,6 +352,35 @@ describe('the Hexagon backend', () => {
     expect(status).toBe(0);
     expect(output).toContain('llama.rn unknown');
   });
+
+  it('reports the installed tree, not the declared pin, when the two disagree', () => {
+    const isolated = path.join(workspace, 'isolated');
+    fs.mkdirSync(isolated);
+    const copy = path.join(isolated, 'verify-android-payload.js');
+    fs.copyFileSync(SCRIPT_PATH, copy);
+    fs.mkdirSync(path.join(workspace, 'node_modules', 'llama.rn'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(workspace, 'node_modules', 'llama.rn', 'package.json'),
+      JSON.stringify({name: 'llama.rn', version: '0.0.0-installed'}),
+    );
+    fs.writeFileSync(
+      path.join(workspace, 'package.json'),
+      JSON.stringify({dependencies: {'llama.rn': '0.0.0-declared'}}),
+    );
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+
+    const {status, output} = runScript(copy, [
+      '--manifest',
+      MANIFEST_PATH,
+      '--apk',
+      archive,
+    ]);
+    expect(status).toBe(0);
+    expect(output).toContain('llama.rn 0.0.0-installed');
+    expect(output).not.toContain('0.0.0-declared');
+  });
 });
 
 describe('the declared payload', () => {

--- a/scripts/__tests__/verify-android-payload.test.js
+++ b/scripts/__tests__/verify-android-payload.test.js
@@ -184,11 +184,11 @@ function writeArchive(name, entries) {
   return archive;
 }
 
-function runGate(args) {
+function runScript(scriptPath, args) {
   try {
     return {
       status: 0,
-      output: execFileSync('node', [SCRIPT_PATH, ...args], {encoding: 'utf-8'}),
+      output: execFileSync('node', [scriptPath, ...args], {encoding: 'utf-8'}),
     };
   } catch (err) {
     return {
@@ -196,6 +196,10 @@ function runGate(args) {
       output: `${err.stdout || ''}${err.stderr || ''}`,
     };
   }
+}
+
+function runGate(args) {
+  return runScript(SCRIPT_PATH, args);
 }
 
 function gateApk(entries, extraArgs = []) {
@@ -305,6 +309,48 @@ describe('the Hexagon backend', () => {
     expect(output).toContain('18 .dynsym entries matching "hexagon"');
     expect(output).toContain('re-declare');
     expect(output).toContain('expectedMatchCount as 18');
+  });
+
+  it('names the llama.rn version the count was read from', () => {
+    const {count, pattern} = manifest.abis.find(abi => abi.abi === 'arm64-v8a')
+      .requiredSymbols[0].expectedMatchCount;
+    const installed = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          '..',
+          '..',
+          'node_modules',
+          'llama.rn',
+          'package.json',
+        ),
+        'utf-8',
+      ),
+    ).version;
+
+    const {status, output} = gateApk(conformingEntries());
+    expect(status).toBe(0);
+    expect(output).toContain(`${count} .dynsym entries matching "${pattern}"`);
+    expect(output).toContain(`(declared ${count}), llama.rn ${installed}`);
+  });
+
+  it('reads unknown when llama.rn is not installed, and still passes', () => {
+    // One level below the workspace root so `__dirname/..` is a directory this
+    // test created: os.tmpdir() is /tmp on CI, where a node_modules could exist.
+    const isolated = path.join(workspace, 'isolated');
+    fs.mkdirSync(isolated);
+    const copy = path.join(isolated, 'verify-android-payload.js');
+    fs.copyFileSync(SCRIPT_PATH, copy);
+    const archive = writeArchive('app-prod-release.apk', conformingEntries());
+
+    const {status, output} = runScript(copy, [
+      '--manifest',
+      MANIFEST_PATH,
+      '--apk',
+      archive,
+    ]);
+    expect(status).toBe(0);
+    expect(output).toContain('llama.rn unknown');
   });
 });
 

--- a/scripts/verify-android-payload.js
+++ b/scripts/verify-android-payload.js
@@ -434,6 +434,20 @@ function readDynsym(buf) {
   return symbols;
 }
 
+function installedLlamaRnVersion() {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(
+        path.join(__dirname, '..', 'node_modules', 'llama.rn', 'package.json'),
+        'utf-8',
+      ),
+    );
+    return pkg.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 function checkSymbolRule({rule, archive, artifactName, entry, report, fail}) {
   let symbols;
   try {
@@ -481,7 +495,7 @@ function checkSymbolRule({rule, archive, artifactName, entry, report, fail}) {
     symbol.name.toLowerCase().includes(pattern),
   ).length;
   report.push(
-    `      ${matched} .dynsym entries matching "${expected.pattern}" (declared ${expected.count})`,
+    `      ${matched} .dynsym entries matching "${expected.pattern}" (declared ${expected.count}), llama.rn ${installedLlamaRnVersion()}`,
   );
   if (matched !== expected.count && missing.length === 0) {
     fail(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6520,10 +6520,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.13.0-rc.0:
-  version "0.13.0-rc.0"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.13.0-rc.0.tgz#5381c6cb874afe49d84ac5083e77f485a12f59f8"
-  integrity sha512-6VWkmFzcPBX+Xv2gqKm+o0kWpa4gPhNJ74EM89iL2zaxruxmu/eApTHDjGRzX3dMPHhDJWyloJ+d00xhg+9FeA==
+llama.rn@0.13.0-rc.1:
+  version "0.13.0-rc.1"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.13.0-rc.1.tgz#624923ea7dcca50aa2e2905db45def0f2ecfe951"
+  integrity sha512-sXpw1b6jUns6HhFUlQiaTY1hFvN/vKTWn+lKI0isz8YuY1BupqmKY7XTi2EWShpQ9sLm9F2g76Lzddk+F/+d3g==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Description

Upgrades the vendored `llama.rn` native dependency from `0.13.0-rc.0` to `0.13.0-rc.1` — a pure llama.cpp sync of 253 builds, b10335 (`74ce157`) → b10588 (`70adb1b`).

The TypeScript surface of `llama.rn` is unchanged apart from `src/version.ts`, so no app code moves. `android/gradle.properties`, `android/build.gradle` and `rn-slot.cpp` are byte-identical between the two releases, so the from-source Android build mode and the native generation-rate path both carry forward unchanged. The one behavioural change in the package, an `embd.clear()` in `llama_rn_context_completion::embedding`, is unreachable here — PocketPal does not call the embedding API.

Also in this PR: the Android payload gate's symbol-count line now names the `llama.rn` version it read from `node_modules`, so `payload-report.txt` dates the Hexagon `.dynsym` count to the tree that was actually built rather than to whatever `package.json` declares. It is printed, never asserted — an unreadable `node_modules/llama.rn` prints `unknown` and leaves the verdict alone.

The Hexagon (NPU) backend evidence for this bump is the payload report from the `build-android` job — the SDK is provisioned there, so it is the build the project can guarantee produces the count. A build on a host without the SDK compiles the backend out and reports zero matches; that is compile health only, never a re-baseline.

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] I have tested this change on:
  - [x] iOS Simulator/Device
  - [x] Android Emulator/Device
- [x] Unit tests and integration tests pass locally.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)

