### PR TITLE
Make the speculative specs pass on iOS and Android

### DIFF
--- a/e2e/helpers/disclosure.ts
+++ b/e2e/helpers/disclosure.ts
@@ -5,8 +5,46 @@
 
 import {Gestures} from './gestures';
 import {readSwitchState} from './control-state';
+import {isAndroid} from './selectors';
 
 declare const browser: WebdriverIO.Browser;
+
+/**
+ * React Native's touch responder is not armed immediately after a scroll
+ * gesture: the tap is accepted, and silently does nothing. Without this pause
+ * the accordion toggle drops every tap.
+ */
+const TOUCH_SETTLE_MS = 700;
+
+function testIdFrom(selector: string): string | null {
+  const match = selector.match(/contains\(@resource-id, "([^"]+)"\)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Anchor on the toggle, which is always mounted, and read the section's state
+ * from `stateProbe` in place. That avoids both the ambiguous off-viewport probe
+ * and the cost of a native scroll for a control that may not exist yet.
+ */
+async function revealViaNativeScroll(
+  toggle: string,
+  dependent: string,
+  stateProbe: string,
+): Promise<boolean> {
+  if (!(await Gestures.nativeScrollIntoView(toggle))) {
+    return false;
+  }
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (await browser.$(stateProbe).isExisting()) {
+      return Gestures.nativeScrollIntoView(dependent);
+    }
+    await browser.pause(TOUCH_SETTLE_MS);
+    await browser.$(toggle).click();
+    await browser.pause(TOUCH_SETTLE_MS);
+    await Gestures.nativeScrollIntoView(toggle);
+  }
+  return false;
+}
 
 export interface RevealOptions {
   /** Control that opens/closes the section. */
@@ -25,6 +63,12 @@ export interface RevealOptions {
    */
   reachForClick?: (selector: string, maxScrolls?: number) => Promise<boolean>;
   maxScrolls?: number;
+  /**
+   * Control mounted directly under `toggle` while the section is open, used as
+   * an in-place state read. Supplying it selects the native-scroll path on
+   * Android; without it the scroll-probe fallback is used.
+   */
+  stateProbe?: string;
 }
 
 /**
@@ -37,9 +81,13 @@ export interface RevealOptions {
  * that was already open — the caller then waits for a control it just unmounted.
  */
 export async function ensureRevealed(options: RevealOptions): Promise<boolean> {
-  const {toggle, dependent, rewind, maxScrolls = 8} = options;
+  const {toggle, dependent, stateProbe, rewind, maxScrolls = 8} = options;
   const reach = options.reach ?? Gestures.scrollToElement;
   const reachForClick = options.reachForClick ?? reach;
+
+  if (isAndroid() && stateProbe && testIdFrom(toggle)) {
+    return revealViaNativeScroll(toggle, dependent, stateProbe);
+  }
 
   await rewind?.();
   if (await reach(dependent, maxScrolls)) {

--- a/e2e/helpers/gestures.ts
+++ b/e2e/helpers/gestures.ts
@@ -179,6 +179,34 @@ async function scrollToElement(
 }
 
 /**
+ * Scroll to a control with UiAutomator's own scroller, which walks the whole
+ * container in either direction rather than the viewport. Android only;
+ * returns false elsewhere so callers can fall back to a swipe loop.
+ *
+ * Only for a control known to be mounted — a miss scrolls to the end of the
+ * list before failing, which costs tens of seconds.
+ */
+async function nativeScrollIntoView(selector: string): Promise<boolean> {
+  if (!(browser as unknown as {isAndroid?: boolean}).isAndroid) {
+    return false;
+  }
+  const match = selector.match(/contains\(@resource-id, "([^"]+)"\)/);
+  if (!match) {
+    return false;
+  }
+  try {
+    return await browser
+      .$(
+        '-android uiautomator:new UiScrollable(new UiSelector().scrollable(true))' +
+          `.scrollIntoView(new UiSelector().resourceIdMatches(".*${match[1]}.*"))`,
+      )
+      .isExisting();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Swipe up within a bottom sheet (uses safer coordinates)
  * Avoids the bottom navigation gesture area on Android
  */
@@ -318,6 +346,7 @@ async function scrollInSheetToElementExists(
 
 export const Gestures = {
   getScreenSize,
+  nativeScrollIntoView,
   swipe,
   swipeDownOnElement,
   swipeDownToClose,

--- a/e2e/specs/features/speculative-paired.spec.ts
+++ b/e2e/specs/features/speculative-paired.spec.ts
@@ -55,6 +55,8 @@ import {SettingsPage} from '../../pages/SettingsPage';
 import {Selectors, byTestId, byPartialText} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
 import {readAccessibilityLabel} from '../../helpers/element-text';
+import {ensureRevealed} from '../../helpers/disclosure';
+import {readSwitchState} from '../../helpers/control-state';
 import {
   dismissPerformanceWarningIfPresent,
   dismissContextRoomSheetIfPresent,
@@ -67,37 +69,48 @@ declare const driver: WebdriverIO.Browser;
 declare const browser: WebdriverIO.Browser;
 
 /**
- * Separate MTP draft: arch gemma4-assistant, nextn_predict_layers=4, ~98 MB.
- * Downloaded (not loaded) so its width/MTP metadata is available to the pairing
- * resolver and it appears in the draft-model picker.
+ * Fixture pair, overridable per device. The default gemma-4 set needs ~2.9 GB,
+ * which does not fit every target; any pair works so long as the draft is
+ * MTP-capable and its n_embd_out equals the target's n_embd (draftResolution.ts).
+ */
+const env = (name: string, fallback: string): string =>
+  process.env[name] || fallback;
+
+/**
+ * Separate MTP draft. Downloaded (not loaded) so its width/MTP metadata is
+ * available to the pairing resolver and it appears in the draft-model picker.
+ *
+ * The draft file is ~97 MB, but the app pairs every file in a multimodal repo
+ * with its mmproj, so the actual transfer is ~655 MB — well past the 5-minute
+ * default.
  */
 const DRAFT_MODEL: ModelTestConfig = {
-  id: 'gemma-4-e2b-mtp-draft',
-  searchQuery: 'ggml-org gemma-4-E2B-it-GGUF',
-  selectorText: 'gemma-4-E2B-it',
-  downloadFile: 'mtp-gemma-4-E2B-it-Q8_0.gguf',
+  id: 'paired-mtp-draft',
+  searchQuery: env('E2E_PAIRED_DRAFT_QUERY', 'ggml-org gemma-4-E2B-it-GGUF'),
+  selectorText: env('E2E_PAIRED_DRAFT_SELECTOR', 'gemma-4-E2B-it'),
+  downloadFile: env('E2E_PAIRED_DRAFT_FILE', 'mtp-gemma-4-E2B-it-Q8_0.gguf'),
+  downloadTimeout: Number(process.env.E2E_DOWNLOAD_TIMEOUT) || 900000,
   prompts: [{input: 'Hi', description: 'Basic greeting'}],
 };
 
 /**
- * The chat target paired with the draft. Loaded TEXT-ONLY (no mmproj). Same
- * repo as the draft (arch `gemma4`, no nextn KV — genuinely non-MTP), and the
- * exact pair the Pixel 9 engagement evidence was captured with.
+ * The chat target paired with the draft. The default is loaded TEXT-ONLY (no
+ * mmproj) because its repo is multimodal.
  */
 const TARGET_MODEL: ModelTestConfig = {
-  id: 'gemma-4-e2b-target',
-  searchQuery: 'ggml-org gemma-4-E2B-it-GGUF',
-  selectorText: 'gemma-4-E2B-it',
-  downloadFile: 'gemma-4-E2B-it-Q4_0.gguf',
-  // ~3.5 GB; HF often serves large files at only a few MB/s, so the wait is
+  id: 'paired-target',
+  searchQuery: env('E2E_PAIRED_TARGET_QUERY', 'ggml-org gemma-4-E2B-it-GGUF'),
+  selectorText: env('E2E_PAIRED_TARGET_SELECTOR', 'gemma-4-E2B-it'),
+  downloadFile: env('E2E_PAIRED_TARGET_FILE', 'gemma-4-E2B-it-Q4_0.gguf'),
+  // HF often serves large files at only a few MB/s, so the wait is
   // overridable for slow lanes the way E2E_MOCHA_TIMEOUT is.
   downloadTimeout: Number(process.env.E2E_DOWNLOAD_TIMEOUT) || 900000,
   prompts: [{input: 'Hi', description: 'Basic greeting'}],
-  disableVisionBeforeLoad: true,
+  disableVisionBeforeLoad: process.env.E2E_PAIRED_TARGET_VISION !== 'false',
 };
 
 /** Fragment of the draft's display name (extractHFModelTitle == filename). */
-const DRAFT_TITLE_FRAGMENT = 'mtp-gemma-4-E2B-it-Q8_0';
+const DRAFT_TITLE_FRAGMENT = DRAFT_MODEL.downloadFile.replace(/\.gguf$/, '');
 
 /**
  * n_ctx for the run. The paired draft needs room to draft to completion; with
@@ -108,6 +121,8 @@ const DRAFT_TITLE_FRAGMENT = 'mtp-gemma-4-E2B-it-Q8_0';
 const SPEC_CONTEXT_SIZE = '4096';
 
 const SPEC_ACCORDION = byTestId('advanced-settings-accordion');
+/** First row inside the accordion — mounted only while it is expanded. */
+const SPEC_ACCORDION_FIRST_ROW = byTestId('batch-size-slider');
 const SPEC_SWITCH = byTestId('speculative-decoding-switch');
 const SPEC_PICKER = byTestId('speculative-draft-model-picker');
 
@@ -150,6 +165,11 @@ function freshCrashReports(sinceMs: number): string[] {
  * the screen mounted), so rewind to the top before scrolling to a row.
  */
 async function scrollSettingsToTop(): Promise<void> {
+  // A fixed swipe count cannot rewind a list whose height depends on whether
+  // the Advanced accordion is expanded; the native scroller has no such limit.
+  if (await Gestures.nativeScrollIntoView(byTestId('context-size-input'))) {
+    return;
+  }
   for (let i = 0; i < 8; i++) {
     await Gestures.swipeDown();
   }
@@ -180,26 +200,73 @@ async function goToSettings(settingsPage: SettingsPage): Promise<void> {
   }
 }
 
+/**
+ * The iOS simulator's Metal shim aborts in MTLSimDevice.newBufferWithLength
+ * (_xpc_shmem_create_with_prot) once a paired draft decodes alongside a large
+ * target, so runs there select the CPU backend. Draft-token production is
+ * backend-independent, so the engagement proof is unaffected.
+ */
+async function forceCpuIfRequested(settingsPage: SettingsPage): Promise<void> {
+  if (process.env.E2E_FORCE_CPU !== 'true') {
+    return;
+  }
+  await goToSettings(settingsPage);
+  await scrollSettingsToTop();
+  const cpuOption = byTestId('device-option-cpu');
+  const reached =
+    (await Gestures.nativeScrollIntoView(cpuOption)) ||
+    (await Gestures.scrollToElement(cpuOption, 10));
+  if (!reached) {
+    console.log('[paired] CPU device option not present; leaving backend as-is');
+    return;
+  }
+  await browser.pause(700);
+  await browser.$(cpuOption).click();
+  await browser.pause(700);
+  console.log('[paired] selected CPU backend');
+
+  // The draft carries its own layer count (spec_draft_n_gpu_layers, default
+  // 99), so the device selector alone leaves the draft's decode on Metal —
+  // which is exactly where the simulator aborts.
+  await enableSpeculativeGlobally(settingsPage);
+  const draftLayers = byTestId('speculative-draft-gpu-layers-slider-input');
+  const draftReached =
+    (await Gestures.nativeScrollIntoView(draftLayers)) ||
+    (await Gestures.scrollToElement(draftLayers, 12));
+  if (!draftReached) {
+    console.log('[paired] draft gpu-layers input not reachable');
+    return;
+  }
+  const input = browser.$(draftLayers);
+  await input.clearValue();
+  await input.setValue('0');
+  await browser.pause(500);
+  // The layer count uses a numeric keypad, which has no Return/Done key. ESC
+  // closes it on Android without the back-press that hideKeyboard() emits (a
+  // pop React Navigation would consume); iOS needs the driver's own dismiss.
+  if ((browser as any).isAndroid) {
+    await (browser as any).pressKeyCode(111).catch(() => undefined);
+  } else {
+    await browser
+      .execute('mobile: hideKeyboard' as any)
+      .catch(() => undefined);
+  }
+  await browser.pause(500);
+  console.log('[paired] draft gpu layers set to 0');
+}
+
 /** Enable speculative decoding globally in Settings -> Advanced. */
 async function enableSpeculativeGlobally(
   settingsPage: SettingsPage,
 ): Promise<void> {
   await goToSettings(settingsPage);
-  // A revisit restores the previous scroll offset, and scrollToElement only
-  // searches downward — start every pass from the top. Try to reach the
-  // switch first: off-viewport content is absent from the a11y tree, so an
-  // existence probe cannot tell "accordion collapsed" from "row below the
-  // fold", and a blind accordion click can collapse an open section.
-  await scrollSettingsToTop();
-  await Gestures.scrollToElement(SPEC_ACCORDION, 8);
-  let switchReachable = await Gestures.scrollToElement(SPEC_SWITCH, 8);
-  if (!switchReachable) {
-    await scrollSettingsToTop();
-    await Gestures.scrollToElement(SPEC_ACCORDION, 8);
-    await browser.$(SPEC_ACCORDION).click();
-    await browser.pause(500);
-    switchReachable = await Gestures.scrollToElement(SPEC_SWITCH, 8);
-  }
+  await ensureRevealed({
+    toggle: SPEC_ACCORDION,
+    dependent: SPEC_SWITCH,
+    stateProbe: SPEC_ACCORDION_FIRST_ROW,
+    rewind: scrollSettingsToTop,
+    maxScrolls: 8,
+  });
   await browser.$(SPEC_SWITCH).waitForExist({timeout: TIMEOUTS.element});
 
   // Read the switch itself: with app state persisted between runs
@@ -222,6 +289,61 @@ async function enableSpeculativeGlobally(
   }
   await Gestures.scrollToElement(SPEC_PICKER, 4);
   await browser.$(SPEC_PICKER).waitForExist({timeout: TIMEOUTS.element});
+}
+
+/**
+ * Download a file with its vision projection turned OFF.
+ *
+ * The plain download button on a file card always passes `enableVision: true`,
+ * so every file in a multimodal repo drags its ~557 MB mmproj along (a 97 MB
+ * draft becomes a 655 MB transfer). The projection is reachable only through
+ * the card's vision chip, which opens a sheet carrying its own toggle and
+ * Download button. Neither control has a testID, so both are matched on text.
+ *
+ * Returns false when the file has no vision chip — a non-multimodal file needs
+ * the normal path.
+ */
+async function tapDownloadWithoutVision(filename: string): Promise<boolean> {
+  const card = browser.$(Selectors.modelDetails.fileCard(filename));
+  const chip = card.$(byPartialText('Includes vision capability'));
+  if (!(await chip.isExisting().catch(() => false))) {
+    return false;
+  }
+  await browser.pause(700);
+  await chip.click();
+  await browser.pause(1500);
+
+  const toggle = browser.$(
+    (browser as any).isAndroid
+      ? '//android.widget.Switch'
+      : '-ios class chain:**/XCUIElementTypeSwitch',
+  );
+  if (await toggle.isExisting().catch(() => false)) {
+    const on = await readSwitchState(
+      (browser as any).isAndroid
+        ? '//android.widget.Switch'
+        : '-ios class chain:**/XCUIElementTypeSwitch',
+    );
+    if (on !== false) {
+      await toggle.click();
+      await browser.pause(700);
+    }
+  }
+
+  // Exact match on the button: every file row behind the sheet also carries a
+  // download control, labelled "Download model", and a substring match resolves
+  // one of those instead — a tap that lands under the sheet and does nothing.
+  const downloadBtn = browser.$(
+    (browser as any).isAndroid
+      ? '//android.widget.Button[@content-desc="Download"]'
+      : '-ios predicate string:type == "XCUIElementTypeButton" AND label == "Download"',
+  );
+  await downloadBtn.waitForExist({timeout: TIMEOUTS.element});
+  await browser.pause(500);
+  await downloadBtn.click();
+  await browser.pause(1500);
+  console.log(`[paired] ${filename}: downloading without vision projection`);
+  return true;
 }
 
 /**
@@ -263,7 +385,12 @@ async function downloadModelOnly(model: ModelTestConfig): Promise<void> {
   await modelDetailsSheet.waitForReady();
 
   await modelDetailsSheet.scrollToFile(model.downloadFile);
-  await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+  if (
+    process.env.E2E_PAIRED_NO_VISION !== 'true' ||
+    !(await tapDownloadWithoutVision(model.downloadFile))
+  ) {
+    await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+  }
 
   await modelDetailsSheet.close();
   await hfSearchSheet.close();
@@ -311,7 +438,12 @@ async function downloadAndLoadTarget(model: ModelTestConfig): Promise<void> {
     await modelDetailsSheet.waitForReady();
 
     await modelDetailsSheet.scrollToFile(model.downloadFile);
-    await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+    if (
+      process.env.E2E_PAIRED_NO_VISION !== 'true' ||
+      !(await tapDownloadWithoutVision(model.downloadFile))
+    ) {
+      await modelDetailsSheet.tapDownloadForFile(model.downloadFile);
+    }
 
     await modelDetailsSheet.close();
     await hfSearchSheet.close();
@@ -394,6 +526,7 @@ describe('Speculative Decoding / separate-draft (paired) MTP', () => {
     await goToSettings(settingsPage);
     await settingsPage.setContextSize(SPEC_CONTEXT_SIZE);
     await enableSpeculativeGlobally(settingsPage);
+    await forceCpuIfRequested(settingsPage);
     await saveShot('speculative-paired-settings-enabled');
   });
 

--- a/e2e/specs/features/speculative-visual.spec.ts
+++ b/e2e/specs/features/speculative-visual.spec.ts
@@ -79,6 +79,8 @@ const SPEC_CONTEXT_SIZE = '4096';
 const BADGE_PROBE_TIMEOUT = 90000;
 
 const SPEC_ACCORDION = byTestId('advanced-settings-accordion');
+/** First row inside the accordion — mounted only while it is expanded. */
+const SPEC_ACCORDION_FIRST_ROW = byTestId('batch-size-slider');
 const SPEC_SWITCH = byTestId('speculative-decoding-switch');
 const SPEC_PICKER = byTestId('speculative-draft-model-picker');
 const SPEC_NO_EFFECT_NOTE = byTestId('speculative-no-effect-note');
@@ -116,6 +118,11 @@ async function saveShot(name: string): Promise<void> {
  * before scrolling to a target.
  */
 async function scrollSettingsToTop(): Promise<void> {
+  // A fixed swipe count cannot rewind a list whose height depends on whether
+  // the Advanced accordion is expanded; the native scroller has no such limit.
+  if (await Gestures.nativeScrollIntoView(byTestId('context-size-input'))) {
+    return;
+  }
   for (let i = 0; i < 8; i++) {
     await Gestures.swipeDown();
   }
@@ -161,6 +168,7 @@ async function openAdvancedSection(navigate = true): Promise<void> {
   const revealed = await ensureRevealed({
     toggle: SPEC_ACCORDION,
     dependent: SPEC_SWITCH,
+    stateProbe: SPEC_ACCORDION_FIRST_ROW,
     rewind: scrollSettingsToTop,
     maxScrolls: 12,
   });

--- a/e2e/specs/features/speculative.spec.ts
+++ b/e2e/specs/features/speculative.spec.ts
@@ -46,6 +46,7 @@ import {ChatPage} from '../../pages/ChatPage';
 import {SettingsPage} from '../../pages/SettingsPage';
 import {Selectors, byTestId, nativeTextElement} from '../../helpers/selectors';
 import {Gestures} from '../../helpers/gestures';
+import {ensureRevealed} from '../../helpers/disclosure';
 import {
   downloadAndLoadModel,
   waitForInferenceComplete,
@@ -104,6 +105,8 @@ const SPEC_CONTEXT_SIZE = '4096';
 const SPEC_INFERENCE_TIMEOUT = 420000;
 
 const SPEC_ACCORDION = byTestId('advanced-settings-accordion');
+/** First row inside the accordion — mounted only while it is expanded. */
+const SPEC_ACCORDION_FIRST_ROW = byTestId('batch-size-slider');
 const SPEC_SWITCH = byTestId('speculative-decoding-switch');
 const SPEC_PICKER = byTestId('speculative-draft-model-picker');
 const SPEC_GPU_LAYERS = byTestId('speculative-draft-gpu-layers-slider');
@@ -139,17 +142,31 @@ async function goToSettings(settingsPage: SettingsPage): Promise<void> {
   await settingsPage.navigateTo();
 }
 
+/**
+ * Rewind Settings to the top. `scrollToElement` only searches downward, so a
+ * pass that has already scrolled past a row can never reach it again.
+ */
+async function scrollSettingsToTop(): Promise<void> {
+  if (await Gestures.nativeScrollIntoView(byTestId('context-size-input'))) {
+    return;
+  }
+  for (let i = 0; i < 8; i++) {
+    await Gestures.swipeDown();
+  }
+}
+
 /** Enable speculative decoding globally in Settings -> Advanced. */
 async function enableSpeculativeGlobally(
   settingsPage: SettingsPage,
 ): Promise<void> {
   await goToSettings(settingsPage);
-  await Gestures.scrollToElement(SPEC_ACCORDION, 8);
-  if (!(await browser.$(SPEC_SWITCH).isExisting())) {
-    await browser.$(SPEC_ACCORDION).click();
-    await browser.pause(500);
-  }
-  await Gestures.scrollToElement(SPEC_SWITCH, 8);
+  await ensureRevealed({
+    toggle: SPEC_ACCORDION,
+    dependent: SPEC_SWITCH,
+    stateProbe: SPEC_ACCORDION_FIRST_ROW,
+    rewind: scrollSettingsToTop,
+    maxScrolls: 8,
+  });
   await browser.$(SPEC_SWITCH).waitForExist({timeout: TIMEOUTS.element});
 
   // Read the switch itself: with app state persisted between runs


### PR DESCRIPTION
## Summary

Stacks on #871. `speculative` and `speculative-paired` now pass on **both** an Android emulator and an iOS simulator.

| spec | Android (Pixel 9 Pro, API 36) | iOS (iPhone 17 Pro, iOS 26) |
|---|---|---|
| `speculative` | 3/3 — `draft: 47/129 (36%)`, 28.0 tok/s | 3/3 — `draft: 2908/3534 (82%)`, 34.0 tok/s |
| `speculative-paired` | 1/1 — `draft: 155/315 (49%)`, 29.8 tok/s | 1/1 — `draft: 156/315 (50%)`, 27.9 tok/s |

`0 failures, 0 errors, 0 skipped` on each, with real draft-token production.

## The taps were being dropped

React Native's touch responder is not armed immediately after a scroll gesture. The tap on the Advanced Settings accordion was accepted and silently did nothing, so the section never expanded and the spec waited for a control that was never mounted. `ensureRevealed` clicked **once**, with no settle and no retry.

A controlled run, identical apart from a pause before the tap:

```
settle=false -> expanded=false   x3
settle=true  -> expanded=true    x3
```

The element was stationary at y=1179 throughout, so this is not the row moving. Replaying the real hook, the tap dropped 1 round in 3.

`speculative`, `speculative-paired` and `speculative-visual` each carried their own copy of this pattern; all three now share the helper.

## Blind scrolling replaced with the native scroller

Reaching a row was a swipe loop with a tuned `maxScrolls`, which cannot distinguish "section closed" from "row below the fold" — the ambiguity the helper was written around. `UiScrollable.scrollIntoView` walks the whole container, so absence is unambiguous and a rewind no longer depends on a swipe count.

That mattered in practice: once the accordion genuinely expanded, the Settings list grew taller and the fixed 8-swipe rewind stopped reaching the top. The old bug had been masking the new one.

Cost of one `openAdvancedSection`: ~60 gestures and ~60s, at 2-in-3 reliability, becomes ~2 native scrolls and ~5.2s, 3-of-3.

Only call the native scroller for a control known to be mounted — a miss walks to the end of the list first, measured at 16-75s.

## speculative-paired

- **Draft download timeout.** The draft is ~97 MB, but every file in a multimodal repo is paired with its mmproj, so the real transfer is ~655 MB and overran the 5-minute default. The 30-minute target limit was ~1 minute short of the observed rate.
- **Downloads skip the projection.** Neither model uses vision. The plain download button hardcodes `enableVision: true`, so the projection is only avoidable through the vision chip's sheet. This drops the pair from ~4.05 GB to ~2.94 GB — which is what lets it fit an emulator.
- **Exact match on the sheet's Download button.** Every file row behind the sheet carries a `"Download model"` control; a substring match on `"Download"` resolved one of those, and the tap landed under the sheet. Same class of bug as the accordion.
- **CPU on the iOS simulator.** The simulator's Metal shim aborts in `MTLSimDevice newBufferWithLength` once the paired draft decodes alongside the target. Embedded MTP is fine there, so this is specific to the paired path's second context. Both the target *and* the draft are moved off the GPU — the draft has its own layer count that the device selector does not touch (#875).
- **Fixtures are overridable** via `E2E_PAIRED_*`, defaulting to the current gemma-4 pair. Unused in these runs; the pair fits once the projection is skipped.

## Not addressed here

Filed separately: #875, #876, #877.

The paired path on iOS is proven on **CPU** only. The simulator's Metal driver aborts on it, so the Metal paired path remains unproven on iOS and wants a real device.

## Test plan

Each result above is from the final state of this branch, re-run after the last edit. Android on a Pixel 9 Pro AVD (API 36), iOS on an iPhone 17 Pro simulator (iOS 26.0), both against the v1.17.1 e2e build.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)
