### PR TITLE
i18n(zh): translate sidebar menu item 'Pals' to '伙伴'

### DIFF
--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -955,7 +955,7 @@
       "menuItems": {
         "chat": "聊天",
         "models": "模型",
-        "pals": "Pals",
+        "pals": "伙伴",
         "benchmark": "基准测试",
         "settings": "设置",
         "appInfo": "关于",


### PR DESCRIPTION
## Summary
zh.json `sidebarContent.menuItems.pals` remains untranslated ("Pals") while all sibling menu items (聊天 / 模型 / 基准测试 / 设置 / 关于) are localized. This aligns with the existing `menuItems.pals → "Pals（实验性）"` translation at the settings submenu.

## Motivation
- Single missing key in the Chinese locale (verified `l10n:validate`-style scan: all other sibling keys are translated)
- Pocket Chick (fork) carries the same translation; upstreaming keeps source of truth in one place

## Change
- `src/locales/zh.json`: `"pals": "Pals"` → `"pals": "伙伴"`

No code change, JSON only.