### PR TITLE
Upgrade llama.rn to 0.13.0-rc.3 (llama.cpp b10588 -> b10829)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Versions are pinned in [`package.json`](package.json); the highlights:
 | UI | React Native Paper `5.14.5`, React Navigation |
 | State | MobX `6` (`mobx`, `mobx-react`, `mobx-persist-store`) |
 | Persistence | WatermelonDB (chat history), AsyncStorage (settings), Keychain (secrets) |
-| LLM | `llama.rn` `0.13.0-rc.1` → llama.cpp · GGUF |
+| LLM | `llama.rn` `0.13.0-rc.3` → llama.cpp b10829 · GGUF |
 | TTS | `react-native-speech` `2.3.1` + `onnxruntime-react-native` `1.23.2` · ONNX |
 | Tooling | Yarn 1 (Classic), ESLint, Prettier, Jest, Husky + Commitlint |
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,7 +59,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - llama-rn (0.13.0-rc.1):
+  - llama-rn (0.13.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.18",
     "expr-eval": "^2.0.2",
-    "llama.rn": "0.13.0-rc.1",
+    "llama.rn": "0.13.0-rc.3",
     "marked": "^16.4.0",
     "mobx": "^6.15.0",
     "mobx-persist-store": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6520,10 +6520,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-llama.rn@0.13.0-rc.1:
-  version "0.13.0-rc.1"
-  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.13.0-rc.1.tgz#624923ea7dcca50aa2e2905db45def0f2ecfe951"
-  integrity sha512-sXpw1b6jUns6HhFUlQiaTY1hFvN/vKTWn+lKI0isz8YuY1BupqmKY7XTi2EWShpQ9sLm9F2g76Lzddk+F/+d3g==
+llama.rn@0.13.0-rc.3:
+  version "0.13.0-rc.3"
+  resolved "https://registry.yarnpkg.com/llama.rn/-/llama.rn-0.13.0-rc.3.tgz#ec382df987b480d03e65a8433a806455289a940b"
+  integrity sha512-pf3ckONVjPGo4wwbjZrYqrX89ZaW1b4Ul1SrZkq1yU/Y4ZOaPHKMv7qGXax+F0uHNJvxNh8jz0hicrmIJ07PBg==
 
 locate-path@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Description

Upgrades the vendored `llama.rn` native dependency from `0.13.0-rc.1` to `0.13.0-rc.3` — a llama.cpp sync of b10588 → b10829.

The TypeScript surface of `llama.rn` is unchanged apart from `src/version.ts`, so no app code moves.

### What's new in rc.3 (over rc.1)

- **llama.cpp sync to b10829** (rc.1 was b10588; rc.2 brought b10603/b10645 along the way)
- **Android fix**: probe HTP sessions for real device count, keep CPU out of device overrides — lets CPU paths use optimized repacked buffers
- **New model support**: `hy-v4`, `qwen4exp`, `spark2-5`, `deepseek4v`
- Android OpenCL kernel entries, mmap adjustments, Metal guard fix, Android madvise constant conversion

### Known follow-up

`ios/Podfile.lock` SPEC CHECKSUMS for `llama-rn` still reflects the rc.1 hash; it needs a `pod install` to recompute. The current local `pod install` fails on a pre-existing, unrelated `react-native-worklets-core` resolution issue (reproduces on `main` before this bump), so the checksum was left for a follow-up once that is addressed.

## Platform Affected

- [x] iOS
- [x] Android

## Checklist

- [x] Necessary comments have been made.
- [x] Unit tests and integration tests pass locally.