### PR TITLE
Count cache-reused prompt tokens in the remote context total

### DIFF
--- a/jest/fixtures/llamaServerTimings.ts
+++ b/jest/fixtures/llamaServerTimings.ts
@@ -9,22 +9,12 @@
  * aarch64). Every wire fact here was observed on that one build; cross-build
  * generalisation is unverified.
  *
- * Three things this capture must not be read as saying. Each is a citation that
- * looks right, and each was written down before being checked against the
- * source lines:
- *
- *  - Upstream's own `timings` assertions (`test_completion.py:659`,
- *    `test_kv_keep_only_active.py:80`) run against the native
- *    `POST /completion` and read the response body non-streaming, while this
- *    app reads the OpenAI-compatible endpoint's SSE finish chunk — a different
- *    endpoint and a different envelope. Upstream does not cover this path, and
- *    this fixture is the app's own capture rather than a copy of theirs.
- *  - Upstream asserts nothing about the join between a separately counted
- *    prompt and `prompt_n + cache_n`. Its token-count endpoint has exactly two
- *    tests and both are loose bounds (`> 5`, `> 10`).
- *  - `test_compat_anthropic.py:882` is a different endpoint,
- *    `POST /v1/messages/count_tokens`, which merely shares the `input_tokens`
- *    field name. It constrains nothing here and must not be cited for it.
+ * Upstream's own `timings` assertions (`test_completion.py:659`,
+ * `test_kv_keep_only_active.py:80`) run against the native `POST /completion`
+ * and read the response body non-streaming, while this app reads the
+ * OpenAI-compatible endpoint's SSE finish chunk — a different endpoint and a
+ * different envelope. Upstream does not cover this path, and this capture is
+ * the app's own rather than a copy of theirs.
  */
 export const cacheReuseTimings = {
   cache_n: 31,

--- a/jest/fixtures/llamaServerTimings.ts
+++ b/jest/fixtures/llamaServerTimings.ts
@@ -1,0 +1,39 @@
+/**
+ * Verbatim `timings` object from a llama-server SSE finish chunk, captured on a
+ * cache-reuse turn: `prompt_n` counts only the newly evaluated tokens and
+ * `cache_n` the reused prefix, so the prompt total is their sum. All nine keys
+ * are as they arrived — a stand-in trimmed to the fields a reader finds
+ * interesting would test the parser against a shape no server emits.
+ *
+ * Captured from llama-server build `b9976-e3546c794` (2026-07-11, Linux
+ * aarch64). Every wire fact here was observed on that one build; cross-build
+ * generalisation is unverified.
+ *
+ * Three things this capture must not be read as saying. Each is a citation that
+ * looks right, and each was written down before being checked against the
+ * source lines:
+ *
+ *  - Upstream's own `timings` assertions (`test_completion.py:659`,
+ *    `test_kv_keep_only_active.py:80`) run against the native
+ *    `POST /completion` and read the response body non-streaming, while this
+ *    app reads the OpenAI-compatible endpoint's SSE finish chunk — a different
+ *    endpoint and a different envelope. Upstream does not cover this path, and
+ *    this fixture is the app's own capture rather than a copy of theirs.
+ *  - Upstream asserts nothing about the join between a separately counted
+ *    prompt and `prompt_n + cache_n`. Its token-count endpoint has exactly two
+ *    tests and both are loose bounds (`> 5`, `> 10`).
+ *  - `test_compat_anthropic.py:882` is a different endpoint,
+ *    `POST /v1/messages/count_tokens`, which merely shares the `input_tokens`
+ *    field name. It constrains nothing here and must not be cited for it.
+ */
+export const cacheReuseTimings = {
+  cache_n: 31,
+  prompt_n: 1,
+  prompt_ms: 6.454,
+  prompt_per_token_ms: 6.454,
+  prompt_per_second: 154.94267121165169,
+  predicted_n: 3,
+  predicted_ms: 12.9,
+  predicted_per_token_ms: 4.3,
+  predicted_per_second: 232.5581395348837,
+};

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -1610,6 +1610,32 @@ describe('streamChatCompletion', () => {
     expect(result.timings?.cache_n).toBeUndefined();
   });
 
+  it('guards each timings token key independently (only cache_n)', async () => {
+    const resultPromise = streamChatCompletion(
+      {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
+      'http://localhost:1234',
+    );
+
+    const xhr = MockXHR.instances[0];
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+    );
+    xhr.simulateProgress(
+      `data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":${JSON.stringify(
+        {cache_n: cacheReuseTimings.cache_n},
+      )}}\n\n`,
+    );
+    xhr.simulateProgress('data: [DONE]\n\n');
+    xhr.simulateLoad();
+
+    const result = await resultPromise;
+    // A fully reused prompt evaluates nothing, so the whole count arrives on
+    // cache_n and prompt_n is absent. Reading prompt_n alone loses it.
+    expect(result.tokens_evaluated).toBe(31);
+    expect(result.timings?.prompt_n).toBeUndefined();
+  });
+
   it('returns no timings when server does not provide them', async () => {
     const resultPromise = streamChatCompletion(
       {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -13,6 +13,7 @@ import {
   directVisionModelsBody,
   routerModelsBody,
 } from '../../../jest/fixtures/remoteModelList';
+import {cacheReuseTimings} from '../../../jest/fixtures/llamaServerTimings';
 
 /** Build a minimal Headers-like object for fetch mocks. */
 function mockHeaders(entries: Record<string, string> = {}) {
@@ -1488,6 +1489,60 @@ describe('streamChatCompletion', () => {
     expect(result.tokens_predicted).toBe(500);
   });
 
+  it('adds the cache-reused prefix to the evaluated prompt count', async () => {
+    const resultPromise = streamChatCompletion(
+      {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
+      'http://localhost:1234',
+    );
+
+    const xhr = MockXHR.instances[0];
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+    );
+    xhr.simulateProgress(
+      `data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":${JSON.stringify(
+        cacheReuseTimings,
+      )}}\n\n`,
+    );
+    xhr.simulateProgress('data: [DONE]\n\n');
+    xhr.simulateLoad();
+
+    const result = await resultPromise;
+    // The server evaluated one token and reused thirty-one, so reading
+    // `prompt_n` alone reports 1 for a prompt of 32.
+    expect(cacheReuseTimings.prompt_n).toBe(1);
+    expect(result.tokens_evaluated).toBe(32);
+    expect(result.tokens_predicted).toBe(3);
+    // The total the context banner reads off the snapshot.
+    expect(
+      (result.tokens_evaluated ?? 0) + (result.tokens_predicted ?? 0),
+    ).toBe(35);
+  });
+
+  it('treats a reported cache_n of 0 as a count, not as an absent key', async () => {
+    const resultPromise = streamChatCompletion(
+      {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
+      'http://localhost:1234',
+    );
+
+    const xhr = MockXHR.instances[0];
+    xhr.simulateHeaders(200);
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+    );
+    // Every cold prompt on a build that reports reuse looks like this.
+    xhr.simulateProgress(
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"prompt_n":3000,"cache_n":0,"predicted_n":500}}\n\n',
+    );
+    xhr.simulateProgress('data: [DONE]\n\n');
+    xhr.simulateLoad();
+
+    const result = await resultPromise;
+    expect(result.tokens_evaluated).toBe(3000);
+    expect(result.timings?.cache_n).toBe(0);
+  });
+
   it('guards each timings token key independently (only predicted_n)', async () => {
     const resultPromise = streamChatCompletion(
       {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
@@ -1533,6 +1588,9 @@ describe('streamChatCompletion', () => {
     // per-event tally — it keeps the single content-bearing event count.
     expect(result.tokens_evaluated).toBe(3000);
     expect(result.tokens_predicted).toBe(1);
+    // A build too old to report prompt-cache reuse omits the key outright, and
+    // must degrade to the prompt count it does report — never below it.
+    expect(result.timings?.cache_n).toBeUndefined();
   });
 
   it('returns no timings when server does not provide them', async () => {

--- a/src/api/__tests__/openai.test.ts
+++ b/src/api/__tests__/openai.test.ts
@@ -1520,27 +1520,44 @@ describe('streamChatCompletion', () => {
     ).toBe(35);
   });
 
-  it('treats a reported cache_n of 0 as a count, not as an absent key', async () => {
-    const resultPromise = streamChatCompletion(
-      {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
-      'http://localhost:1234',
-    );
+  // Both shapes are projected from the capture rather than retyped, so each
+  // still carries the finish chunk's full nine-key `timings` object.
+  it('distinguishes a reported cache_n of 0 from an absent one', async () => {
+    const coldTimings = {...cacheReuseTimings, cache_n: 0};
+    const preReuseTimings: Record<string, number> = {...cacheReuseTimings};
+    delete preReuseTimings.cache_n;
 
-    const xhr = MockXHR.instances[0];
-    xhr.simulateHeaders(200);
-    xhr.simulateProgress(
-      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
-    );
-    // Every cold prompt on a build that reports reuse looks like this.
-    xhr.simulateProgress(
-      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":{"prompt_n":3000,"cache_n":0,"predicted_n":500}}\n\n',
-    );
-    xhr.simulateProgress('data: [DONE]\n\n');
-    xhr.simulateLoad();
+    const finish = async (timings: Record<string, number>) => {
+      const resultPromise = streamChatCompletion(
+        {messages: [{role: 'user', content: 'Hi'}], model: 'test-model'},
+        'http://localhost:1234',
+      );
+      const xhr = MockXHR.instances[MockXHR.instances.length - 1];
+      xhr.simulateHeaders(200);
+      xhr.simulateProgress(
+        'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+      );
+      xhr.simulateProgress(
+        `data: {"choices":[{"delta":{},"finish_reason":"stop"}],"timings":${JSON.stringify(
+          timings,
+        )}}\n\n`,
+      );
+      xhr.simulateProgress('data: [DONE]\n\n');
+      xhr.simulateLoad();
+      return resultPromise;
+    };
 
-    const result = await resultPromise;
-    expect(result.tokens_evaluated).toBe(3000);
-    expect(result.timings?.cache_n).toBe(0);
+    // A cold prompt on a build that reports reuse: 0 is a real count.
+    const cold = await finish(coldTimings);
+    expect(cold.tokens_evaluated).toBe(cacheReuseTimings.prompt_n);
+    expect(cold.timings?.cache_n).toBe(0);
+
+    // A build too old to report reuse omits the key. Same total, and the app
+    // degrades to it rather than below it — but a different fact, and the
+    // result keeps the two apart.
+    const preReuse = await finish(preReuseTimings);
+    expect(preReuse.tokens_evaluated).toBe(cacheReuseTimings.prompt_n);
+    expect(preReuse.timings?.cache_n).toBeUndefined();
   });
 
   it('guards each timings token key independently (only predicted_n)', async () => {

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -958,6 +958,18 @@ export async function streamChatCompletion(
         return;
       }
 
+      // The server evaluates only the prompt tokens it did not already hold in
+      // its KV cache, so the prompt total is `prompt_n + cache_n`. The two keys
+      // are guarded separately: a build too old to report reuse omits `cache_n`
+      // entirely, while a cold prompt on a newer one reports 0, and those are
+      // different facts.
+      const promptTokens =
+        serverTimings &&
+        (serverTimings.prompt_n !== undefined ||
+          serverTimings.cache_n !== undefined)
+          ? (serverTimings.prompt_n ?? 0) + (serverTimings.cache_n ?? 0)
+          : undefined;
+
       const result: CompletionResult = {
         text: fullContent,
         content: fullContent,
@@ -966,7 +978,7 @@ export async function streamChatCompletion(
         // llama.cpp reports authoritative token counts on `timings`; the server
         // count wins over the per-event tally. Each field is guarded on its own
         // key so a server that emits only one does not zero the other.
-        tokens_evaluated: serverTimings?.prompt_n,
+        tokens_evaluated: promptTokens,
         tokens_predicted: serverTimings?.predicted_n ?? tokensPredicted,
         timings: serverTimings,
       };

--- a/src/components/ChatView/BannerRow.tsx
+++ b/src/components/ChatView/BannerRow.tsx
@@ -228,6 +228,13 @@ export const BannerRow: React.FC<BannerRowProps> = observer(
           <Text style={[styles.bannerText, styles.bannerHeaderText]}>
             {fullText}
           </Text>
+          {ratio != null ? (
+            <Text
+              style={[styles.bannerPercent, {color: error}]}
+              testID="banner-percent">
+              {`${Math.round(ratio * 100)}%`}
+            </Text>
+          ) : null}
         </View>
         {ratio != null ? (
           <Meter ratio={ratio} tint={error} styles={styles} />

--- a/src/components/ChatView/__tests__/BannerRow.test.tsx
+++ b/src/components/ChatView/__tests__/BannerRow.test.tsx
@@ -522,4 +522,34 @@ describe('BannerRow', () => {
     expect(getByTestId('context-full-banner')).toBeTruthy();
     expect(queryByTestId('soft-cap-warning')).toBeNull();
   });
+
+  it('shows the fullness percentage beside the full banner meter', () => {
+    runInAction(() => {
+      chatSessionStore.lastCompletionResult = {
+        used: 3900,
+        contextFull: true,
+        isRemote: false,
+      };
+    });
+    const {getByTestId} = renderBanner();
+    expect(getByTestId('context-full-banner')).toBeTruthy();
+    // 3900 / 4096 ≈ 95%, the same ratio the meter is drawn from.
+    expect(getByTestId('banner-percent')).toHaveTextContent('95%');
+    expect(
+      getByTestId('banner-meter', {includeHiddenElements: true}),
+    ).toBeTruthy();
+  });
+
+  it('renders no banner at all when the turn reported no token count', () => {
+    runInAction(() => {
+      chatSessionStore.lastCompletionResult = {
+        used: undefined,
+        contextFull: true,
+        isRemote: false,
+      };
+    });
+    const {queryByTestId} = renderBanner();
+    expect(queryByTestId('context-full-banner')).toBeNull();
+    expect(queryByTestId('banner-percent')).toBeNull();
+  });
 });

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -9,7 +9,9 @@ import {
 } from '../../../jest/fixtures/models';
 
 import {useChatSession} from '../useChatSession';
-import {chatSessionStore, modelStore, palStore} from '../../store';
+import {chatSessionStore, modelStore, palStore, serverStore} from '../../store';
+import {resolveBannerVariant} from '../../utils/bannerVariantResolver';
+import {ModelOrigin} from '../../utils/types';
 import {assistant} from '../../utils/chat';
 import {chatSessionRepository} from '../../repositories/ChatSessionRepository';
 import {talentRegistry} from '../../services/talents';
@@ -1112,5 +1114,161 @@ describe('useChatSession — AssistantTurn integration', () => {
 
     deleteMessageSpy.mockRestore();
     errSpy.mockRestore();
+  });
+
+  describe('remote context accounting', () => {
+    const REMOTE_WINDOW = 4096;
+
+    // `activeModelCaps` is a computed over `capsFor()`, so the window is set up
+    // by registering a remote model and the probe entry it resolves through.
+    const activateRemoteModel = () => {
+      modelStore.activeModelId = 'remote-1';
+      modelStore.models = [
+        {id: 'remote-1', origin: ModelOrigin.REMOTE, serverId: 'srv-1'} as any,
+      ];
+      (modelStore as any).activeContextSettings = undefined;
+      serverStore.servers = [
+        {
+          id: 'srv-1',
+          name: 'llama',
+          url: 'http://localhost:8080',
+          serverType: 'llama.cpp',
+        } as any,
+      ];
+      serverStore.remoteCaps = {'remote-1': {contextLength: REMOTE_WINDOW}};
+    };
+
+    const bannerInput = () => ({
+      effectiveNCtx: modelStore.activeModelCaps.effectiveContextLength,
+      isRemote: true,
+      htmlPreviewCount: 0,
+      activeModelId: modelStore.activeModelId,
+      dismissed: new Set<never>(),
+    });
+
+    it('a finished remote turn feeds the full banner a real count', async () => {
+      activateRemoteModel();
+      if (modelStore.context) {
+        modelStore.context.completion = jest.fn().mockResolvedValue({
+          text: 'cut off',
+          content: 'cut off',
+          timings: {prompt_n: 3900, cache_n: 0, predicted_n: 100},
+          tokens_evaluated: 3900,
+          tokens_predicted: 100,
+          stopped_limit: 1,
+        });
+      }
+      const {result} = renderHook(() =>
+        useChatSession({current: null}, textMessage.author, mockAssistant),
+      );
+
+      await act(async () => {
+        await result.current.handleSendPress(textMessage);
+      });
+
+      const snapshot = (
+        chatSessionStore.recordCompletionSnapshot as jest.Mock
+      ).mock.calls.at(-1)![0];
+      expect(snapshot.used).toBe(4000);
+      expect(snapshot.contextFull).toBe(true);
+      expect(modelStore.activeModelCaps.effectiveContextLength).toBe(
+        REMOTE_WINDOW,
+      );
+
+      expect(resolveBannerVariant(snapshot, bannerInput()).variant).toBe(
+        'context-full',
+      );
+      // The window is only reached because the count is real: a zeroed one
+      // fails the freshness gate and the banner never renders.
+      expect(
+        resolveBannerVariant({...snapshot, used: 0}, bannerInput()).variant,
+      ).not.toBe('context-full');
+    });
+
+    it('a remote turn with no timings reports no count at all', async () => {
+      activateRemoteModel();
+      if (modelStore.context) {
+        modelStore.context.completion = jest.fn().mockResolvedValue({
+          text: 'hello',
+          content: 'hello',
+          tokens_predicted: 12,
+        });
+      }
+      const {result} = renderHook(() =>
+        useChatSession({current: null}, textMessage.author, mockAssistant),
+      );
+
+      await act(async () => {
+        await result.current.handleSendPress(textMessage);
+      });
+
+      const snapshot = (
+        chatSessionStore.recordCompletionSnapshot as jest.Mock
+      ).mock.calls.at(-1)![0];
+      // A predicted-only tally carries no prompt term and is not an occupancy
+      // number, so there is nothing to report.
+      expect(snapshot.used).toBeUndefined();
+      expect(resolveBannerVariant(snapshot, bannerInput()).variant).not.toBe(
+        'context-full',
+      );
+    });
+
+    it('an aborted turn with partial content reports no count, not zero', async () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      activateRemoteModel();
+      if (modelStore.context) {
+        modelStore.context.completion = jest
+          .fn()
+          .mockRejectedValueOnce(new Error('socket hang up'));
+      }
+      const ref: {
+        current: {createdAt: number; id: string; sessionId: string} | null;
+      } = {current: null};
+      const {result} = renderHook(() =>
+        useChatSession(ref, textMessage.author, mockAssistant),
+      );
+
+      const turnId = 'turn-remote-abort';
+      chatSessionStore.sessions = [
+        {
+          id: 'session-1',
+          title: '',
+          date: '',
+          messages: [
+            {
+              id: turnId,
+              type: 'assistant_turn',
+              author: assistant,
+              createdAt: Date.now(),
+              steps: [{content: 'partial'}],
+              metadata: {copyable: true},
+            } as MessageType.AssistantTurn,
+          ],
+          completionSettings: {},
+          settingsSource: 'pal',
+        },
+      ] as any;
+      (
+        chatSessionStore.addMessageToCurrentSession as jest.Mock
+      ).mockImplementation(async (msg: any) => {
+        msg.id = turnId;
+      });
+
+      await act(async () => {
+        await result.current.handleSendPress(textMessage);
+      });
+
+      const interruptedCall = (
+        chatSessionStore.updateMessage as jest.Mock
+      ).mock.calls.find(c => c[2]?.metadata?.interrupted === true);
+      expect(interruptedCall).toBeDefined();
+      const snapshot = interruptedCall![2].metadata.completionResult;
+      expect(snapshot.contextFull).toBe(false);
+      // Tokens were certainly consumed and no turn reported how many.
+      expect(snapshot.used).toBeUndefined();
+      expect('used' in snapshot).toBe(true);
+
+      errSpy.mockRestore();
+    });
   });
 });

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -1213,6 +1213,35 @@ describe('useChatSession — AssistantTurn integration', () => {
       );
     });
 
+    it('a remote turn whose timings carry rates but no token counts reports no count', async () => {
+      activateRemoteModel();
+      if (modelStore.context) {
+        modelStore.context.completion = jest.fn().mockResolvedValue({
+          text: 'hello',
+          content: 'hello',
+          // `timings` is present and carries no prompt term, so the presence
+          // of the object says nothing about whether a count arrived.
+          timings: {predicted_per_second: 80, prompt_per_second: 800},
+          tokens_predicted: 600,
+        });
+      }
+      const {result} = renderHook(() =>
+        useChatSession({current: null}, textMessage.author, mockAssistant),
+      );
+
+      await act(async () => {
+        await result.current.handleSendPress(textMessage);
+      });
+
+      const snapshot = (
+        chatSessionStore.recordCompletionSnapshot as jest.Mock
+      ).mock.calls.at(-1)![0];
+      expect(snapshot.used).toBeUndefined();
+      expect(resolveBannerVariant(snapshot, bannerInput()).variant).not.toBe(
+        'context-full',
+      );
+    });
+
     it('an aborted turn with partial content reports no count, not zero', async () => {
       const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       activateRemoteModel();
@@ -1381,5 +1410,29 @@ describe('useChatSession — AssistantTurn integration', () => {
 
       errSpy.mockRestore();
     });
+  });
+
+  it('a local turn with no evaluated count reports no count either', async () => {
+    if (modelStore.context) {
+      modelStore.context.completion = jest.fn().mockResolvedValue({
+        text: 'hello',
+        content: 'hello',
+        timings: {predicted_per_second: 80},
+        tokens_predicted: 600,
+      });
+    }
+    const {result} = renderHook(() =>
+      useChatSession({current: null}, textMessage.author, mockAssistant),
+    );
+
+    await act(async () => {
+      await result.current.handleSendPress(textMessage);
+    });
+
+    const snapshot = (
+      chatSessionStore.recordCompletionSnapshot as jest.Mock
+    ).mock.calls.at(-1)![0];
+    expect(snapshot.isRemote).toBe(false);
+    expect(snapshot.used).toBeUndefined();
   });
 });

--- a/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
+++ b/src/hooks/__tests__/useChatSession.assistantTurn.test.ts
@@ -1270,5 +1270,116 @@ describe('useChatSession — AssistantTurn integration', () => {
 
       errSpy.mockRestore();
     });
+
+    // The overflow paths never see a finished turn, so they pin `used` to the
+    // session's context window. A remote session leaves the local context
+    // settings unset, which is why reading the window from there suppressed
+    // this banner outright.
+    const overflowSession = (turnId: string, steps: any[]) => {
+      chatSessionStore.sessions = [
+        {
+          id: 'session-1',
+          title: '',
+          date: '',
+          messages: [
+            {
+              id: turnId,
+              type: 'assistant_turn',
+              author: assistant,
+              createdAt: Date.now(),
+              steps,
+              metadata: {copyable: true},
+            } as MessageType.AssistantTurn,
+          ],
+          completionSettings: {},
+          settingsSource: 'pal',
+        },
+      ] as any;
+      (
+        chatSessionStore.addMessageToCurrentSession as jest.Mock
+      ).mockImplementation(async (msg: any) => {
+        msg.id = turnId;
+      });
+    };
+
+    it('a prompt that overflows a remote window pins used to that window', async () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      activateRemoteModel();
+      if (modelStore.context) {
+        modelStore.context.completion = jest
+          .fn()
+          .mockRejectedValueOnce(new Error('Context is full'));
+      }
+      const ref: {
+        current: {createdAt: number; id: string; sessionId: string} | null;
+      } = {current: null};
+      const {result} = renderHook(() =>
+        useChatSession(ref, textMessage.author, mockAssistant),
+      );
+      overflowSession('turn-remote-overflow', []);
+
+      await act(async () => {
+        await result.current.handleSendPress(textMessage);
+      });
+
+      const snapshot = (
+        chatSessionStore.recordCompletionSnapshot as jest.Mock
+      ).mock.calls.at(-1)![0];
+      expect(snapshot).toMatchObject({
+        used: REMOTE_WINDOW,
+        contextFull: true,
+        isRemote: true,
+      });
+      expect(resolveBannerVariant(snapshot, bannerInput()).variant).toBe(
+        'context-full',
+      );
+
+      // The window has to come from the probe: a remote session never
+      // populates the local context settings, so a snapshot sourced from
+      // those carries no count and the freshness gate rejects it.
+      expect(modelStore.activeContextSettings?.n_ctx).toBeUndefined();
+      expect(
+        resolveBannerVariant(
+          {...snapshot, used: modelStore.activeContextSettings?.n_ctx ?? 0},
+          bannerInput(),
+        ).variant,
+      ).not.toBe('context-full');
+
+      errSpy.mockRestore();
+    });
+
+    it('an overflow after partial output records the window on the turn', async () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      activateRemoteModel();
+      if (modelStore.context) {
+        modelStore.context.completion = jest
+          .fn()
+          .mockRejectedValueOnce(new Error('Context is full'));
+      }
+      const ref: {
+        current: {createdAt: number; id: string; sessionId: string} | null;
+      } = {current: null};
+      const {result} = renderHook(() =>
+        useChatSession(ref, textMessage.author, mockAssistant),
+      );
+      overflowSession('turn-remote-overflow-partial', [{content: 'partial'}]);
+
+      await act(async () => {
+        await result.current.handleSendPress(textMessage);
+      });
+
+      const interruptedCall = (
+        chatSessionStore.updateMessage as jest.Mock
+      ).mock.calls.find(c => c[2]?.metadata?.interrupted === true);
+      expect(interruptedCall).toBeDefined();
+      const snapshot = interruptedCall![2].metadata.completionResult;
+      expect(snapshot.contextFull).toBe(true);
+      expect(snapshot.used).toBe(REMOTE_WINDOW);
+      expect(resolveBannerVariant(snapshot, bannerInput()).variant).toBe(
+        'context-full',
+      );
+
+      errSpy.mockRestore();
+    });
   });
 });

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -245,13 +245,12 @@ function deriveSnapshotFromResult(
   result: CompletionResult,
   isRemote: boolean,
 ): CompletionResultSnapshot {
-  // A remote turn carries its counts on `timings`; with no such object there
-  // is no prompt term at all, and a predicted-only tally is not an occupancy
-  // number. Local turns always report `tokens_evaluated`.
+  // Without a prompt term the total is a predicted-only tally, which is not an
+  // occupancy number on either path.
   const used =
-    isRemote && !result.timings
+    result.tokens_evaluated === undefined
       ? undefined
-      : (result.tokens_evaluated ?? 0) + (result.tokens_predicted ?? 0);
+      : result.tokens_evaluated + (result.tokens_predicted ?? 0);
   // Local turns set context_full/truncated directly; finishReason only bridges
   // the remote engine's signal (stopped_limit) into the OR predicate below, so
   // it is intentionally remote-only.

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -243,7 +243,6 @@ type TtsRunState = {
 // and (remote only) a 'length' finish reason derived from `stopped_limit`.
 function deriveSnapshotFromResult(
   result: CompletionResult,
-  effectiveNCtx: number | undefined,
   isRemote: boolean,
 ): CompletionResultSnapshot {
   const used = (result.tokens_evaluated ?? 0) + (result.tokens_predicted ?? 0);
@@ -421,7 +420,6 @@ async function applyEventToStore(
       const finalResult = event.result.finalResult;
       const snapshot = deriveSnapshotFromResult(
         finalResult,
-        modelStore.activeContextSettings?.n_ctx,
         modelStore.activeModel?.origin === ModelOrigin.REMOTE,
       );
       const draftTimings =

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -245,7 +245,13 @@ function deriveSnapshotFromResult(
   result: CompletionResult,
   isRemote: boolean,
 ): CompletionResultSnapshot {
-  const used = (result.tokens_evaluated ?? 0) + (result.tokens_predicted ?? 0);
+  // A remote turn carries its counts on `timings`; with no such object there
+  // is no prompt term at all, and a predicted-only tally is not an occupancy
+  // number. Local turns always report `tokens_evaluated`.
+  const used =
+    isRemote && !result.timings
+      ? undefined
+      : (result.tokens_evaluated ?? 0) + (result.tokens_predicted ?? 0);
   // Local turns set context_full/truncated directly; finishReason only bridges
   // the remote engine's signal (stopped_limit) into the OR predicate below, so
   // it is intentionally remote-only.
@@ -793,15 +799,17 @@ export const useChatSession = (
         const hasPartialContent = hasAnyStepContent || hasLegacyText;
 
         if (hasPartialContent) {
-          // No finalResult on the abort path. truncationLikely is the
-          // n_ctx-exhaustion signal; when set, treat the turn as full and
-          // pin `used` to the loaded n_ctx so the sticky banner's freshness
-          // gate holds.
+          // No finalResult on the abort path, so no turn reported a count.
+          // truncationLikely is the n_ctx-exhaustion signal: when set, treat
+          // the turn as full and pin `used` to the context window so the
+          // sticky banner's freshness gate holds. Otherwise the count is
+          // unknown, which is not zero.
           const isRemote =
             modelStore.activeModel?.origin === ModelOrigin.REMOTE;
-          const effectiveNCtx = modelStore.activeContextSettings?.n_ctx;
+          const effectiveNCtx =
+            modelStore.activeModelCaps.effectiveContextLength;
           const abortSnapshot: CompletionResultSnapshot = {
-            used: treatAsContextFull ? (effectiveNCtx ?? 0) : 0,
+            used: treatAsContextFull ? effectiveNCtx : undefined,
             contextFull: treatAsContextFull,
             isRemote,
           };
@@ -832,9 +840,10 @@ export const useChatSession = (
           if (isContextFullError) {
             const isRemote =
               modelStore.activeModel?.origin === ModelOrigin.REMOTE;
-            const effectiveNCtx = modelStore.activeContextSettings?.n_ctx;
+            const effectiveNCtx =
+              modelStore.activeModelCaps.effectiveContextLength;
             chatSessionStore.recordCompletionSnapshot({
-              used: effectiveNCtx ?? 0,
+              used: effectiveNCtx,
               contextFull: true,
               isRemote,
             });
@@ -875,7 +884,7 @@ export const useChatSession = (
         // No turn to attach to; surface the banner via a store snapshot
         // rather than dumping the raw "Context is full" native error.
         chatSessionStore.recordCompletionSnapshot({
-          used: modelStore.activeContextSettings?.n_ctx ?? 0,
+          used: modelStore.activeModelCaps.effectiveContextLength,
           contextFull: true,
           isRemote: modelStore.activeModel?.origin === ModelOrigin.REMOTE,
         });

--- a/src/utils/__tests__/bannerVariantResolver.test.ts
+++ b/src/utils/__tests__/bannerVariantResolver.test.ts
@@ -307,6 +307,47 @@ describe('resolveBannerVariant', () => {
     });
   });
 
+  describe('unknown versus zero token count', () => {
+    it('does not fire the full banner when the token count is unknown', () => {
+      const result = resolveBannerVariant(
+        snap({contextFull: true, used: undefined}),
+        baseInput(),
+      );
+      expect(result.variant).toBe('none');
+      expect(result.ratio).toBeUndefined();
+    });
+
+    it('still hedges a remote turn when the token count is unknown', () => {
+      const result = resolveBannerVariant(
+        snap({
+          used: undefined,
+          isRemote: true,
+          tokensPredicted: 600,
+          content: 'cut off here',
+        }),
+        baseInput({isRemote: true}),
+      );
+      expect(result.variant).toBe('context-remote-hedged');
+    });
+
+    it('treats a zero token count as a real number, not as unknown', () => {
+      const input = baseInput({effectiveNCtx: AUTOCLEAR_RUNWAY});
+
+      const counted = resolveBannerVariant(
+        snap({contextFull: true, used: 0}),
+        input,
+      );
+      expect(counted.variant).toBe('context-full');
+      expect(counted.ratio).toBe(0);
+
+      const uncounted = resolveBannerVariant(
+        snap({contextFull: true, used: undefined}),
+        input,
+      );
+      expect(uncounted.variant).toBe('none');
+    });
+  });
+
   describe('suppression', () => {
     it('suppresses context-* when no model is loaded', () => {
       const result = resolveBannerVariant(

--- a/src/utils/bannerVariantResolver.ts
+++ b/src/utils/bannerVariantResolver.ts
@@ -98,8 +98,8 @@ export function resolveBannerVariant(
     }
 
     // 3. context-remote-hedged — remote weak-signal truncation, dismissable.
-    // Remote models never set activeContextSettings.n_ctx, so this branch
-    // must not depend on effectiveNCtx.
+    // A remote session's window is known only once its /props probe lands, so
+    // this branch must not depend on effectiveNCtx.
     if (
       isRemote &&
       snapshot.finishReason !== 'length' &&

--- a/src/utils/bannerVariantResolver.ts
+++ b/src/utils/bannerVariantResolver.ts
@@ -58,21 +58,24 @@ export function resolveBannerVariant(
   } = input;
 
   // context-* variants require a loaded model. The nCtx-reading variants
-  // (full, warning) additionally need a known runtime n_ctx; the remote
-  // hedged advisory does not read n_ctx and only needs a loaded model.
+  // (full, warning) additionally need a known runtime n_ctx and a known token
+  // count; the remote hedged advisory reads neither and only needs a loaded
+  // model.
   const modelLoaded = activeModelId !== undefined;
 
   if (snapshot && modelLoaded) {
-    if (effectiveNCtx !== undefined) {
+    const used = snapshot.used;
+
+    if (effectiveNCtx !== undefined && used !== undefined) {
       const nCtx = effectiveNCtx;
 
-      const ratio = Math.min(1, Math.max(0, snapshot.used / nCtx));
+      const ratio = Math.min(1, Math.max(0, used / nCtx));
 
       // 1. context-full — freshness gate corroborates the frozen flag;
       // dismissable per draft (the dismissal clears on the next finished turn).
       if (
         snapshot.contextFull &&
-        snapshot.used >= nCtx - AUTOCLEAR_RUNWAY &&
+        used >= nCtx - AUTOCLEAR_RUNWAY &&
         !dismissed.has('context-full')
       ) {
         return {
@@ -87,7 +90,7 @@ export function resolveBannerVariant(
       // remote model once its /props contextLength is known.
       if (
         !snapshot.contextFull &&
-        snapshot.used / nCtx >= WARNING_THRESHOLD &&
+        used / nCtx >= WARNING_THRESHOLD &&
         !dismissed.has('context-warning')
       ) {
         return {variant: 'context-warning', ratio};

--- a/src/utils/completionTypes.ts
+++ b/src/utils/completionTypes.ts
@@ -61,6 +61,7 @@ export interface CompletionResult {
     prompt_per_second?: number;
     prompt_ms?: number;
     prompt_n?: number;
+    cache_n?: number;
     predicted_n?: number;
     [key: string]: number | undefined;
   };
@@ -77,13 +78,14 @@ export interface CompletionResult {
   interrupted?: boolean;
 }
 
-// `used` is tokens_evaluated + tokens_predicted; tokens_cached is not exposed at
-// the engine boundary, so on prompt-cache-reuse turns it under-counts KV
-// occupancy.
+// An absent `used` means the count is unknown, and must never be shown as zero.
+// llama.rn's local `tokens_evaluated` is the whole prompt; a llama.cpp server's
+// `timings.prompt_n` is only the part it evaluated, the reused prefix being in
+// `cache_n`.
 export interface CompletionResultSnapshot {
   content?: string;
   reasoning_content?: string;
-  used: number;
+  used?: number;
   contextFull: boolean;
   tokensPredicted?: number;
   finishReason?: string;


### PR DESCRIPTION
## What this fixes

A remote turn's used-token total dropped the part of the prompt the server served from
its KV cache, so the context meter under-reported — badly, and worst exactly when a
conversation was long enough for the meter to matter.

Measured against a live `llama-server` (build `b9976-e3546c794`): a repeated prompt
reported `prompt_n = 1` and `cache_n = 17`, a true prompt of 18. **The banner saw 1.**

`completionTypes.ts` already documented this as a known limitation — *"tokens_cached is
not exposed at the engine boundary, so on prompt-cache-reuse turns it under-counts KV
occupancy"*. That note was wrong twice over, which is why the fix is small:

- **The local path never had the bug.** `JSICompletion.h:247` sets `tokens_evaluated`
  from `slot->num_prompt_tokens`, which `rn-slot.cpp:172` sets to `tokens.size()` — the
  whole prompt.
- **The value was never unexposed.** llama.rn declares both `tokens_cached` and
  `timings.cache_n`; this app's own mapping dropped them.

So the missing term was already arriving on every finish chunk. No new request, no new
store field, no new failure branch.

## Also fixed: the remote context-full banner never rendered

Three sites wrote `used: 0` alongside `contextFull: true`, reading an `n_ctx` that is
never set for a remote model. The resolver's freshness gate requires
`used >= effectiveNCtx - AUTOCLEAR_RUNWAY`, which `0` always fails — so the banner was
unreachable for every remote session. Those sites now read the same resolved window the
banner itself reads, and write *absent* rather than `0` when the window is unknown.

A fourth site was a parameter that was never read — the trap that produced the other
three.

## The identity this rests on

```
input_tokens  ==  usage.prompt_tokens  ==  timings.prompt_n + timings.cache_n
```

Verified 5/5 on a live server across cold, cache-reuse, tool-carrying, thinking-disabled
and long-prompt turns, then re-verified on the **streaming** path the app actually uses:

| case | `input_tokens` | `prompt_n` + `cache_n` | |
| --- | --- | --- | --- |
| cold | 32 | 32 + 0 | match |
| **cache reuse** | **32** | **1 + 31** | **match — the load-bearing case** |
| with a tool schema | 161 | 161 + 0 | match |
| `enable_thinking: false` | 34 | 28 + 6 | match |
| long prompt | 314 | 311 + 3 | match |

The cache-reuse row carries the weight: it is the only case where the two sources are
computed differently enough to drift, and it is the case this fix exists for.

Upstream asserts the arithmetic itself (`test_completion.py:659`,
`test_kv_keep_only_active.py:80`) — but **on the native `POST /completion`, read
non-streaming from `res.body`**. This app reads the OpenAI-compatible endpoint's SSE
finish chunk. Endpoint *and* delivery differ, so those tests constrain the field names
and their relationship, not our path; the streaming observation is ours.

## `undefined` is not `0`

`timings.cache_n` landed in **b6399 (2025-09-06)**. An older build emits no key at all,
and that is a different fact from a cold prompt reporting `0` — which is common and
real. Absent degrades to the previous value, never below it; a reported `0` is a count.
Both are covered by tests that catch *different defects* rather than different values:
one fails a naive sum (`NaN`), the other fails a shape that reads a real `0` as absent.

## Evidence and its limits

Every wire fact here was measured on **`b9976-e3546c794`, 2026-07-11, Linux aarch64**.
Cross-build generalisation is unverified. The fixture is a verbatim nine-key capture;
tests project their inputs from it and keep expectations as independent literals, so an
edited fixture fails loudly rather than moving the goalposts.

Three claims about upstream coverage were checked and withdrawn during this work:

- Upstream does **not** assert `input_tokens == prompt_n + cache_n`. Every assertion on
  that endpoint is a loose bound (`> 5`, `> 10`) or relational — all would still pass if
  the count drifted from what the completion charges.
- The timings assertions run against the **native** endpoint, non-streaming (above).
- `test_compat_anthropic.py:882` exercises `POST /v1/messages/count_tokens`, a
  **different endpoint**. It shares the `input_tokens` field *name*, which is what made
  the citation look right.

## Scope

The pre-send token count and the persistent gauge are **not** in this change. They moved
to a follow-up, together, because the count has no home without a surface and the surface
is a larger change than it appears: `effectiveContextLength` is defined for local models
too, so a permanent gauge is either arbitrarily remote-only or a chat-wide change
touching a read path this PR deliberately leaves alone — plus copy and an a11y label
across 19 locales.

Splitting that way also puts the wider-reaching half first: `cache_n` predates the count
endpoint by nine months and ~3,600 builds, so this fix works on essentially every
`llama-server` in the wild.

## Architecture

The remote-servers and chat-flow architecture docs are updated alongside this change: the
token-accounting rule now reads `prompt_n + cache_n`, and a new section records where the
context window comes from and what each `used` state means.

---

Generated by [PocketPal Dev Team](https://github.com/a-ghorbani/pocketpal-dev-team)




