### PR TITLE
Declare the location purpose string ITMS-90683 asks for

### DIFF
--- a/ios/PocketPal/Info.plist
+++ b/ios/PocketPal/Info.plist
@@ -60,6 +60,8 @@
 	<string>PocketPal uses your camera to capture images and video for local AI analysis only. All processing happens on your device and no images are transmitted to external servers.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>PocketPal connects to AI servers you run on your own network (like Ollama or llama.cpp) when you add them as remote endpoints.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>PocketPal never requests or collects your location. A bundled camera library references the system location API to offer optional photo geotagging, which PocketPal leaves turned off.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>PocketPal accesses your photo library to select images for local AI analysis only. Selected images are processed entirely on your device and are never transmitted to external servers.</string>
 	<key>NSSiriUsageDescription</key>


### PR DESCRIPTION
## Problem

Every App Store Connect upload returns a non-blocking delivery warning:

> **ITMS-90683:** Missing purpose string in Info.plist — … The Info.plist file for the "PocketPal.app" bundle should contain a `NSLocationWhenInUseUsageDescription` key with a user-facing purpose string …

PocketPal never uses location. `Info.plist` declared four non-location purpose strings and no location key, and `PocketPal.entitlements` has no location entitlement. Two bundled dependencies reference CoreLocation anyway:

- **`react-native-vision-camera`** compiles a location provider for optional photo geotagging. The app never sets `enableLocation` on `<Camera>`, so the provider is always nil and no capture has ever carried GPS EXIF.
- **`react-native-device-info`** exposes `isLocationEnabled()` / `getAvailableLocationProviders()`, neither of which is called anywhere in `src/` or `e2e/`.

Apple's scan reads *referenced* symbols, not reachable ones, so the purpose string is required regardless of whether the code can run.

## Change

One key in `ios/PocketPal/Info.plist`, placed in the existing alphabetical order.

## Why this rather than removing the symbols

The alternative is patching both dependencies' native source to compile the CoreLocation code out. That works — it was built and measured — but it means two `patch-package` patches pinned to exact versions, to be re-created against restructured upstream source on every bump of either dependency, plus an instrument to detect when they silently stop applying.

ITMS-90683 is non-blocking and has cost nothing across 146 builds. A permanent maintenance obligation is the wrong trade for it. The purpose string works forever and survives every dependency bump.

The string is accurate: it states that PocketPal never requests location and that the library feature is left off, rather than inventing a use.

## Verification

| Check | Result |
| --- | --- |
| `plutil -lint` | OK |
| `pod install` | exit 0, `Podfile.lock` unchanged |
| iOS Release build (simulator) | **BUILD SUCCEEDED** |
| Key present in **built** `PocketPal.app/Info.plist` | confirmed |

The last row is the one that matters — the target sets both `INFOPLIST_FILE` and `GENERATE_INFOPLIST_FILE`, so the key was read back out of the built bundle to prove no build setting overrides it. Positive control: all five purpose strings are present in the built artifact.

Android is untouched — no Android file changes, and `Info.plist` is iOS-only.

## Residual

The warning's clearance is confirmed only by the next TestFlight delivery, since ITMS-90683 is emitted against the uploaded IPA and nothing here examines one.

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)